### PR TITLE
fix(domains): allow valid wildcard hosts through hostname validation and emit Traefik v3 HostRegexp

### DIFF
--- a/apps/dokploy/__test__/traefik/wildcard-domain.test.ts
+++ b/apps/dokploy/__test__/traefik/wildcard-domain.test.ts
@@ -1,0 +1,151 @@
+import type { Domain } from "@dokploy/server";
+import { createDomainLabels, domain as domainSchema } from "@dokploy/server";
+import { apiCreateDomain } from "@dokploy/server/db/schema";
+import { createRouterConfig } from "@dokploy/server/utils/traefik/domain";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Wildcard domains regression suite.
+ *
+ * 1) Validation: "*.example.com"-style hosts must pass the shared zod schemas
+ *    (the UI form AND apiCreateDomain), while malformed wildcards keep being
+ *    rejected. Regression for the base hostname refine (VALID_HOSTNAME_REGEX,
+ *    upstream #4729 port) firing before the wildcard rules and 400-ing every
+ *    wildcard host.
+ *
+ * 2) Rule generation: wildcard hosts must emit a Traefik v3 HostRegexp with a
+ *    plain anchored Go regexp. The old "{subdomain:[a-zA-Z0-9-]+}" named-group
+ *    syntax is Traefik v2 only — on v3 (what Dokploy ships) it is an invalid
+ *    rule that never matches.
+ */
+
+const baseDomain: Domain = {
+	host: "app.example.com",
+	port: 8080,
+	https: true,
+	customEntrypoint: null,
+	uniqueConfigKey: 1,
+	customCertResolver: null,
+	certificateType: "letsencrypt",
+	applicationId: "app-1",
+	composeId: "",
+	domainType: "application",
+	serviceName: "web",
+	domainId: "dom-1",
+	path: "/",
+	createdAt: "",
+	previewDeploymentId: "",
+	internalPath: "/",
+	stripPath: false,
+	middlewares: null,
+	forwardAuthEnabled: false,
+	publishToCloudflare: false,
+	cloudflareTunnelMode: null,
+	cloudflareId: null,
+	cloudflareZoneId: null,
+	cloudflareTunnelId: null,
+	cloudflareDnsRecordId: null,
+	cloudflareIngressApplied: false,
+	enableCloudflareAccess: false,
+	cloudflareAccessApplicationId: null,
+};
+
+const fakeApp = {
+	appName: "test-app",
+	redirects: [],
+	security: [],
+} as never;
+
+const parseHost = (host: string) =>
+	domainSchema.safeParse({ host, customCertResolver: "" });
+
+const hostError = (host: string) => {
+	const result = parseHost(host);
+	if (result.success) return null;
+	return (
+		result.error.issues.find((issue) => issue.path[0] === "host")?.message ??
+		null
+	);
+};
+
+describe("domain schema host validation (UI form + apiCreateDomain path)", () => {
+	it.each([
+		"example.com",
+		"foo.wild.devino.ca",
+		"*.wild.devino.ca",
+		"*.sub.example.com",
+	])("accepts %s", (host) => {
+		expect(parseHost(host).success).toBe(true);
+	});
+
+	it.each(["bad*.x.com", "*", "*.", "a.*.b.com", "*.*.com", "under_score.com"])(
+		"rejects %s",
+		(host) => {
+			expect(parseHost(host).success).toBe(false);
+		},
+	);
+
+	it("surfaces the wildcard-specific message for misplaced wildcards", () => {
+		expect(hostError("bad*.x.com")).toContain("must start with '*.'");
+		expect(hostError("*.*.com")).toContain("Only one wildcard");
+	});
+
+	it("apiCreateDomain accepts a wildcard host and rejects a malformed one", () => {
+		const valid = apiCreateDomain.safeParse({
+			host: "*.wild.devino.ca",
+			customCertResolver: "",
+			applicationId: "app-1",
+		});
+		expect(valid.success).toBe(true);
+
+		const invalid = apiCreateDomain.safeParse({
+			host: "ba*d.wild.devino.ca",
+			customCertResolver: "",
+			applicationId: "app-1",
+		});
+		expect(invalid.success).toBe(false);
+	});
+});
+
+describe("application file config rule (traefik/domain.ts)", () => {
+	it("emits a Traefik v3 anchored Go regexp for wildcard hosts", async () => {
+		const config = await createRouterConfig(
+			fakeApp,
+			{ ...baseDomain, host: "*.wild.devino.ca" },
+			"websecure",
+		);
+		expect(config.rule).toBe(
+			"HostRegexp(`^[a-zA-Z0-9-]+\\.wild\\.devino\\.ca\\z`)",
+		);
+		expect(config.rule).not.toContain("{subdomain:");
+	});
+
+	it("keeps plain hosts on Host()", async () => {
+		const config = await createRouterConfig(fakeApp, baseDomain, "websecure");
+		expect(config.rule).toBe("Host(`app.example.com`)");
+	});
+});
+
+describe("compose Docker labels rule (docker/domain.ts)", () => {
+	it("emits a Traefik v3 anchored Go regexp for wildcard hosts", () => {
+		const labels = createDomainLabels(
+			"test-app",
+			{ ...baseDomain, host: "*.wild.devino.ca" },
+			"websecure",
+		);
+		expect(labels[0]).toBe(
+			"traefik.http.routers.test-app-1-websecure.rule=HostRegexp(`^[a-zA-Z0-9-]+\\.wild\\.devino\\.ca\\z`)",
+		);
+		expect(labels.join("\n")).not.toContain("{subdomain:");
+		// A bare `$` would trip docker-compose variable interpolation — the Go
+		// regexp must anchor with \z instead.
+		expect(labels.join("\n")).not.toContain("$");
+	});
+
+	it("keeps plain hosts on Host()", () => {
+		const labels = createDomainLabels("test-app", baseDomain, "websecure");
+		expect(labels[0]).toBe(
+			"traefik.http.routers.test-app-1-websecure.rule=Host(`app.example.com`)",
+		);
+	});
+});

--- a/apps/dokploy/__test__/utils/hostname-validation.test.ts
+++ b/apps/dokploy/__test__/utils/hostname-validation.test.ts
@@ -1,4 +1,12 @@
-import { VALID_HOSTNAME_REGEX } from "@dokploy/server";
+import {
+	getDomainHostError,
+	INVALID_HOSTNAME_MESSAGE,
+	isValidDomainHost,
+	VALID_HOSTNAME_REGEX,
+	WILDCARD_SINGLE_MESSAGE,
+	WILDCARD_START_MESSAGE,
+	wildcardHostRegexp,
+} from "@dokploy/server";
 import { describe, expect, it } from "vitest";
 
 describe("VALID_HOSTNAME_REGEX", () => {
@@ -42,5 +50,67 @@ describe("VALID_HOSTNAME_REGEX", () => {
 		"xn--wgv71a119e.jp", // punycode for 日本語.jp
 	])("accepts punycode-encoded IDN %s", (host) => {
 		expect(VALID_HOSTNAME_REGEX.test(host)).toBe(true);
+	});
+
+	// The base regex itself stays wildcard-free — wildcard awareness lives in
+	// getDomainHostError so plain-hostname consumers (e.g. the server web
+	// domain form) keep rejecting asterisks.
+	it("rejects wildcard hosts (handled by getDomainHostError instead)", () => {
+		expect(VALID_HOSTNAME_REGEX.test("*.example.com")).toBe(false);
+	});
+});
+
+describe("getDomainHostError / isValidDomainHost (wildcard-aware)", () => {
+	it.each([
+		"example.com",
+		"foo.wild.devino.ca",
+		"*.wild.devino.ca",
+		"*.sub.example.com",
+	])("accepts %s", (host) => {
+		expect(getDomainHostError(host)).toBeNull();
+		expect(isValidDomainHost(host)).toBe(true);
+	});
+
+	it.each([
+		["bad*.x.com", WILDCARD_START_MESSAGE],
+		["a.*.b.com", WILDCARD_START_MESSAGE],
+		["*", WILDCARD_START_MESSAGE],
+		["**.example.com", WILDCARD_START_MESSAGE],
+		["*.*.com", WILDCARD_SINGLE_MESSAGE],
+		["*.exa*mple.com", WILDCARD_SINGLE_MESSAGE],
+		["*.", INVALID_HOSTNAME_MESSAGE],
+		["under_score.com", INVALID_HOSTNAME_MESSAGE],
+		["*.under_score.com", INVALID_HOSTNAME_MESSAGE],
+	])("rejects %s with its specific message", (host, message) => {
+		expect(getDomainHostError(host)).toBe(message);
+		expect(isValidDomainHost(host)).toBe(false);
+	});
+});
+
+describe("wildcardHostRegexp (Traefik v3 HostRegexp payload)", () => {
+	it("emits an anchored Go regexp with the literal remainder escaped", () => {
+		expect(wildcardHostRegexp("*.wild.devino.ca")).toBe(
+			"^[a-zA-Z0-9-]+\\.wild\\.devino\\.ca\\z",
+		);
+		expect(wildcardHostRegexp("*.sub.example.com")).toBe(
+			"^[a-zA-Z0-9-]+\\.sub\\.example\\.com\\z",
+		);
+	});
+
+	it("never emits the Traefik v2 named-group syntax", () => {
+		expect(wildcardHostRegexp("*.example.com")).not.toContain("{subdomain:");
+	});
+
+	it("matches exactly one subdomain label (Go \\z ~ JS $)", () => {
+		// Go's RE2 supports \z but JS does not — swap it for $ to exercise the
+		// matching semantics in-process.
+		const re = new RegExp(
+			wildcardHostRegexp("*.wild.devino.ca").replace(/\\z$/, "$"),
+		);
+		expect(re.test("foo.wild.devino.ca")).toBe(true);
+		expect(re.test("wild.devino.ca")).toBe(false); // no bare apex
+		expect(re.test("a.b.wild.devino.ca")).toBe(false); // single level only
+		expect(re.test("foo.wild-devino.ca")).toBe(false); // dots stay literal
+		expect(re.test("foo.wild.devino.ca.evil.com")).toBe(false); // anchored end
 	});
 });

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -1,7 +1,4 @@
-import {
-	INVALID_HOSTNAME_MESSAGE,
-	VALID_HOSTNAME_REGEX,
-} from "@dokploy/server/utils/hostname-validation";
+import { getDomainHostError } from "@dokploy/server/utils/hostname-validation";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { DatabaseZap, Dices, RefreshCw, X } from "lucide-react";
 import Link from "next/link";
@@ -58,8 +55,16 @@ export const domain = z
 				message: "Domain name cannot have leading or trailing spaces",
 			})
 			.transform((val) => val.trim())
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
-				message: INVALID_HOSTNAME_MESSAGE,
+			// Wildcard-aware hostname validation ("*.example.com" is valid, the
+			// wildcard placement rules reject "bad*.x.com", "*.*.com", etc.).
+			.superRefine((val, ctx) => {
+				const error = getDomainHostError(val);
+				if (error) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: error,
+					});
+				}
 			}),
 		path: z.string().min(1).optional(),
 		internalPath: z.string().optional(),

--- a/apps/dokploy/server/db/validations/domain.ts
+++ b/apps/dokploy/server/db/validations/domain.ts
@@ -1,7 +1,4 @@
-import {
-	INVALID_HOSTNAME_MESSAGE,
-	VALID_HOSTNAME_REGEX,
-} from "@dokploy/server/utils/hostname-validation";
+import { getDomainHostError } from "@dokploy/server/utils/hostname-validation";
 import { z } from "zod";
 
 export const domain = z
@@ -13,8 +10,16 @@ export const domain = z
 				message: "Domain name cannot have leading or trailing spaces",
 			})
 			.transform((val) => val.trim())
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
-				message: INVALID_HOSTNAME_MESSAGE,
+			// Wildcard-aware hostname validation ("*.example.com" is valid, the
+			// wildcard placement rules reject "bad*.x.com", "*.*.com", etc.).
+			.superRefine((val, ctx) => {
+				const error = getDomainHostError(val);
+				if (error) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: error,
+					});
+				}
 			}),
 		path: z.string().min(1).optional(),
 		port: z
@@ -43,35 +48,8 @@ export const domain = z
 			});
 		}
 
-		// Validate wildcard domain format
-		if (input.host.includes("*")) {
-			// Check if wildcard is only at the beginning of a subdomain
-			if (!input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard domains must start with '*.' (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-			// Check if there are multiple wildcards
-			if ((input.host.match(/\*/g) || []).length > 1) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message: "Only one wildcard is allowed per domain",
-				});
-			}
-			// Check if wildcard is in the middle or end (not at start of subdomain)
-			if (input.host.includes("*") && !input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard must be at the beginning of a subdomain (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-		}
+		// Wildcard placement rules are enforced in the field-level host check
+		// (getDomainHostError), so every consumer of this schema gets them.
 	});
 
 export const domainCompose = z
@@ -83,8 +61,16 @@ export const domainCompose = z
 				message: "Domain name cannot have leading or trailing spaces",
 			})
 			.transform((val) => val.trim())
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
-				message: INVALID_HOSTNAME_MESSAGE,
+			// Wildcard-aware hostname validation ("*.example.com" is valid, the
+			// wildcard placement rules reject "bad*.x.com", "*.*.com", etc.).
+			.superRefine((val, ctx) => {
+				const error = getDomainHostError(val);
+				if (error) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: error,
+					});
+				}
 			}),
 		path: z.string().min(1).optional(),
 		port: z
@@ -114,33 +100,6 @@ export const domainCompose = z
 			});
 		}
 
-		// Validate wildcard domain format
-		if (input.host.includes("*")) {
-			// Check if wildcard is only at the beginning of a subdomain
-			if (!input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard domains must start with '*.' (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-			// Check if there are multiple wildcards
-			if ((input.host.match(/\*/g) || []).length > 1) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message: "Only one wildcard is allowed per domain",
-				});
-			}
-			// Check if wildcard is in the middle or end (not at start of subdomain)
-			if (input.host.includes("*") && !input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard must be at the beginning of a subdomain (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-		}
+		// Wildcard placement rules are enforced in the field-level host check
+		// (getDomainHostError), so every consumer of this schema gets them.
 	});

--- a/packages/server/src/db/validations/domain.ts
+++ b/packages/server/src/db/validations/domain.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-	INVALID_HOSTNAME_MESSAGE,
-	VALID_HOSTNAME_REGEX,
-} from "../../utils/hostname-validation";
+import { getDomainHostError } from "../../utils/hostname-validation";
 
 export const domain = z
 	.object({
@@ -13,8 +10,17 @@ export const domain = z
 				message: "Domain name cannot have leading or trailing spaces",
 			})
 			.transform((val) => val.trim())
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
-				message: INVALID_HOSTNAME_MESSAGE,
+			// Wildcard-aware hostname validation ("*.example.com" is valid, the
+			// wildcard placement rules reject "bad*.x.com", "*.*.com", etc.).
+			// Kept at field level so apiCreateDomain/apiUpdateDomain inherit it.
+			.superRefine((val, ctx) => {
+				const error = getDomainHostError(val);
+				if (error) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: error,
+					});
+				}
 			}),
 		path: z.string().min(1).optional(),
 		internalPath: z.string().optional(),
@@ -69,35 +75,9 @@ export const domain = z
 			});
 		}
 
-		// Validate wildcard domain format
-		if (input.host.includes("*")) {
-			// Check if wildcard is only at the beginning of a subdomain
-			if (!input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard domains must start with '*.' (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-			// Check if there are multiple wildcards
-			if ((input.host.match(/\*/g) || []).length > 1) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message: "Only one wildcard is allowed per domain",
-				});
-			}
-			// Check if wildcard is in the middle or end (not at start of subdomain)
-			if (input.host.includes("*") && !input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard must be at the beginning of a subdomain (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-		}
+		// Wildcard placement rules are enforced in the field-level host check
+		// (getDomainHostError), so they also apply to schemas that only inherit
+		// the field via .shape/.pick (e.g. apiCreateDomain).
 	});
 
 export const domainCompose = z
@@ -109,8 +89,17 @@ export const domainCompose = z
 				message: "Domain name cannot have leading or trailing spaces",
 			})
 			.transform((val) => val.trim())
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
-				message: INVALID_HOSTNAME_MESSAGE,
+			// Wildcard-aware hostname validation ("*.example.com" is valid, the
+			// wildcard placement rules reject "bad*.x.com", "*.*.com", etc.).
+			// Kept at field level so apiCreateDomain/apiUpdateDomain inherit it.
+			.superRefine((val, ctx) => {
+				const error = getDomainHostError(val);
+				if (error) {
+					ctx.addIssue({
+						code: z.ZodIssueCode.custom,
+						message: error,
+					});
+				}
 			}),
 		path: z.string().min(1).optional(),
 		internalPath: z.string().optional(),
@@ -166,33 +155,7 @@ export const domainCompose = z
 			});
 		}
 
-		// Validate wildcard domain format
-		if (input.host.includes("*")) {
-			// Check if wildcard is only at the beginning of a subdomain
-			if (!input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard domains must start with '*.' (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-			// Check if there are multiple wildcards
-			if ((input.host.match(/\*/g) || []).length > 1) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message: "Only one wildcard is allowed per domain",
-				});
-			}
-			// Check if wildcard is in the middle or end (not at start of subdomain)
-			if (input.host.includes("*") && !input.host.match(/^\*\./)) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					path: ["host"],
-					message:
-						"Wildcard must be at the beginning of a subdomain (e.g., '*.example.com' or '*.sub.example.com')",
-				});
-			}
-		}
+		// Wildcard placement rules are enforced in the field-level host check
+		// (getDomainHostError), so they also apply to schemas that only inherit
+		// the field via .shape/.pick (e.g. apiCreateDomain).
 	});

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -4,6 +4,7 @@ import { paths } from "@dokploy/server/constants";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
 import { parse, stringify } from "yaml";
+import { wildcardHostRegexp } from "../hostname-validation";
 import { execAsyncRemote } from "../process/execAsync";
 import { cloneBitbucketRepository } from "../providers/bitbucket";
 import { cloneGitRepository } from "../providers/git";
@@ -274,9 +275,10 @@ export const createDomainLabels = (
 		internalPath,
 	} = domain;
 	const routerName = `${appName}-${uniqueConfigKey}-${entrypoint}`;
-	// Generate the Host rule - support wildcards
-	const hostRule = host.includes("*")
-		? `HostRegexp(\`${host.replace("*", "{subdomain:[a-zA-Z0-9-]+}")}\`)`
+	// Generate the Host rule - support wildcards. Traefik v3 HostRegexp takes
+	// a plain Go regexp (the v2 "{subdomain:...}" syntax is invalid in v3).
+	const hostRule = host.startsWith("*.")
+		? `HostRegexp(\`${wildcardHostRegexp(host)}\`)`
 		: `Host(\`${host}\`)`;
 
 	const labels = [

--- a/packages/server/src/utils/hostname-validation.ts
+++ b/packages/server/src/utils/hostname-validation.ts
@@ -6,3 +6,58 @@ export const VALID_HOSTNAME_REGEX =
 
 export const INVALID_HOSTNAME_MESSAGE =
 	"Invalid domain name. Use only letters, numbers, hyphens and dots (e.g. example.com). Underscores are not allowed.";
+
+export const WILDCARD_START_MESSAGE =
+	"Wildcard domains must start with '*.' (e.g., '*.example.com' or '*.sub.example.com')";
+
+export const WILDCARD_SINGLE_MESSAGE =
+	"Only one wildcard is allowed per domain";
+
+/**
+ * Wildcard-aware host validation shared by the domain form schemas and the
+ * API input schemas (apiCreateDomain/apiUpdateDomain inherit it via the
+ * field-level `host` checks, which survive drizzle-zod's createInsertSchema
+ * and .pick() — object-level superRefines do not).
+ *
+ * - Non-wildcard hosts must match VALID_HOSTNAME_REGEX (underscores stay banned).
+ * - Wildcard hosts must be exactly "*." followed by a valid hostname:
+ *   a single leading asterisk only, so "bad*.x.com", "a.*.b.com", "*.*.com",
+ *   "**.example.com", bare "*" and "*." are all rejected.
+ *
+ * Returns null when the host is valid, otherwise the error message to surface.
+ */
+export const getDomainHostError = (host: string): string | null => {
+	if (!host.includes("*")) {
+		return VALID_HOSTNAME_REGEX.test(host) ? null : INVALID_HOSTNAME_MESSAGE;
+	}
+	if (!host.startsWith("*.")) {
+		return WILDCARD_START_MESSAGE;
+	}
+	if (host.includes("*", 1)) {
+		return WILDCARD_SINGLE_MESSAGE;
+	}
+	return VALID_HOSTNAME_REGEX.test(host.slice(2))
+		? null
+		: INVALID_HOSTNAME_MESSAGE;
+};
+
+export const isValidDomainHost = (host: string): boolean =>
+	getDomainHostError(host) === null;
+
+/**
+ * Builds the anchored Go regexp for a Traefik v3 `HostRegexp(...)` rule from a
+ * validated wildcard host, e.g. "*.wild.devino.ca" ->
+ * "^[a-zA-Z0-9-]+\.wild\.devino\.ca\z".
+ *
+ * Traefik v3 takes a plain Go (RE2) regexp here — the v2
+ * "{subdomain:[a-zA-Z0-9-]+}" named-group syntax is invalid in v3 and produces
+ * a router that never matches. The literal remainder is regexp-escaped, and
+ * the wildcard matches exactly one DNS label (same scope as a wildcard cert).
+ * `\z` (RE2 end-of-text, equivalent to `$` here) is used instead of `$` so the
+ * rule stays inert when embedded in a docker-compose label, where a bare `$`
+ * trips compose variable interpolation.
+ */
+export const wildcardHostRegexp = (host: string): string => {
+	const remainder = host.slice(2).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return `^[a-zA-Z0-9-]+\\.${remainder}\\z`;
+};

--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -1,5 +1,6 @@
 import type { Domain } from "@dokploy/server/services/domain";
 import type { ApplicationNested } from "../builders";
+import { wildcardHostRegexp } from "../hostname-validation";
 import {
 	createServiceConfig,
 	loadOrCreateConfig,
@@ -147,10 +148,11 @@ export const createRouterConfig = async (
 	} = domain;
 	const punycodeHost = toPunycode(host);
 	// Generate the Host rule — support wildcard subdomains via HostRegexp.
-	// Wildcards are ASCII in practice, so keep the raw host there and reserve
-	// punycode (IDN support) for the regular Host() rule.
-	const hostRule = host.includes("*")
-		? `HostRegexp(\`${host.replace("*", "{subdomain:[a-zA-Z0-9-]+}")}\`)`
+	// Traefik v3 HostRegexp takes a plain Go regexp (the v2 "{subdomain:...}"
+	// syntax is invalid in v3), built from the raw host since wildcards are
+	// ASCII in practice; punycode (IDN support) stays on the Host() rule.
+	const hostRule = host.startsWith("*.")
+		? `HostRegexp(\`${wildcardHostRegexp(host)}\`)`
 		: `Host(\`${punycodeHost}\`)`;
 	const routerConfig: HttpRouter = {
 		rule: `${hostRule}${path !== null && path !== "/" ? ` && PathPrefix(\`${path}\`)` : ""}`,


### PR DESCRIPTION
## E2E symptom

On the test instance (canary v0.29.12-community.3), the wildcard domains feature is fully regressed: both the Add Domain form and `domain.create` (apiCreateDomain) respond 400 BAD_REQUEST with *"Invalid domain name. Use only letters, numbers, hyphens and dots…"* for a perfectly valid `*.wild.devino.ca`. The wildcard-specific error messages were never shown for malformed wildcards either.

## Root causes

**1. Validation ordering — wildcards never reach the wildcard rules** (`packages/server/src/db/validations/domain.ts`, `apps/dokploy/server/db/validations/domain.ts`, `handle-domain.tsx`)

`b2692cd59` (port of upstream #4729) added a field-level refine on `host` using `VALID_HOSTNAME_REGEX`, which only permits `[a-zA-Z0-9-]` labels — no `*`. The wildcard feature (`110e3d365`) added its placement rules as an **object-level** `superRefine` on the same schemas but never exempted `*.` hosts from the base refine, so every wildcard host was rejected with the generic message and the wildcard-specific messages were dead code.

Worse: `apiCreateDomain` is built via `createInsertSchema(domains, { ...domain.shape })` + `.pick()` (`packages/server/src/db/schema/domain.ts`), which inherits only the **field-level** checks — the object-level wildcard superRefine never applied to the API at all.

**2. Traefik v2 rule syntax on a v3 deployment** (`packages/server/src/utils/traefik/domain.ts` ~L152, `packages/server/src/utils/docker/domain.ts` ~L279)

Both rule generators emitted ``HostRegexp(`{subdomain:[a-zA-Z0-9-]+}.x.com`)`` — that `{name:regexp}` named-group syntax is **Traefik v2**. The repo ships Traefik v3 (`TRAEFIK_VERSION = 3.6.20` in `packages/server/src/setup/traefik-setup.ts`; `install.sh` pins `traefik:v3.6.7`), where `HostRegexp` takes a plain Go regexp — the v2 syntax produces a router that never matches. So even if validation had passed, wildcard routing would have been broken.

## Fix

- **`hostname-validation.ts`**: new shared `getDomainHostError()` / `isValidDomainHost()` — non-wildcard hosts still must match `VALID_HOSTNAME_REGEX` unchanged (underscores stay banned); wildcard hosts must be exactly `*.` + a valid hostname. Placement violations return the wildcard-specific messages (now actually reachable). Applied at the **field level** in all three schema sites, so the UI form and `apiCreateDomain`/`apiUpdateDomain` agree; the now-redundant object-level wildcard blocks were removed.
- **`wildcardHostRegexp()`**: wildcard hosts now emit a Traefik-v3-valid anchored Go regexp with the literal remainder regexp-escaped: `*.wild.devino.ca` → ``HostRegexp(`^[a-zA-Z0-9-]+\.wild\.devino\.ca\z`)``. `\z` (RE2 end-of-text, equivalent to `$`) is used so the rule stays inert inside docker-compose labels, where a bare `$` trips compose variable interpolation. Both generator sites (file-provider config + compose labels) updated; non-wildcard hosts keep `Host(punycode)` / `Host(host)` exactly as before.
- The dashboard's own web-domain form intentionally keeps the plain (non-wildcard) regex.
- Preview deployments are unaffected: they interpolate `*` away before `createDomain` (`preview-deployment.ts`), and internal service calls don't parse the zod schema anyway.
- Migration `0179_overrated_bug.sql` only adds `webServerSettings.domainRestrictionConfig` (admin allow-list feature) — no DB constraint on domain hosts; untouched and consistent.

## Test matrix

`__test__/utils/hostname-validation.test.ts` + new `__test__/traefik/wildcard-domain.test.ts`:

- Accepts: `example.com`, `foo.wild.devino.ca`, `*.wild.devino.ca`, `*.sub.example.com` — via helper, `domain` schema, and `apiCreateDomain`.
- Rejects: `bad*.x.com`, `*`, `*.`, `a.*.b.com`, `*.*.com`, `**.example.com`, `under_score.com`, `*.under_score.com` — each asserted against its specific message.
- Rule generation: wildcard → exact v3 `HostRegexp` string in both `createRouterConfig` and `createDomainLabels` (and no `{subdomain:` / no `$` in labels); non-wildcard → `Host()` unchanged; JS-side matching proof that the regex matches exactly one label and is anchored.

## Verification

- `pnpm --filter @dokploy/server typecheck` — clean.
- `pnpm --filter dokploy typecheck` — only the two known pre-existing zod-resolver errors (handle-network.tsx, handle-tag.tsx).
- Touched + neighboring suites: `__test__/utils/hostname-validation.test.ts`, `__test__/traefik/**`, `__test__/cloudflare/cloudflare-redirect-suppression.test.ts` — 6 files, 87 tests, all passing.
- Biome check clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)