### PR TITLE
fix(project): project deletion 500s — delete-tree query exceeds Postgres 100-arg json_build_array limit

### DIFF
--- a/apps/dokploy/__test__/db/relational-query-args-project-delete.test.ts
+++ b/apps/dokploy/__test__/db/relational-query-args-project-delete.test.ts
@@ -1,0 +1,104 @@
+import * as schema from "@dokploy/server/db/schema";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Postgres caps any function call at 100 arguments (error 54023,
+ * "cannot pass more than 100 arguments to a function"). Drizzle's relational
+ * queries pack every selected column of a joined resource, plus one entry per
+ * nested relation, into a single json_build_array(...). The `application` table
+ * has exactly 100 columns, so selecting it in full inside a relational query
+ * that also nests a relation (e.g. `domains`) emits json_build_array(100
+ * columns + 1) = 101 args and throws.
+ *
+ * `deleteProject` gathers every Cloudflare-published domain under a project
+ * before the FK cascade drops the rows. Its tree query therefore projects
+ * `application`/`compose` down to their primary keys and only loads `domains`
+ * in full. This test mirrors that query shape (see
+ * packages/server/src/services/project.ts) and asserts the generated SQL stays
+ * within the cap. It builds SQL via .toSQL() only — no DB connection.
+ */
+
+const PG_MAX_FUNCTION_ARGS = 100;
+
+// Lazy postgres-js client: only .toSQL() is called, so it never connects.
+const client = postgres("postgres://user:pass@127.0.0.1:5432/db", { max: 1 });
+const db = drizzle(client, { schema });
+
+function maxJsonBuildArrayArgs(sqlStr: string): number {
+	const marker = "json_build_array(";
+	let max = 0;
+	let start = sqlStr.indexOf(marker);
+	while (start !== -1) {
+		let depth = 0;
+		let args = 1;
+		let inString: string | null = null;
+		for (let i = start + marker.length - 1; i < sqlStr.length; i++) {
+			const ch = sqlStr[i];
+			if (inString) {
+				if (ch === inString) inString = null;
+				continue;
+			}
+			if (ch === '"' || ch === "'") inString = ch;
+			else if (ch === "(") depth++;
+			else if (ch === ")") {
+				depth--;
+				if (depth === 0) break;
+			} else if (ch === "," && depth === 1) args++;
+		}
+		if (args > max) max = args;
+		start = sqlStr.indexOf(marker, start + 1);
+	}
+	return max;
+}
+
+describe("deleteProject tree query json_build_array argument limit", () => {
+	it("deleteProject domain-gathering query stays within the Postgres 100-argument cap", () => {
+		const { sql } = db.query.projects
+			.findFirst({
+				where: eq(schema.projects.projectId, "x"),
+				with: {
+					environments: {
+						columns: { environmentId: true },
+						with: {
+							applications: {
+								columns: { applicationId: true },
+								with: { domains: true },
+							},
+							compose: {
+								columns: { composeId: true },
+								with: { domains: true },
+							},
+						},
+					},
+				},
+			})
+			.toSQL();
+		expect(maxJsonBuildArrayArgs(sql)).toBeLessThanOrEqual(
+			PG_MAX_FUNCTION_ARGS,
+		);
+	});
+
+	it("selecting application in full with nested domains exceeds the cap (regression guard)", () => {
+		// Documents why the projection is required: the un-projected tree query
+		// that shipped with the Cloudflare feature blows the limit and 500s
+		// project.remove instance-wide. If `application` ever shrinks below the
+		// threshold this will flag that the projection can be revisited.
+		const { sql } = db.query.projects
+			.findFirst({
+				where: eq(schema.projects.projectId, "x"),
+				with: {
+					environments: {
+						with: {
+							applications: { with: { domains: true } },
+							compose: { with: { domains: true } },
+						},
+					},
+				},
+			})
+			.toSQL();
+		expect(maxJsonBuildArrayArgs(sql)).toBeGreaterThan(PG_MAX_FUNCTION_ARGS);
+	});
+});

--- a/packages/server/src/services/project.ts
+++ b/packages/server/src/services/project.ts
@@ -85,13 +85,27 @@ export const deleteProject = async (projectId: string) => {
 	// when the project is removed, with no per-row hook. Gather every
 	// Cloudflare-published domain under the project and tear down its external
 	// Cloudflare state (DNS/ingress/connector) BEFORE the cascade drops the rows.
+	// Only `domains` is consumed below, so project the parent rows down to their
+	// primary keys. Drizzle's relational queries pack every selected column plus
+	// one entry per nested relation into a single json_build_array(...), and
+	// Postgres caps function calls at 100 arguments (error 54023). `application`
+	// has exactly 100 columns, so selecting it in full alongside the nested
+	// `domains` relation emits 101 args and breaks project deletion (see
+	// findMountById / findScheduleById for the same projection pattern).
 	const projectTree = await db.query.projects.findFirst({
 		where: eq(projects.projectId, projectId),
 		with: {
 			environments: {
+				columns: { environmentId: true },
 				with: {
-					applications: { with: { domains: true } },
-					compose: { with: { domains: true } },
+					applications: {
+						columns: { applicationId: true },
+						with: { domains: true },
+					},
+					compose: {
+						columns: { composeId: true },
+						with: { domains: true },
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Symptom

On the test instance (v0.29.12-community.3), `project.remove` returns a 500 — `Failed query: select "projects"...` — for **every** project, instance-wide. The UI delete dialog fails silently (separate UX issue, see note below). Project pages/list and application create/read still work.

## Root cause

**Not a new schema column** — `application` still has exactly 100 columns, same as the June baseline (verified against `31b4b9907`). The 101st `json_build_array` argument comes from a **nested relation**, not a column.

PR #116 (`70e04f9a0`, *feat(cloudflare): native Cloudflare Tunnel domain publishing*, merged 2026-07-16) added a pre-delete tree query to `deleteProject` in `packages/server/src/services/project.ts` to gather Cloudflare-published domains before the FK cascade drops them:

```ts
applications: { with: { domains: true } },
```

Drizzle's relational query builder packs every selected column **plus one entry per nested relation** into a single `json_build_array(...)`. Postgres caps function calls at 100 arguments (error 54023). With `application` sitting at exactly 100 columns, `100 columns + 1 nested domains entry = 101 args` → the query throws, project deletion breaks. That's also why `findProjectById` (`applications: true`, exactly 100 args) and all other project queries still work — only this query crosses the cap.

## Fix (June `findMountById` precedent)

Explicit `columns:` projection, no behavior change, no migration, schema untouched. The only consumer of the tree is:

```ts
env.applications.flatMap((application) => application.domains)
env.compose.flatMap((compose) => compose.domains)
```

so `applications`/`compose` are projected down to their primary keys and `domains` stays full (`deprovisionCloudflareForDomains` takes full `Domain[]` rows). `environments` is projected to `environmentId` for the same reason. Application-level `json_build_array` drops from 101 args to 2.

## Verification

- `corepack pnpm@10.22.0 --filter @dokploy/server typecheck` — clean.
- `corepack pnpm@10.22.0 --filter dokploy typecheck` — only the 2 pre-existing, unrelated zod-resolver errors in `handle-network.tsx` / `handle-tag.tsx` (present on canary before this change).
- New guard test `apps/dokploy/__test__/db/relational-query-args-project-delete.test.ts` (mirrors the existing June guard tests, builds SQL via `.toSQL()` only, no DB): asserts the fixed query stays ≤ 100 args **and** that the un-projected shape that shipped in #116 exceeds the cap (regression guard). All 3 db guard test files pass (8 tests).

## Audit of remaining full-column application loads

All other sites that load `applications` as a relation were swept: they either already project (`environment.ts findEnvironmentById`, all `project.ts` router queries at lines 356/447/526/680) or load `applications: true` / `where`-only with **no nested relation** — exactly 100 args, which Postgres accepts. Deliberately left untouched (`findProjectById`, `findEnvironmentsByProjectId`, `haveActiveServices`, `validUniqueServerAppName`, router `project.one`): trimming them would change API response shapes. They sit at the cap with zero headroom — any 101st `application` column breaks them all, per the fork's standing side-table rule.

## Notes

- The delete dialog swallowing the 500 silently (no toast) is a separate UI issue, not addressed here.
- Alternative considered: chunking the relational query / raw select. The projection is smaller, matches the repo's established pattern, and is guard-tested, so it was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
