### PR TITLE
feat(compose): GitLab merge-request previews for Docker Compose

### DIFF
--- a/apps/dokploy/__test__/deploy/gitlab.test.ts
+++ b/apps/dokploy/__test__/deploy/gitlab.test.ts
@@ -25,6 +25,8 @@ vi.mock(
 			removePreviewDeployment: vi.fn(),
 			findPreviewDeploymentByApplicationId: vi.fn(),
 			createPreviewDeployment: vi.fn(),
+			findPreviewDeploymentByComposeId: vi.fn(),
+			createComposePreview: vi.fn(),
 		};
 	},
 );
@@ -51,8 +53,10 @@ vi.mock("@/server/queues/queueSetup", () => ({
 import { db } from "@dokploy/server/db";
 import { findGitlabByWebhookSecret } from "@dokploy/server/services/gitlab";
 import {
+	createComposePreview,
 	createPreviewDeployment,
 	findPreviewDeploymentByApplicationId,
+	findPreviewDeploymentByComposeId,
 	findPreviewDeploymentsByPullRequestId,
 	removePreviewDeployment,
 } from "@dokploy/server/services/preview-deployment";
@@ -87,6 +91,23 @@ const FAKE_APP = {
 	previewLimit: 3,
 	serverId: null,
 	previewDeployments: [],
+};
+
+const FAKE_COMPOSE = {
+	composeId: "compose-id-1",
+	name: "My Compose",
+	appName: "my-compose",
+	sourceType: "gitlab" as const,
+	gitlabId: "gitlab-id-1",
+	gitlabPathNamespace: "mygroup/myrepo",
+	gitlabBranch: "main",
+	isPreviewDeploymentsActive: true,
+	previewRequireCollaboratorPermissions: true,
+	previewLabels: [],
+	previewLimit: 3,
+	serverId: null,
+	previewDeployments: [],
+	domains: [],
 };
 
 const makeMrPayload = (
@@ -262,6 +283,10 @@ describe("GitLab webhook handler — Merge Request Hook open/update", () => {
 		vi.mocked(findGitlabByWebhookSecret).mockResolvedValue(
 			FAKE_GITLAB_PROVIDER as any,
 		);
+		// The setup.ts Proxy shares one findMany mock across tables, so the compose
+		// query in the MR branch returns FAKE_APP too. Its preview gates mirror the
+		// app's, so every assertion below holds; the compose service mocks keep the
+		// extra loop iteration from throwing.
 		vi.mocked(db.query.applications.findMany).mockResolvedValue([
 			FAKE_APP as any,
 		]);
@@ -271,6 +296,12 @@ describe("GitLab webhook handler — Merge Request Hook open/update", () => {
 		);
 		vi.mocked(createPreviewDeployment).mockResolvedValue({
 			previewDeploymentId: "new-preview-id",
+		} as any);
+		vi.mocked(findPreviewDeploymentByComposeId).mockResolvedValue(
+			undefined as any,
+		);
+		vi.mocked(createComposePreview).mockResolvedValue({
+			previewDeploymentId: "new-compose-preview-id",
 		} as any);
 	});
 	afterEach(() => vi.clearAllMocks());
@@ -417,6 +448,202 @@ describe("GitLab webhook handler — Merge Request Hook open/update", () => {
 		expect(createSecurityBlockedMRNote).toHaveBeenCalledTimes(1);
 		// Both apps blocked — no jobs queued
 		expect(myQueue.add).not.toHaveBeenCalled();
+	});
+});
+
+describe("GitLab webhook handler — Merge Request Hook compose previews", () => {
+	// The MR branch runs two findMany queries (applications first, compose
+	// second) against the shared setup.ts Proxy mock — prime both explicitly.
+	const primeMrQueries = (
+		composeRows: unknown[],
+		appRows: unknown[] = [],
+	) => {
+		vi.mocked(db.query.applications.findMany).mockResolvedValueOnce(
+			appRows as any,
+		);
+		vi.mocked(db.query.applications.findMany).mockResolvedValueOnce(
+			composeRows as any,
+		);
+	};
+
+	beforeEach(() => {
+		vi.mocked(findGitlabByWebhookSecret).mockResolvedValue(
+			FAKE_GITLAB_PROVIDER as any,
+		);
+		vi.mocked(findPreviewDeploymentsByPullRequestId).mockResolvedValue([]);
+		vi.mocked(findPreviewDeploymentByComposeId).mockResolvedValue(
+			undefined as any,
+		);
+		vi.mocked(createComposePreview).mockResolvedValue({
+			previewDeploymentId: "new-compose-preview-id",
+		} as any);
+	});
+	afterEach(() => vi.clearAllMocks());
+
+	it("creates a compose preview from the MR source branch and enqueues a compose-preview job on open", async () => {
+		vi.mocked(checkGitlabMemberPermissionsByUserId).mockResolvedValue({
+			hasWriteAccess: true,
+			accessLevel: 30,
+		});
+		primeMrQueries([FAKE_COMPOSE]);
+
+		const req = makeReq("Merge Request Hook", makeMrPayload("open"));
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(createComposePreview).toHaveBeenCalledWith({
+			composeId: "compose-id-1",
+			branch: "feature-branch",
+			pullRequestId: "12345",
+			pullRequestNumber: "42",
+			pullRequestTitle: "My MR Title",
+			pullRequestURL:
+				"https://gitlab.example.com/mygroup/myrepo/-/merge_requests/42",
+		});
+		expect(myQueue.add).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				composeId: "compose-id-1",
+				applicationType: "compose-preview",
+				type: "deploy",
+				previewDeploymentId: "new-compose-preview-id",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it("authorizes the compose preview against the MR author, not the privileged event actor", async () => {
+		// Actor≠author regression: a privileged member labeling/updating an
+		// untrusted author's MR must NOT unblock the compose preview. The check
+		// runs against object_attributes.author_id, and the author lacks access.
+		vi.mocked(checkGitlabMemberPermissionsByUserId).mockResolvedValue({
+			hasWriteAccess: false,
+			accessLevel: 20,
+		});
+		primeMrQueries([FAKE_COMPOSE]);
+
+		const payload = makeMrPayload("update", { author_id: 555 });
+		(payload as { user: unknown }).user = { username: "privileged-labeler" };
+		const req = makeReq("Merge Request Hook", payload);
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(checkGitlabMemberPermissionsByUserId).toHaveBeenCalledWith(
+			"gitlab-id-1",
+			99,
+			555,
+		);
+		expect(createComposePreview).not.toHaveBeenCalled();
+		expect(myQueue.add).not.toHaveBeenCalled();
+		expect(createSecurityBlockedMRNote).toHaveBeenCalledTimes(1);
+	});
+
+	it("reuses the existing compose preview on update instead of creating a duplicate", async () => {
+		vi.mocked(checkGitlabMemberPermissionsByUserId).mockResolvedValue({
+			hasWriteAccess: true,
+			accessLevel: 30,
+		});
+		vi.mocked(findPreviewDeploymentByComposeId).mockResolvedValue({
+			previewDeploymentId: "existing-compose-preview",
+		} as any);
+		primeMrQueries([FAKE_COMPOSE]);
+
+		const req = makeReq("Merge Request Hook", makeMrPayload("update"));
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(findPreviewDeploymentByComposeId).toHaveBeenCalledWith(
+			"compose-id-1",
+			"12345",
+		);
+		expect(createComposePreview).not.toHaveBeenCalled();
+		expect(myQueue.add).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationType: "compose-preview",
+				previewDeploymentId: "existing-compose-preview",
+			}),
+			expect.any(Object),
+		);
+	});
+
+	it("does not create a compose preview once the preview limit is reached", async () => {
+		vi.mocked(checkGitlabMemberPermissionsByUserId).mockResolvedValue({
+			hasWriteAccess: true,
+			accessLevel: 30,
+		});
+		primeMrQueries([
+			{
+				...FAKE_COMPOSE,
+				previewLimit: 1,
+				previewDeployments: [{ previewDeploymentId: "already-there" }],
+			},
+		]);
+
+		const req = makeReq("Merge Request Hook", makeMrPayload("open"));
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(createComposePreview).not.toHaveBeenCalled();
+		expect(myQueue.add).not.toHaveBeenCalled();
+	});
+
+	it("skips composes whose preview labels do not match the MR labels", async () => {
+		vi.mocked(checkGitlabMemberPermissionsByUserId).mockResolvedValue({
+			hasWriteAccess: true,
+			accessLevel: 30,
+		});
+		primeMrQueries([{ ...FAKE_COMPOSE, previewLabels: ["needs-review"] }]);
+
+		const req = makeReq("Merge Request Hook", makeMrPayload("open"));
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(createComposePreview).not.toHaveBeenCalled();
+		expect(myQueue.add).not.toHaveBeenCalled();
+	});
+
+	it("skips the permission check when previewRequireCollaboratorPermissions is disabled on the compose", async () => {
+		primeMrQueries([
+			{ ...FAKE_COMPOSE, previewRequireCollaboratorPermissions: false },
+		]);
+
+		const req = makeReq("Merge Request Hook", makeMrPayload("open"));
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(checkGitlabMemberPermissionsByUserId).not.toHaveBeenCalled();
+		expect(createComposePreview).toHaveBeenCalledTimes(1);
+	});
+
+	it("tears down compose preview rows on close via the shared PR finder", async () => {
+		vi.mocked(findPreviewDeploymentsByPullRequestId).mockResolvedValue([
+			{ previewDeploymentId: "app-preview-row" },
+			{
+				previewDeploymentId: "compose-preview-row",
+				composeId: "compose-id-1",
+			},
+		] as any);
+
+		const req = makeReq("Merge Request Hook", makeMrPayload("merge"));
+		const res = makeRes();
+
+		await handler(req, res);
+
+		expect(findPreviewDeploymentsByPullRequestId).toHaveBeenCalledWith("12345");
+		expect(removePreviewDeployment).toHaveBeenCalledTimes(2);
+		expect(removePreviewDeployment).toHaveBeenCalledWith("compose-preview-row");
+		expect(res.status).toHaveBeenCalledWith(200);
 	});
 });
 

--- a/apps/dokploy/pages/api/deploy/gitlab.ts
+++ b/apps/dokploy/pages/api/deploy/gitlab.ts
@@ -1,9 +1,11 @@
 import {
 	checkGitlabMemberPermissionsByUserId,
+	createComposePreview,
 	createPreviewDeployment,
 	createSecurityBlockedMRNote,
 	findGitlabByWebhookSecret,
 	findPreviewDeploymentByApplicationId,
+	findPreviewDeploymentByComposeId,
 	findPreviewDeploymentsByPullRequestId,
 	IS_CLOUD,
 	removePreviewDeployment,
@@ -252,7 +254,9 @@ export default async function handler(
 		const pathNamespace = body?.project?.path_with_namespace as string;
 
 		// Teardown BEFORE the author-id null-guard: close/merge must clean up
-		// even if the payload is missing author information.
+		// even if the payload is missing author information. The finder returns
+		// application AND compose preview rows for the MR; removePreviewDeployment
+		// dispatches compose rows to the compose-specific teardown internally.
 		if (action === "close" || action === "merge") {
 			const previewDeployments =
 				await findPreviewDeploymentsByPullRequestId(mrId);
@@ -307,10 +311,29 @@ export default async function handler(
 				},
 			});
 
+			const composeApps = await db.query.compose.findMany({
+				where: and(
+					eq(compose.sourceType, "gitlab"),
+					eq(compose.gitlabPathNamespace, pathNamespace),
+					eq(compose.gitlabBranch, targetBranch),
+					eq(compose.isPreviewDeploymentsActive, true),
+					eq(compose.gitlabId, gitlabProvider.gitlabId),
+				),
+				with: {
+					previewDeployments: true,
+					domains: true,
+				},
+			});
+
 			// Permission check is per-MR-author, not per-app — check once before the loop
-			const requiresPermissionCheck = apps.some(
-				(app) => app.previewRequireCollaboratorPermissions !== false,
-			);
+			const requiresPermissionCheck =
+				apps.some(
+					(app) => app.previewRequireCollaboratorPermissions !== false,
+				) ||
+				composeApps.some(
+					(composeApp) =>
+						composeApp.previewRequireCollaboratorPermissions !== false,
+				);
 			let permissionResult: Awaited<
 				ReturnType<typeof checkGitlabMemberPermissionsByUserId>
 			> | null = null;
@@ -358,6 +381,30 @@ export default async function handler(
 					}
 				}
 				secureApps.push(app);
+			}
+
+			// SECURITY: same MR-author gate for compose services, honoring each
+			// compose's previewRequireCollaboratorPermissions flag.
+			const secureComposeApps: typeof composeApps = [];
+
+			for (const composeApp of composeApps) {
+				if (composeApp.previewRequireCollaboratorPermissions !== false) {
+					if (permissionError) {
+						continue;
+					}
+					const { hasWriteAccess, accessLevel } = permissionResult!;
+					if (!hasWriteAccess) {
+						console.warn(
+							`🚨 SECURITY: Blocked compose preview deployment for ${composeApp.name} from ${authorDisplay}. Access level: ${accessLevel}`,
+						);
+						if (!blocked) {
+							blockedAccessLevel = accessLevel;
+							blocked = true;
+						}
+						continue;
+					}
+				}
+				secureComposeApps.push(composeApp);
 			}
 
 			if (blocked) {
@@ -423,6 +470,72 @@ export default async function handler(
 				if (previewDeploymentId) {
 					if (IS_CLOUD && app.serverId) {
 						jobData.serverId = app.serverId;
+						deploy(jobData).catch((error) => {
+							console.error("Background deployment failed:", error);
+						});
+						continue;
+					}
+					await myQueue.add(
+						"deployments",
+						{ ...jobData },
+						{
+							removeOnComplete: true,
+							removeOnFail: true,
+						},
+					);
+				}
+			}
+
+			// --- Compose preview deployments (mirrors the application flow) ---
+			for (const composeApp of secureComposeApps) {
+				// Label filtering
+				if (composeApp.previewLabels && composeApp.previewLabels.length > 0) {
+					const mrLabels: { title: string }[] =
+						body?.object_attributes?.labels ?? [];
+					const hasLabel = mrLabels.some((l) =>
+						composeApp.previewLabels!.includes(l.title),
+					);
+					if (!hasLabel) continue;
+				}
+
+				const existingComposePreview = await findPreviewDeploymentByComposeId(
+					composeApp.composeId,
+					mrId,
+				);
+
+				let previewDeploymentId =
+					existingComposePreview?.previewDeploymentId ?? "";
+
+				if (!existingComposePreview) {
+					// Only enforce the limit for new previews, not updates to existing ones
+					const previewLimit = composeApp.previewLimit ?? 3;
+					if (composeApp.previewDeployments.length >= previewLimit) {
+						continue;
+					}
+					const newComposePreview = await createComposePreview({
+						composeId: composeApp.composeId,
+						branch: sourceBranch,
+						pullRequestId: mrId,
+						pullRequestNumber: mrNumber,
+						pullRequestTitle: mrTitle,
+						pullRequestURL: mrUrl,
+					});
+					previewDeploymentId = newComposePreview.previewDeploymentId;
+				}
+
+				const jobData: DeploymentJob = {
+					composeId: composeApp.composeId,
+					titleLog: "Preview Deployment",
+					descriptionLog: `Hash: ${deploymentHash}`,
+					type: "deploy",
+					applicationType: "compose-preview",
+					server: !!composeApp.serverId,
+					previewDeploymentId,
+				};
+
+				if (previewDeploymentId) {
+					if (IS_CLOUD && composeApp.serverId) {
+						jobData.serverId = composeApp.serverId;
 						deploy(jobData).catch((error) => {
 							console.error("Background deployment failed:", error);
 						});


### PR DESCRIPTION
## Summary

Completes the GitLab half of compose preview deployments (follow-up to #135, which shipped the schema, services, queue plumbing, and GitHub-first webhook wiring). Closes the GitLab gap for upstream Dokploy/dokploy#2028 and Dokploy/dokploy#1483.

- **MR open / reopen / update** → spins up (or redeploys) an isolated copy of every matching Docker Compose stack: `sourceType=gitlab`, `gitlabPathNamespace` + `gitlabId` match, `gitlabBranch` equals the MR target branch, previews enabled. The preview is created from the MR **source branch** and enqueued as a `compose-preview` job, reusing the per-PR suffix isolation (services, volumes, networks) and per-service preview domains from #135.
- **MR update on an existing preview** → redeploys the same preview row — dedupe on `(composeId, pullRequestId)` via `findPreviewDeploymentByComposeId` plus the insert-first unique-index race close inside `createComposePreview`.
- **MR close / merge** → teardown needed **no webhook changes**: the close path already uses the shared `findPreviewDeploymentsByPullRequestId` finder, which returns application *and* compose rows, and `removePreviewDeployment` dispatches compose rows to `removeComposePreview` internally (stack down `--volumes`, network rm, deployments, directory, DB row).

## Security

Authorization runs against `object_attributes.author_id` — the **MR author, whose code actually deploys** — via `checkGitlabMemberPermissionsByUserId`, never `body.user` (the event actor: a privileged member labeling/updating an untrusted MR must not unblock it). Each compose honors its own `previewRequireCollaboratorPermissions` flag; the permission check stays hoisted (one API call per webhook covers apps and composes), and a single security MR note is posted when anything is blocked, with the existing note dedupe.

`previewLimit` is enforced for new previews (default 3), and `previewLabels` filtering mirrors the application flow.

GitLab compose previews skip the GitHub-App PR comment by design — `createComposePreview` / the deploy path gate comment posting on `sourceType === "github"`, so nothing throws for gitlab-sourced composes; status surfaces via the security MR notes as in the application flow.

## Scope

- No schema or migration changes (all landed in #135).
- `apps/dokploy/pages/api/deploy/gitlab.ts`: compose lookup + author-id gate + compose-preview job wiring in the Merge Request Hook branch.
- `apps/dokploy/__test__/deploy/gitlab.test.ts`: 7 new tests — compose preview created from the MR source branch, actor≠author authorization regression (privileged labeler must not unblock an untrusted author's compose preview), blocked security-note path, existing-preview reuse on update, preview limit, label gating, permission-check opt-out, and compose teardown on merge via the shared finder.

## Testing

- `tsc --noEmit` (apps/dokploy, cleared incremental cache): clean.
- `pnpm --filter=@dokploy/server build`: clean.
- `gitlab.test.ts`: 23/23 passing (16 existing + 7 new).
- Full suite: 939 passed, 1 skipped; the only failures are the 3 known Windows-local/docker-only files (`application.real.test.ts`, `server-setup.test.ts`, `readValidDirectory.test.ts`) — unrelated to this change.
