### PR TITLE
feat(auth): 30-day sliding sessions (configurable via DOKPLOY_SESSION_DAYS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Beyond the ported features, this fork carries **7 direct security commits** and 
 - **Git providers & auth** — GitHub/Google social login on self-hosted, self-hosted password reset, Codeberg preset, Gitea `write:repository` scope, and several OAuth/redirect fixes
 - **Organizations & teams** — editable descriptions, bulk invitations, drag-and-drop logo upload, and **project export** to a portable JSON file
 - **Reliability** — clean exit on fatal startup errors instead of crash-looping, Podman idle-exec support, custom `template.toml` in git repos, and Docker/Ubuntu install-failure fixes
+- **Longer login sessions** — sessions last 30 days (sliding) instead of upstream's 3, configurable via `DOKPLOY_SESSION_DAYS`
 - **15+ UI/UX fixes** — deployments filtering and tab behavior, env-form edit stability, log-counter layout shift, responsive log pages, dark-theme icons, and new translations
 
 Every item above is ported 1:1 and credited to its original upstream author. See the **[full release notes](https://github.com/DevinoSolutions/dokploy-community/releases/tag/v0.29.12-community.2)** for the complete, per-PR credited list, migration details, and known caveats.

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -30,6 +30,17 @@ import { getPublicIpWithFallback } from "../wss/utils";
 import { ac, adminRole, memberRole, ownerRole } from "./access-control";
 import { betterAuthSecret } from "./auth-secret";
 
+// Number of days a login session stays valid (sliding window). Reads
+// DOKPLOY_SESSION_DAYS, falling back to 30. Invalid or non-positive values
+// fall back to the default so a bad env var can never lock everyone out.
+const DEFAULT_SESSION_DAYS = 30;
+const getSessionDays = () => {
+	const raw = process.env.DOKPLOY_SESSION_DAYS;
+	if (!raw) return DEFAULT_SESSION_DAYS;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_DAYS;
+};
+
 const resolveTrustedOrigins = async () => {
 	try {
 		if (IS_CLOUD) {
@@ -372,7 +383,11 @@ const createBetterAuth = () =>
 			},
 		},
 		session: {
-			expiresIn: 60 * 60 * 24 * 3,
+			// Sliding session lifetime, in days. Defaults to 30 (upstream ships 3,
+			// which logs infrequent users out too aggressively for a dashboard).
+			// Override per-install with DOKPLOY_SESSION_DAYS.
+			expiresIn: 60 * 60 * 24 * getSessionDays(),
+			// Refresh the sliding expiry at most once a day of use.
 			updateAge: 60 * 60 * 24,
 		},
 		user: {


### PR DESCRIPTION
## What

Login sessions now last **30 days on a sliding window** instead of upstream Dokploy's 3 days. The expiry is refreshed at most once per day of use (`updateAge` = 1 day), so active users stay logged in and infrequent users are no longer kicked out aggressively.

## Configurable

The lifetime is overridable per-install via the `DOKPLOY_SESSION_DAYS` env var:
- Unset -> defaults to **30 days**.
- Invalid or non-positive values (non-numeric, `0`, negative) -> **safely fall back to 30 days**, so a bad env var can never lock everyone out.

## Changes

- `packages/server/src/lib/auth.ts`: adds a `getSessionDays()` helper reading `DOKPLOY_SESSION_DAYS` (default 30, safe fallback), and wires the better-auth `session` config to `expiresIn: 60 * 60 * 24 * getSessionDays()` with `updateAge: 60 * 60 * 24`.
- `README.md`: documents the longer login sessions and the `DOKPLOY_SESSION_DAYS` override in the **Also included** section.

## Verification

- `tsc --noEmit` on `packages/server` passes (exit 0).
- Formatted with Biome.