### PR TITLE
fix(schedules): fail cleanly when target container is not running

### DIFF
--- a/apps/dokploy/__test__/schedules/schedule-empty-container.test.ts
+++ b/apps/dokploy/__test__/schedules/schedule-empty-container.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression tests for the "invalid container name or ID: value is empty" storm
+ * (Sentry DOKPLOY-COMMUNITY-1 / DOKPLOY-COMMUNITY-2).
+ *
+ * When an application/compose schedule fires while its target container is not
+ * running, the container lookup returns null and containerId defaulted to "".
+ * The old code then ran `docker exec "" ...` on every cron tick, and because
+ * node-schedule's async callback had no catch, the rethrow became an
+ * unhandledRejection.
+ */
+
+const mocks = vi.hoisted(() => ({
+	findScheduleById: vi.fn(),
+	findScheduleOrganizationId: vi.fn(),
+	createDeploymentSchedule: vi.fn(),
+	updateDeployment: vi.fn(),
+	updateDeploymentStatus: vi.fn(),
+	getDokployUrl: vi.fn(),
+	getServiceContainer: vi.fn(),
+	getComposeContainer: vi.fn(),
+	spawnAsync: vi.fn(),
+	execAsyncRemote: vi.fn(),
+	sendScheduleFailureNotifications: vi.fn(),
+	appendFile: vi.fn(),
+	scheduleJobNode: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/constants", () => ({
+	IS_CLOUD: false,
+	paths: () => ({ SCHEDULES_PATH: "/tmp/schedules" }),
+}));
+
+vi.mock("@dokploy/server/services/schedule", () => ({
+	findScheduleById: mocks.findScheduleById,
+	findScheduleOrganizationId: mocks.findScheduleOrganizationId,
+}));
+
+vi.mock("@dokploy/server/services/deployment", () => ({
+	createDeploymentSchedule: mocks.createDeploymentSchedule,
+	updateDeployment: mocks.updateDeployment,
+	updateDeploymentStatus: mocks.updateDeploymentStatus,
+}));
+
+vi.mock("@dokploy/server/services/admin", () => ({
+	getDokployUrl: mocks.getDokployUrl,
+}));
+
+vi.mock("@dokploy/server/utils/docker/utils", () => ({
+	getServiceContainer: mocks.getServiceContainer,
+	getComposeContainer: mocks.getComposeContainer,
+}));
+
+vi.mock("@dokploy/server/utils/process/spawnAsync", () => ({
+	spawnAsync: mocks.spawnAsync,
+}));
+
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsyncRemote: mocks.execAsyncRemote,
+}));
+
+vi.mock("@dokploy/server/utils/notifications/schedule-failure", () => ({
+	sendScheduleFailureNotifications: mocks.sendScheduleFailureNotifications,
+}));
+
+vi.mock("node:fs/promises", () => ({
+	appendFile: mocks.appendFile,
+}));
+
+vi.mock("node-schedule", () => ({
+	scheduleJob: mocks.scheduleJobNode,
+	scheduledJobs: {},
+}));
+
+import { runCommand, scheduleJob } from "@dokploy/server/utils/schedules/utils";
+
+const applicationSchedule = () => ({
+	scheduleId: "sch-app-1",
+	name: "Nightly cleanup",
+	scheduleType: "application" as const,
+	command: "echo hi",
+	shellType: "sh",
+	appName: "my-app",
+	serviceName: null,
+	serverId: null,
+	compose: null,
+	application: {
+		appName: "my-app",
+		serverId: null,
+		environment: { project: { name: "My Project" } },
+	},
+});
+
+const composeSchedule = () => ({
+	scheduleId: "sch-compose-1",
+	name: "Compose task",
+	scheduleType: "compose" as const,
+	command: "echo hi",
+	shellType: "sh",
+	appName: "my-compose",
+	serviceName: "web",
+	serverId: null,
+	application: null,
+	compose: {
+		appName: "my-compose",
+		serverId: null,
+		composeType: "docker-compose",
+		environment: { project: { name: "My Project" } },
+	},
+});
+
+describe("runCommand — target container not running (DOKPLOY-COMMUNITY-1/2)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.createDeploymentSchedule.mockResolvedValue({
+			deploymentId: "dep-1",
+			logPath: "/tmp/dep-1.log",
+		});
+		mocks.updateDeploymentStatus.mockResolvedValue(undefined);
+		mocks.findScheduleOrganizationId.mockResolvedValue("org-1");
+		mocks.getDokployUrl.mockResolvedValue("https://dokploy.test");
+		mocks.sendScheduleFailureNotifications.mockResolvedValue(undefined);
+		mocks.appendFile.mockResolvedValue(undefined);
+	});
+
+	it("rejects with an actionable error and never runs docker exec for an application", async () => {
+		mocks.findScheduleById.mockResolvedValue(applicationSchedule());
+		mocks.getServiceContainer.mockResolvedValue(null);
+
+		await expect(runCommand("sch-app-1")).rejects.toThrow(
+			"Container not found for my-app — the service may not be running",
+		);
+
+		// The whole point: no docker exec with an empty container id.
+		expect(mocks.spawnAsync).not.toHaveBeenCalled();
+		expect(mocks.execAsyncRemote).not.toHaveBeenCalled();
+
+		// It is recorded as a proper schedule failure, not a success.
+		expect(mocks.updateDeploymentStatus).toHaveBeenCalledWith("dep-1", "error");
+		expect(mocks.updateDeploymentStatus).not.toHaveBeenCalledWith(
+			"dep-1",
+			"done",
+		);
+		expect(mocks.sendScheduleFailureNotifications).toHaveBeenCalledTimes(1);
+
+		// The failure is written to the deployment log.
+		expect(mocks.appendFile).toHaveBeenCalledWith(
+			"/tmp/dep-1.log",
+			expect.stringContaining("Container not found for my-app"),
+		);
+	});
+
+	it("includes the service name in the error for a compose schedule", async () => {
+		mocks.findScheduleById.mockResolvedValue(composeSchedule());
+		mocks.getComposeContainer.mockResolvedValue(null);
+
+		await expect(runCommand("sch-compose-1")).rejects.toThrow(
+			'Container not found for my-compose (service "web") — the service may not be running',
+		);
+
+		expect(mocks.spawnAsync).not.toHaveBeenCalled();
+		expect(mocks.execAsyncRemote).not.toHaveBeenCalled();
+		expect(mocks.updateDeploymentStatus).toHaveBeenCalledWith("dep-1", "error");
+	});
+});
+
+describe("scheduleJob — cron callback must not leak rejections", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.createDeploymentSchedule.mockResolvedValue({
+			deploymentId: "dep-1",
+			logPath: "/tmp/dep-1.log",
+		});
+		mocks.updateDeploymentStatus.mockResolvedValue(undefined);
+		mocks.findScheduleOrganizationId.mockResolvedValue("org-1");
+		mocks.getDokployUrl.mockResolvedValue("https://dokploy.test");
+		mocks.sendScheduleFailureNotifications.mockResolvedValue(undefined);
+		mocks.appendFile.mockResolvedValue(undefined);
+	});
+
+	it("swallows a failing runCommand instead of producing an unhandled rejection", async () => {
+		// runCommand will reject because the container lookup returns null.
+		mocks.findScheduleById.mockResolvedValue(applicationSchedule());
+		mocks.getServiceContainer.mockResolvedValue(null);
+
+		const consoleErrorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+
+		scheduleJob({
+			scheduleId: "sch-app-1",
+			cronExpression: "* * * * *",
+			timezone: "UTC",
+		} as never);
+
+		expect(mocks.scheduleJobNode).toHaveBeenCalledTimes(1);
+		const registeredCallback = mocks.scheduleJobNode.mock
+			.calls[0]?.[2] as () => Promise<void>;
+
+		// The callback must resolve (not reject) even though runCommand rejects.
+		await expect(registeredCallback()).resolves.toBeUndefined();
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			"Scheduled job sch-app-1 failed:",
+			expect.any(Error),
+		);
+		consoleErrorSpy.mockRestore();
+	});
+});

--- a/packages/server/src/utils/schedules/utils.ts
+++ b/packages/server/src/utils/schedules/utils.ts
@@ -1,4 +1,5 @@
 import { createWriteStream } from "node:fs";
+import { appendFile } from "node:fs/promises";
 import path from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Schedule } from "@dokploy/server/db/schema/schedule";
@@ -73,7 +74,15 @@ export const scheduleJob = (schedule: Schedule) => {
 			rule: cronExpression,
 		},
 		async () => {
-			await runCommand(scheduleId);
+			try {
+				await runCommand(scheduleId);
+			} catch (error) {
+				// runCommand already logs to the deployment log and fires the
+				// failure notification via handleScheduleError before throwing.
+				// Swallow here so a failing scheduled run does not become an
+				// unhandledRejection from node-schedule's async callback.
+				console.error(`Scheduled job ${scheduleId} failed:`, error);
+			}
 		},
 	);
 };
@@ -117,6 +126,29 @@ export const runCommand = async (scheduleId: string) => {
 			const container = await getComposeContainer(compose, serviceName || "");
 			containerId = container?.Id || "";
 			serverId = compose.serverId || "";
+		}
+
+		if (!containerId) {
+			// The target container could not be resolved (service not running).
+			// Running `docker exec ""` here would fail on every cron tick with a
+			// cryptic "invalid container name or ID: value is empty" error, so
+			// fail the run cleanly with an actionable message instead.
+			const targetName =
+				scheduleType === "compose"
+					? `${compose?.appName || "compose"}${
+							serviceName ? ` (service "${serviceName}")` : ""
+						}`
+					: application?.appName || "application";
+			const error = new Error(
+				`Container not found for ${targetName} — the service may not be running`,
+			);
+			try {
+				await appendFile(deployment.logPath, `❌ ${error.message}\n`);
+			} catch (writeError) {
+				console.log("Failed to write schedule error to log:", writeError);
+			}
+			await handleScheduleError(schedule, deployment.deploymentId, error);
+			throw error;
 		}
 
 		if (serverId) {


### PR DESCRIPTION
## Problem

Sentry issues **DOKPLOY-COMMUNITY-1** and **DOKPLOY-COMMUNITY-2** report `Error: invalid container name or ID: value is empty` from `spawnAsync` at ~2 events/min.

### Root cause

In `runCommand` (`packages/server/src/utils/schedules/utils.ts`), for `scheduleType` `application`/`compose`, when the target container is not running `getServiceContainer`/`getComposeContainer` returns `null` and `containerId` defaults to `""`. The code then runs `docker exec "" <shell> -c <command>` (both the remote `execAsyncRemote` path and the local `spawnAsync` path), which docker rejects with the empty-id error.

The catch blocks call `handleScheduleError` and then rethrow. `scheduleJob` invokes `runCommand` inside node-schedule's async callback with **no catch**, so every scheduled failure became an **unhandledRejection** (now reported to Sentry), firing on every cron tick.

## Fixes

1. **Validate `containerId` before any docker exec.** After container resolution, if `containerId` is empty, `runCommand` fails with an actionable error — `Container not found for <appName / composeName (service "X")> — the service may not be running` — writes it to the deployment log, marks the deployment errored via `handleScheduleError`, and rethrows. No docker command runs. The throw is preserved so the schedule router's `runManually` still surfaces failures to the caller.

2. **Contain the cron callback.** `scheduleJob`'s node-schedule callback now wraps `runCommand` in `try/catch` and logs. Every failure path in `runCommand` already logs to the deployment log and fires the failure notification before throwing, so nothing is lost — this only stops the unhandledRejection storm. (The `apps/schedules` queue worker path already wrapped `runCommand` in try/catch, so the leak was specific to this callback.)

## Tests

New hermetic vitest suite `apps/dokploy/__test__/schedules/schedule-empty-container.test.ts` (no docker, no postgres):
- application schedule with null container lookup → rejects with the descriptive error, marks deployment `error` (never `done`), sends failure notification, and never calls `spawnAsync`/`execAsyncRemote`;
- compose schedule → error message includes the service name;
- `scheduleJob`'s cron callback resolves (does not reject) when `runCommand` rejects, and logs the failure.

All 3 pass locally. Typecheck of `packages/server` and `apps/dokploy` both exit 0; `pnpm-lock.yaml` unchanged.

Fixes DOKPLOY-COMMUNITY-1
Fixes DOKPLOY-COMMUNITY-2