### PR TITLE
fix(backups): remove redundant backup command that runs the DB dump twice

### DIFF
--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -282,15 +282,6 @@ export const getBackupCommand = (
 
 	echo "[$(date)] Container Up: $CONTAINER_ID" >> ${logPath};
 
-	# Run the backup command and capture the exit status
-	BACKUP_OUTPUT=$(${backupCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
-		echo "Error: $BACKUP_OUTPUT" >> ${logPath};
-		exit 1;
-	}
-
-	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
 
 	# Run the upload command and capture the exit status
 	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {


### PR DESCRIPTION
Ports Dokploy/dokploy#4223 by @kuishou68 (OPEN upstream).

## What
`getBackupCommand` embedded the generated database-dump command **twice** in the shell script it produces:
- once as a discarded "test run" — `BACKUP_OUTPUT=$(${backupCommand} 2>&1 >/dev/null)`
- again piped into rclone for the actual upload — `UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} ...)`

Every backup therefore dumped the database twice: wasted resources, and the uploaded dump could reflect a different DB state than the one that "passed" the first (verification) run.

## Fix
Remove the redundant first dump block so the command runs once and streams directly into rclone. `set -eo pipefail` error handling in the upload pipeline is preserved.

## Verify-first
Confirmed the double execution was present in the fork at `packages/server/src/utils/backups/utils.ts` (`BACKUP_OUTPUT` and `UPLOAD_OUTPUT` both ran `${backupCommand}`). Fork divergence `redactRcloneCredentials` is outside the removed block and untouched.

## Scope
- `packages/server/src/utils/backups/utils.ts` — pure deletion (`+0 / -9`)
- No migration.

## Local verify
- `pnpm --filter=dokploy typecheck` — pass
- `@dokploy/server` build (switch:prod + tsc + tsc-alias) — pass
- `tsc --project packages/server/tsconfig.server.json --noEmit` — pass
