### PR TITLE
feat(projects): default project icon from domain favicon

### DIFF
--- a/apps/dokploy/components/dashboard/projects/project-icon.tsx
+++ b/apps/dokploy/components/dashboard/projects/project-icon.tsx
@@ -1,0 +1,78 @@
+import { type ReactNode, useEffect, useState } from "react";
+
+export interface DomainLike {
+	host: string;
+	https: boolean;
+}
+
+/**
+ * Build an ordered, de-duplicated list of favicon candidate URLs from a
+ * project's domains. https domains come first, then http; each yields a
+ * `<scheme>://<host>/favicon.ico` URL. On an https dashboard, http candidates
+ * simply fail to load (mixed content) and the caller cascades to the next one.
+ */
+export const getProjectFaviconUrls = (domains: DomainLike[]): string[] => {
+	const seen = new Set<string>();
+	const urls: string[] = [];
+	const add = (list: DomainLike[]) => {
+		for (const domain of list) {
+			if (!domain?.host) continue;
+			const url = `${domain.https ? "https" : "http"}://${domain.host}/favicon.ico`;
+			if (seen.has(url)) continue;
+			seen.add(url);
+			urls.push(url);
+		}
+	};
+	add(domains.filter((domain) => domain?.https));
+	add(domains.filter((domain) => !domain?.https));
+	return urls;
+};
+
+interface ProjectIconProps {
+	logo?: string | null;
+	faviconUrls?: string[];
+	className?: string;
+	fallback: ReactNode;
+}
+
+/**
+ * Renders a project's icon. If an explicit logo is set it wins. Otherwise it
+ * tries the project's domain favicons in order, advancing to the next
+ * candidate whenever one fails to load, and falls back to `fallback` once all
+ * candidates are exhausted (or there are none). No backend fetching or caching
+ * layer — the browser cache is the cache.
+ */
+export const ProjectIcon = ({
+	logo,
+	faviconUrls = [],
+	className,
+	fallback,
+}: ProjectIconProps) => {
+	const [index, setIndex] = useState(0);
+	const faviconKey = faviconUrls.join("|");
+
+	useEffect(() => {
+		setIndex(0);
+	}, [faviconKey]);
+
+	if (logo) {
+		// biome-ignore lint/performance/noImgElement: user uploaded project icon
+		return <img src={logo} alt="" className={className} />;
+	}
+
+	const current = faviconUrls[index];
+	if (!current) {
+		return <>{fallback}</>;
+	}
+
+	return (
+		// biome-ignore lint/performance/noImgElement: domain favicon
+		<img
+			key={current}
+			src={current}
+			alt=""
+			className={className}
+			onError={() => setIndex((prev) => prev + 1)}
+		/>
+	);
+};

--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -56,6 +56,7 @@ import { useDebounce } from "@/utils/hooks/use-debounce";
 import { ExportProject } from "./export-project";
 import { HandleProject } from "./handle-project";
 import { ProjectEnvironment } from "./project-environment";
+import { getProjectFaviconUrls, ProjectIcon } from "./project-icon";
 
 export const ShowProjects = () => {
 	const utils = api.useUtils();
@@ -350,16 +351,26 @@ export const ShowProjects = () => {
 																<CardTitle className="flex items-center justify-between gap-2 overflow-clip">
 																	<span className="flex flex-col gap-1.5 ">
 																		<div className="flex items-center gap-2">
-																			{project.logo ? (
-																				// biome-ignore lint/performance/noImgElement: user uploaded project icon
-																				<img
-																					src={project.logo}
-																					alt=""
-																					className="size-4 rounded-sm object-contain"
-																				/>
-																			) : (
-																				<BookIcon className="size-4 text-muted-foreground" />
-																			)}
+																			<ProjectIcon
+																				logo={project.logo}
+																				faviconUrls={getProjectFaviconUrls(
+																					project.environments.flatMap(
+																						(env) => [
+																							...env.applications.flatMap(
+																								(app) => app.domains ?? [],
+																							),
+																							...env.compose.flatMap(
+																								(service) =>
+																									service.domains ?? [],
+																							),
+																						],
+																					),
+																				)}
+																				className="size-4 rounded-sm object-contain"
+																				fallback={
+																					<BookIcon className="size-4 text-muted-foreground" />
+																				}
+																			/>
 																			<span className="text-base font-medium leading-none">
 																				{project.name}
 																			</span>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -39,6 +39,10 @@ import { DuplicateProject } from "@/components/dashboard/project/duplicate-proje
 import { EnvironmentVariables } from "@/components/dashboard/project/environment-variables";
 import { ProjectEnvironment } from "@/components/dashboard/projects/project-environment";
 import {
+	getProjectFaviconUrls,
+	ProjectIcon,
+} from "@/components/dashboard/projects/project-icon";
+import {
 	LibsqlIcon,
 	MariadbIcon,
 	MongodbIcon,
@@ -1038,16 +1042,21 @@ const EnvironmentPage = (
 						<div className="flex justify-between gap-4 w-full items-center flex-wrap p-6">
 							<CardHeader className="p-0">
 								<CardTitle className="text-xl flex flex-row gap-2 items-center">
-									{currentEnvironment.project.logo ? (
-										// biome-ignore lint/performance/noImgElement: user uploaded project icon
-										<img
-											src={currentEnvironment.project.logo}
-											alt=""
-											className="size-6 rounded-sm object-contain self-center"
-										/>
-									) : (
-										<FolderInput className="size-6 text-muted-foreground self-center" />
-									)}
+									<ProjectIcon
+										logo={currentEnvironment.project.logo}
+										faviconUrls={getProjectFaviconUrls([
+											...currentEnvironment.applications.flatMap(
+												(app) => app.domains ?? [],
+											),
+											...currentEnvironment.compose.flatMap(
+												(service) => service.domains ?? [],
+											),
+										])}
+										className="size-6 rounded-sm object-contain self-center"
+										fallback={
+											<FolderInput className="size-6 text-muted-foreground self-center" />
+										}
+									/>
 									<p className="text-base font-medium max-w-[250px] truncate">
 										{currentEnvironment.project.name}
 									</p>

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -363,6 +363,14 @@ export const projectRouter = createTRPCRouter({
 									name: true,
 									applicationStatus: true,
 								},
+								with: {
+									domains: {
+										columns: {
+											host: true,
+											https: true,
+										},
+									},
+								},
 							},
 							libsql: {
 								where: buildServiceFilter(libsql.libsqlId, accessedServices),
@@ -422,6 +430,14 @@ export const projectRouter = createTRPCRouter({
 									name: true,
 									composeStatus: true,
 								},
+								with: {
+									domains: {
+										columns: {
+											host: true,
+											https: true,
+										},
+									},
+								},
 							},
 						},
 						columns: {
@@ -449,6 +465,14 @@ export const projectRouter = createTRPCRouter({
 								applicationId: true,
 								name: true,
 								applicationStatus: true,
+							},
+							with: {
+								domains: {
+									columns: {
+										host: true,
+										https: true,
+									},
+								},
 							},
 						},
 						mariadb: {
@@ -481,6 +505,14 @@ export const projectRouter = createTRPCRouter({
 								composeId: true,
 								name: true,
 								composeStatus: true,
+							},
+							with: {
+								domains: {
+									columns: {
+										host: true,
+										https: true,
+									},
+								},
 							},
 						},
 						libsql: {

--- a/packages/server/src/services/environment.ts
+++ b/packages/server/src/services/environment.ts
@@ -51,6 +51,12 @@ export const findEnvironmentById = async (environmentId: string) => {
 							serverId: true,
 						},
 					},
+					domains: {
+						columns: {
+							host: true,
+							https: true,
+						},
+					},
 				},
 				columns: {
 					name: true,
@@ -158,6 +164,12 @@ export const findEnvironmentById = async (environmentId: string) => {
 						columns: {
 							name: true,
 							serverId: true,
+						},
+					},
+					domains: {
+						columns: {
+							host: true,
+							https: true,
 						},
 					},
 				},


### PR DESCRIPTION
## What

When a project has **no uploaded logo**, the UI now falls back to the **favicon of the project's first working domain** instead of the generic `BookIcon`.

## How

- New client component `apps/dokploy/components/dashboard/projects/project-icon.tsx`:
  - If `logo` is set → render it (unchanged behavior).
  - Otherwise, try the project's domain favicons in order via the `<img>` `onError` event, advancing to the next candidate on failure.
  - Fallback chain ends at the caller-supplied icon (`BookIcon` on project cards, `FolderInput` on the detail header) once all candidates fail or there are none.
- `getProjectFaviconUrls()` builds an ordered, de-duplicated candidate list: **`https` domains first, then `http`**, each as `<scheme>://<host>/favicon.ico`.
- Wired into both the project card (`show.tsx`) and the environment detail header (`[environmentId].tsx`), preserving existing sizing (`size-4` / `size-6`).

## Data

- `project.all` (both owner and member-scoped branches) and `findEnvironmentById` now include each application/compose service's domain `host` + `https` (only those two fields) so the candidate list is built entirely client-side.

## Notes

- No backend fetching and no caching layer — the browser cache is the cache.
- Mixed content is acceptable: `http` favicons simply fail to load on an `https` dashboard and cascade to the next candidate / final fallback.
- No schema changes, no migrations, no new dependencies.