### PR TITLE
feat(update-ui): fork release links + combined release notes in update dialog

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -297,7 +297,7 @@ export const UpdateServer = ({
 								<h3 className="text-lg font-medium">Checking for updates...</h3>
 								<p className="text text-muted-foreground">
 									Please wait while we pull the latest version information from
-									Docker Hub.
+									GitHub releases.
 								</p>
 							</div>
 						</div>

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import ReactMarkdown from "react-markdown";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -52,6 +53,11 @@ export const UpdateServer = ({
 	const [latestVersion, setLatestVersion] = useState(
 		updateData?.latestVersion ?? "",
 	);
+	const { data: releaseNotes, isLoading: isLoadingReleaseNotes } =
+		api.settings.getReleaseNotes.useQuery(
+			{ version: latestVersion },
+			{ enabled: isUpdateAvailable && !!latestVersion },
+		);
 	const [isOpenInternal, setIsOpenInternal] = useState(false);
 
 	const handleCheckUpdates = async () => {
@@ -192,6 +198,72 @@ export const UpdateServer = ({
 								</li>
 							</ul>
 						</div>
+
+						{/* Combined release notes: our fork release first, then the upstream base release */}
+						<div className="mt-6 space-y-4">
+							{isLoadingReleaseNotes && (
+								<div className="flex items-center gap-2 text-sm text-muted-foreground">
+									<RefreshCcw className="h-4 w-4 animate-spin" />
+									Loading release notes...
+								</div>
+							)}
+
+							{releaseNotes?.fork && (
+								<div className="space-y-2">
+									<div className="flex items-center justify-between gap-2">
+										<h4 className="text-sm font-semibold text-foreground">
+											Community release {releaseNotes.fork.tag}
+										</h4>
+										<Link
+											href={releaseNotes.fork.url}
+											target="_blank"
+											className="text-xs text-[#5B9DFF] underline hover:text-white shrink-0"
+										>
+											View on GitHub
+										</Link>
+									</div>
+									<div className="max-h-48 overflow-y-auto rounded-lg border border-border bg-muted/40 p-3">
+										{releaseNotes.fork.body ? (
+											<ReactMarkdown className="prose prose-sm dark:prose-invert max-w-none break-words">
+												{releaseNotes.fork.body}
+											</ReactMarkdown>
+										) : (
+											<p className="text-sm text-muted-foreground">
+												Release notes are unavailable right now.
+											</p>
+										)}
+									</div>
+								</div>
+							)}
+
+							{releaseNotes?.upstream && (
+								<div className="space-y-2">
+									<div className="flex items-center justify-between gap-2">
+										<h4 className="text-sm font-semibold text-foreground">
+											From upstream {releaseNotes.upstream.tag}
+										</h4>
+										<Link
+											href={releaseNotes.upstream.url}
+											target="_blank"
+											className="text-xs text-[#5B9DFF] underline hover:text-white shrink-0"
+										>
+											View on GitHub
+										</Link>
+									</div>
+									<div className="max-h-48 overflow-y-auto rounded-lg border border-border bg-muted/40 p-3">
+										{releaseNotes.upstream.body ? (
+											<ReactMarkdown className="prose prose-sm dark:prose-invert max-w-none break-words">
+												{releaseNotes.upstream.body}
+											</ReactMarkdown>
+										) : (
+											<p className="text-sm text-muted-foreground">
+												Upstream release notes are unavailable right now.
+											</p>
+										)}
+									</div>
+								</div>
+							)}
+						</div>
 					</div>
 				)}
 
@@ -239,7 +311,7 @@ export const UpdateServer = ({
 							<div className="text-[#5B9DFF]">
 								We recommend reviewing the{" "}
 								<Link
-									href="https://github.com/Dokploy/dokploy/releases"
+									href="https://github.com/DevinoSolutions/dokploy-community/releases"
 									target="_blank"
 									className="text-white underline hover:text-zinc-200"
 								>

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -18,6 +18,7 @@ import {
 	getDockerDiskUsage,
 	getDokployImageTag,
 	getLogCleanupStatus,
+	getReleaseNotes,
 	getUpdateData,
 	getWebServerSettings,
 	IS_CLOUD,
@@ -587,6 +588,15 @@ export const settingsRouter = createTRPCRouter({
 
 		return await getUpdateData(packageInfo.version);
 	}),
+	getReleaseNotes: protectedProcedure
+		.input(z.object({ version: z.string().min(1) }))
+		.query(async ({ input }) => {
+			if (IS_CLOUD) {
+				return { fork: null, upstream: null };
+			}
+
+			return await getReleaseNotes(input.version);
+		}),
 	updateServer: adminProcedure.mutation(async ({ ctx }) => {
 		if (IS_CLOUD) {
 			return true;

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -91,6 +91,94 @@ export const getUpdateData = async (
 	}
 };
 
+export interface IReleaseNotesSection {
+	/** Git tag for this release, e.g. `v0.29.12-community.1`. */
+	tag: string;
+	/** Public GitHub release page URL. */
+	url: string;
+	/** Raw markdown release body, or null when it could not be fetched. */
+	body: string | null;
+}
+
+export interface IReleaseNotes {
+	fork: IReleaseNotesSection | null;
+	upstream: IReleaseNotesSection | null;
+}
+
+const GITHUB_API_HEADERS = {
+	Accept: "application/vnd.github+json",
+	"User-Agent": "dokploy-community",
+};
+
+/** Fetches the raw markdown release body for a repo + tag from the GitHub API.
+ *  Returns null on any failure so callers never throw. */
+const fetchReleaseBody = async (
+	repo: string,
+	tag: string,
+): Promise<string | null> => {
+	try {
+		const response = await fetch(
+			`https://api.github.com/repos/${repo}/releases/tags/${encodeURIComponent(
+				tag,
+			)}`,
+			{
+				method: "GET",
+				headers: GITHUB_API_HEADERS,
+			},
+		);
+
+		if (!response.ok) {
+			return null;
+		}
+
+		const release = (await response.json()) as { body?: string | null };
+		return release.body ?? null;
+	} catch (error) {
+		console.error(`Error fetching release notes for ${repo}@${tag}:`, error);
+		return null;
+	}
+};
+
+/** Returns the fork release notes for `version` together with the matching
+ *  upstream base-release notes. The upstream base tag is derived by stripping
+ *  the `-community.N` fork suffix. Section metadata (tag + url) is always
+ *  populated; `body` is null when the GitHub fetch fails, and `upstream` is
+ *  null when `version` carries no fork suffix. Never throws to the client. */
+export const getReleaseNotes = async (
+	version: string,
+): Promise<IReleaseNotes> => {
+	const cleaned = version.trim();
+	if (!cleaned) {
+		return { fork: null, upstream: null };
+	}
+
+	const forkTag = cleaned.startsWith("v") ? cleaned : `v${cleaned}`;
+	const baseTag = forkTag.replace(/-community\.\d+$/, "");
+	const hasUpstreamBase = baseTag !== forkTag;
+
+	const [forkBody, upstreamBody] = await Promise.all([
+		fetchReleaseBody("DevinoSolutions/dokploy-community", forkTag),
+		hasUpstreamBase
+			? fetchReleaseBody("Dokploy/dokploy", baseTag)
+			: Promise.resolve(null),
+	]);
+
+	return {
+		fork: {
+			tag: forkTag,
+			url: `https://github.com/DevinoSolutions/dokploy-community/releases/tag/${forkTag}`,
+			body: forkBody,
+		},
+		upstream: hasUpstreamBase
+			? {
+					tag: baseTag,
+					url: `https://github.com/Dokploy/dokploy/releases/tag/${baseTag}`,
+					body: upstreamBody,
+				}
+			: null,
+	};
+};
+
 interface TreeDataItem {
 	id: string;
 	name: string;


### PR DESCRIPTION
## What

Makes the in-app **update / version surfaces point at our fork** instead of upstream Dokploy, and shows **combined release notes** in the update dialog: our community release notes first, then the upstream base release they were built on.

## Changes

- **`packages/server/src/services/settings.ts`** — new `getReleaseNotes(version)` service (+ `IReleaseNotes` / `IReleaseNotesSection` types). Fetches the fork release body from `DevinoSolutions/dokploy-community` and the upstream base release body from `Dokploy/dokploy`, deriving the base tag by stripping the `-community.N` suffix. Reuses the existing GitHub fetch pattern (`Accept: application/vnd.github+json`, `User-Agent` header); returns nulls on any failure and never throws to the client. The two fetches run in parallel.
- **`apps/dokploy/server/api/routers/settings.ts`** — new `getReleaseNotes` protected **query** (input `{ version }`), guarded for cloud like `getUpdateData`.
- **`apps/dokploy/components/dashboard/settings/web-server/update-server.tsx`** — when an update is available, renders **"Community release v…"** (our notes) first, then **"From upstream v…"**, each with a link to its GitHub release page. Markdown is rendered with the already-present `react-markdown` dependency inside a `max-h-48 overflow-y-auto` scroll area (falls back to a plain message if a body can't be fetched). Also fixes the advisory "release notes" link that still pointed at `Dokploy/dokploy/releases` → now the fork's releases page.

## Type/endpoint decision

Added a **separate `getReleaseNotes` query** rather than extending `IUpdateData`. Rationale: `getUpdateData` is polled frequently (auto-check every 7 min + on the navbar button) and only needs `latestVersion` / `updateAvailable`; folding two extra GitHub fetches into it would waste calls on every poll. A dedicated query fetches the notes only when the dialog actually needs them (update available), is cacheable, and keeps `IUpdateData` untouched (so `layouts/update-server.tsx`, which imports it, is unaffected).

## Audit note

Grepped `apps/dokploy` + `packages/server` for `Dokploy/dokploy/releases`, `github.com/dokploy`, `releases/tag`, `CHANGELOG`. The only update/version-flow link pointing upstream was the update dialog's "release notes" link (now fixed). General branding links (onboarding, subscription), the error-page issues link, OpenAPI LICENSE link, and notification test copy were left untouched per scope. No `install.sh` / README / migration / drizzle files touched.

## Verification

- `pnpm --filter=dokploy run typecheck` -> exit 0
- `pnpm --filter=dokploy run build-server` -> exit 0
