### PR TITLE
feat(projects): real favicon resolution + icons in project switcher

### DIFF
--- a/apps/dokploy/__test__/favicon/favicon-resolver.test.ts
+++ b/apps/dokploy/__test__/favicon/favicon-resolver.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+	findIconUrl,
+	parseIconHref,
+	resolveIconUrl,
+} from "@/lib/favicon-resolver";
+
+describe("parseIconHref", () => {
+	it('finds an absolute href on rel="icon"', () => {
+		const html =
+			'<html><head><link rel="icon" href="https://example.com/icon.png"></head></html>';
+		expect(parseIconHref(html)).toBe("https://example.com/icon.png");
+	});
+
+	it("finds a relative href", () => {
+		const html = '<html><head><link rel="icon" href="/icon.png"></head></html>';
+		expect(parseIconHref(html)).toBe("/icon.png");
+	});
+
+	it('recognizes rel="shortcut icon"', () => {
+		const html =
+			'<html><head><link rel="shortcut icon" href="/favicon.ico"></head></html>';
+		expect(parseIconHref(html)).toBe("/favicon.ico");
+	});
+
+	it('prefers rel="icon" over rel="apple-touch-icon" when both present', () => {
+		const html = `<html><head>
+			<link rel="apple-touch-icon" href="/apple-icon.png">
+			<link rel="icon" href="/icon.png">
+		</head></html>`;
+		expect(parseIconHref(html)).toBe("/icon.png");
+	});
+
+	it('prefers rel="icon" over rel="apple-touch-icon" regardless of document order', () => {
+		const html = `<html><head>
+			<link rel="icon" href="/icon.png">
+			<link rel="apple-touch-icon" href="/apple-icon.png">
+		</head></html>`;
+		expect(parseIconHref(html)).toBe("/icon.png");
+	});
+
+	it('prefers rel="shortcut icon" over rel="apple-touch-icon"', () => {
+		const html = `<html><head>
+			<link rel="apple-touch-icon" href="/apple-icon.png">
+			<link rel="shortcut icon" href="/favicon.ico">
+		</head></html>`;
+		expect(parseIconHref(html)).toBe("/favicon.ico");
+	});
+
+	it('falls back to rel="apple-touch-icon" when nothing better is present', () => {
+		const html =
+			'<html><head><link rel="apple-touch-icon" href="/apple-icon.png"></head></html>';
+		expect(parseIconHref(html)).toBe("/apple-icon.png");
+	});
+
+	it("picks the first matching link when multiple icons share the same priority", () => {
+		const html = `<html><head>
+			<link rel="icon" href="/first.png">
+			<link rel="icon" href="/second.png">
+		</head></html>`;
+		expect(parseIconHref(html)).toBe("/first.png");
+	});
+
+	it("returns null when there is no icon link", () => {
+		const html = "<html><head><title>No icons here</title></head></html>";
+		expect(parseIconHref(html)).toBeNull();
+	});
+
+	it("matches rel case-insensitively", () => {
+		const html = '<html><head><link REL="ICON" href="/icon.png"></head></html>';
+		expect(parseIconHref(html)).toBe("/icon.png");
+	});
+});
+
+describe("resolveIconUrl", () => {
+	it("resolves a relative href against the base URL", () => {
+		expect(resolveIconUrl("/icon.png", "https://example.com/page")).toBe(
+			"https://example.com/icon.png",
+		);
+	});
+
+	it("passes through an absolute https URL", () => {
+		expect(
+			resolveIconUrl("https://cdn.example.com/icon.png", "https://example.com"),
+		).toBe("https://cdn.example.com/icon.png");
+	});
+
+	it("passes through an absolute http URL", () => {
+		expect(
+			resolveIconUrl("http://example.com/icon.png", "https://example.com"),
+		).toBe("http://example.com/icon.png");
+	});
+
+	it("returns null for a data: href", () => {
+		expect(
+			resolveIconUrl("data:image/png;base64,AAAA", "https://example.com"),
+		).toBeNull();
+	});
+
+	it("returns null for a javascript: href", () => {
+		expect(
+			resolveIconUrl("javascript:alert(1)", "https://example.com"),
+		).toBeNull();
+	});
+});
+
+describe("findIconUrl", () => {
+	it("resolves the parsed relative icon href against the page URL", () => {
+		const html = '<html><head><link rel="icon" href="/icon.png"></head></html>';
+		expect(findIconUrl(html, "https://example.com/some/page")).toBe(
+			"https://example.com/icon.png",
+		);
+	});
+
+	it("returns null when the page has no icon link", () => {
+		const html = "<html><head></head></html>";
+		expect(findIconUrl(html, "https://example.com")).toBeNull();
+	});
+
+	it("returns null when the only icon href is a data: URI", () => {
+		const html =
+			'<html><head><link rel="icon" href="data:image/png;base64,AAAA"></head></html>';
+		expect(findIconUrl(html, "https://example.com")).toBeNull();
+	});
+});

--- a/apps/dokploy/components/dashboard/projects/project-icon.tsx
+++ b/apps/dokploy/components/dashboard/projects/project-icon.tsx
@@ -7,9 +7,10 @@ export interface DomainLike {
 
 /**
  * Build an ordered, de-duplicated list of favicon candidate URLs from a
- * project's domains. https domains come first, then http; each yields a
- * `<scheme>://<host>/favicon.ico` URL. On an https dashboard, http candidates
- * simply fail to load (mixed content) and the caller cascades to the next one.
+ * project's domains. https domains come first, then http; each is routed
+ * through the `/api/favicon` resolver (which parses the page's `<head>` for
+ * a declared icon, falling back to `/favicon.ico`) rather than requesting
+ * `/favicon.ico` directly, since many apps declare icons at custom paths.
  */
 export const getProjectFaviconUrls = (domains: DomainLike[]): string[] => {
 	const seen = new Set<string>();
@@ -17,7 +18,7 @@ export const getProjectFaviconUrls = (domains: DomainLike[]): string[] => {
 	const add = (list: DomainLike[]) => {
 		for (const domain of list) {
 			if (!domain?.host) continue;
-			const url = `${domain.https ? "https" : "http"}://${domain.host}/favicon.ico`;
+			const url = `/api/favicon?host=${encodeURIComponent(domain.host)}&https=${domain.https ? "1" : "0"}`;
 			if (seen.has(url)) continue;
 			seen.add(url);
 			urls.push(url);

--- a/apps/dokploy/components/shared/advance-breadcrumb.tsx
+++ b/apps/dokploy/components/shared/advance-breadcrumb.tsx
@@ -11,6 +11,10 @@ import {
 import { useRouter } from "next/router";
 import { type ComponentType, useEffect, useMemo, useState } from "react";
 import {
+	getProjectFaviconUrls,
+	ProjectIcon,
+} from "@/components/dashboard/projects/project-icon";
+import {
 	LibsqlIcon,
 	MariadbIcon,
 	MongodbIcon,
@@ -150,7 +154,10 @@ const parseSortBy = (sortBy: string): { field: string; direction: string } => {
 	return { field: sortBy.slice(0, idx), direction: sortBy.slice(idx + 1) };
 };
 
-const sortServices = (services: ServiceItem[], sortBy: string): ServiceItem[] => {
+const sortServices = (
+	services: ServiceItem[],
+	sortBy: string,
+): ServiceItem[] => {
 	const { field, direction } = parseSortBy(sortBy);
 
 	if (field === "createdAt" || field === "lastDeploy") {
@@ -452,9 +459,25 @@ export const AdvanceBreadcrumb = () => {
 															className="flex items-center justify-between py-3 px-2 cursor-pointer"
 														>
 															<div className="flex items-center gap-3">
-																<div className="flex items-center justify-center size-8 rounded-md bg-muted text-xs font-semibold uppercase">
-																	{project.name.slice(0, 2)}
-																</div>
+																<ProjectIcon
+																	logo={project.logo}
+																	faviconUrls={getProjectFaviconUrls(
+																		project.environments.flatMap((env) => [
+																			...env.applications.flatMap(
+																				(app) => app.domains ?? [],
+																			),
+																			...env.compose.flatMap(
+																				(service) => service.domains ?? [],
+																			),
+																		]),
+																	)}
+																	className="size-8 rounded-md object-contain"
+																	fallback={
+																		<div className="flex items-center justify-center size-8 rounded-md bg-muted text-xs font-semibold uppercase">
+																			{project.name.slice(0, 2)}
+																		</div>
+																	}
+																/>
 																<div className="flex flex-col">
 																	<span className="font-medium">
 																		{project.name}

--- a/apps/dokploy/lib/favicon-resolver.ts
+++ b/apps/dokploy/lib/favicon-resolver.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure helpers for the favicon resolver API route. Kept dependency-free and
+ * side-effect-free so the parsing/validation decisions can be unit-tested
+ * without spinning up the HTTP handler, a database, or a network fetch.
+ */
+
+const HEAD_RE = /<head\b[^>]*>([\s\S]*?)<\/head>/i;
+const LINK_RE = /<link\b[^>]*>/gi;
+const REL_RE = /\brel\s*=\s*["']([^"']*)["']/i;
+const HREF_RE = /\bhref\s*=\s*["']([^"']*)["']/i;
+
+/**
+ * Rank a `<link>` element's `rel` for icon preference. Lower wins. Returns
+ * `null` for rels that are not an icon declaration we care about.
+ *   0 = rel="icon"
+ *   1 = rel="shortcut icon"
+ *   2 = rel="apple-touch-icon" (or -precomposed)
+ */
+const relPriority = (rel: string): number | null => {
+	const normalized = rel.toLowerCase().trim();
+	const tokens = new Set(normalized.split(/\s+/).filter(Boolean));
+	if (
+		tokens.has("apple-touch-icon") ||
+		tokens.has("apple-touch-icon-precomposed")
+	) {
+		return 2;
+	}
+	if (tokens.has("icon")) {
+		return tokens.has("shortcut") ? 1 : 0;
+	}
+	return null;
+};
+
+/**
+ * Parse an HTML document's `<head>` for the best icon `<link>` href, following
+ * the preference order icon > shortcut icon > apple-touch-icon. Ties are broken
+ * by document order. Returns the raw (possibly relative) href, or `null` when
+ * no icon link is present.
+ */
+export const parseIconHref = (html: string): string | null => {
+	const headMatch = HEAD_RE.exec(html);
+	const scope = headMatch?.[1] ?? html;
+
+	let best: { priority: number; href: string } | null = null;
+	for (const linkMatch of scope.matchAll(LINK_RE)) {
+		const tag = linkMatch[0];
+		const relMatch = REL_RE.exec(tag);
+		if (!relMatch) continue;
+		const priority = relPriority(relMatch[1] ?? "");
+		if (priority === null) continue;
+		const hrefMatch = HREF_RE.exec(tag);
+		const href = hrefMatch?.[1]?.trim();
+		if (!href) continue;
+		if (!best || priority < best.priority) {
+			best = { priority, href };
+			if (priority === 0) break;
+		}
+	}
+
+	return best?.href ?? null;
+};
+
+/**
+ * Resolve an icon href (absolute or relative) against the page URL it was found
+ * on. Returns `null` when the result is not an http(s) URL (e.g. a `data:` or
+ * otherwise unparseable href), so callers never fetch a non-web target.
+ */
+export const resolveIconUrl = (href: string, base: string): string | null => {
+	try {
+		const resolved = new URL(href, base);
+		if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+			return null;
+		}
+		return resolved.toString();
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Given a fetched page's HTML and the URL it was served from, return the icon
+ * URL to fetch: the parsed `<link>` icon resolved to an absolute URL, or `null`
+ * when there is no usable link (the caller then falls back to /favicon.ico).
+ */
+export const findIconUrl = (html: string, pageUrl: string): string | null => {
+	const href = parseIconHref(html);
+	if (!href) return null;
+	return resolveIconUrl(href, pageUrl);
+};

--- a/apps/dokploy/pages/api/favicon.ts
+++ b/apps/dokploy/pages/api/favicon.ts
@@ -1,0 +1,138 @@
+import { db } from "@dokploy/server/db";
+import { validateRequest } from "@dokploy/server/lib/auth";
+import { eq } from "drizzle-orm";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { findIconUrl } from "@/lib/favicon-resolver";
+import { domains } from "@/server/db/schema";
+
+const REQUEST_TIMEOUT_MS = 5000;
+const MAX_ICON_BYTES = 1024 * 1024; // 1 MB
+const SUCCESS_CACHE = "public, max-age=86400, stale-while-revalidate=604800";
+const FAILURE_CACHE = "public, max-age=3600";
+
+const parseHttps = (value: unknown): boolean => {
+	const raw = Array.isArray(value) ? value[0] : value;
+	return raw === "1" || raw === "true";
+};
+
+const getStringParam = (value: unknown): string | null =>
+	typeof value === "string" && value.length > 0 ? value : null;
+
+/**
+ * Fetch a URL with a hard timeout and a byte cap enforced while streaming the
+ * body, so a hostile or oversized response cannot exhaust memory. Returns the
+ * buffered body plus its content-type, or `null` on any failure (non-ok
+ * status, timeout, network error, or exceeding the cap).
+ */
+const fetchCapped = async (
+	url: string,
+	accept: string,
+): Promise<{ body: Buffer; contentType: string } | null> => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+	try {
+		const response = await fetch(url, {
+			signal: controller.signal,
+			headers: { accept },
+			redirect: "follow",
+		});
+		if (!response.ok || !response.body) {
+			return null;
+		}
+		const reader = response.body.getReader();
+		const chunks: Uint8Array[] = [];
+		let received = 0;
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (value) {
+				received += value.length;
+				if (received > MAX_ICON_BYTES) {
+					await reader.cancel();
+					return null;
+				}
+				chunks.push(value);
+			}
+		}
+		return {
+			body: Buffer.concat(chunks),
+			contentType: response.headers.get("content-type") ?? "",
+		};
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeout);
+	}
+};
+
+const notFound = (res: NextApiResponse) => {
+	res.setHeader("Cache-Control", FAILURE_CACHE);
+	res.status(404).end();
+};
+
+/**
+ * Resolve and stream a project domain's real favicon.
+ *
+ * The handler is auth-gated (better-auth session or API key) and SSRF-guarded:
+ * the requested `host` must exist in the `domain` table, so only hosts the
+ * instance already manages are ever fetched. It reads the page's `<head>` for a
+ * declared icon `<link>`, falls back to `/favicon.ico`, verifies the response
+ * is an image, and streams the bytes back with long-lived cache headers. Any
+ * failure is a short-cached 404 so failing hosts are not re-probed on every
+ * render.
+ */
+export default async function handler(
+	req: NextApiRequest,
+	res: NextApiResponse,
+) {
+	if (req.method !== "GET") {
+		res.setHeader("Allow", "GET");
+		res.status(405).end();
+		return;
+	}
+
+	const { session } = await validateRequest(req);
+	if (!session) {
+		res.status(401).end();
+		return;
+	}
+
+	const host = getStringParam(req.query.host);
+	if (!host) {
+		res.status(400).end();
+		return;
+	}
+	const https = parseHttps(req.query.https);
+
+	// SSRF guard: only ever fetch hosts this instance already manages.
+	const domain = await db.query.domains.findFirst({
+		where: eq(domains.host, host),
+		columns: { domainId: true },
+	});
+	if (!domain) {
+		notFound(res);
+		return;
+	}
+
+	const scheme = https ? "https" : "http";
+	const base = `${scheme}://${host}/`;
+
+	let iconUrl: string | null = null;
+	const page = await fetchCapped(base, "text/html");
+	if (page && /text\/html/i.test(page.contentType)) {
+		iconUrl = findIconUrl(page.body.toString("utf8"), base);
+	}
+	if (!iconUrl) {
+		iconUrl = `${scheme}://${host}/favicon.ico`;
+	}
+
+	const icon = await fetchCapped(iconUrl, "image/*");
+	if (!icon || !/^image\//i.test(icon.contentType)) {
+		notFound(res);
+		return;
+	}
+
+	res.setHeader("Content-Type", icon.contentType);
+	res.setHeader("Cache-Control", SUCCESS_CACHE);
+	res.status(200).send(icon.body);
+}


### PR DESCRIPTION
## Summary
- Many apps declare their icon via `<link rel="icon">` at a custom path instead of serving one at `/favicon.ico`, so the previous direct-probe approach missed them.
- Adds a new auth-gated, SSRF-guarded `GET /api/favicon` route (`apps/dokploy/pages/api/favicon.ts`) that fetches the target page, parses its `<head>` for a declared icon link (preference order: `icon` > `shortcut icon` > `apple-touch-icon`, `data:`/`javascript:` hrefs rejected), falls back to `/favicon.ico` when no link is found, verifies the response content-type is actually an image, and streams the bytes with `Cache-Control: public, max-age=86400, stale-while-revalidate=604800`. Failures are cached briefly as 404 to avoid hammering flaky targets.
- Pure parsing/resolution logic lives in `apps/dokploy/lib/favicon-resolver.ts` (`parseIconHref`, `resolveIconUrl`, `findIconUrl`), independent of the HTTP handler so it's unit-testable without DB/network mocking.
- `ProjectIcon`'s favicon candidates (`apps/dokploy/components/dashboard/projects/project-icon.tsx`) now route through `/api/favicon?host=...&https=...` instead of requesting `<scheme>://<host>/favicon.ico` directly.
- The breadcrumb project switcher (`apps/dokploy/components/shared/advance-breadcrumb.tsx`) now renders `ProjectIcon` (project logo, then resolved favicons) instead of a plain two-letter avatar, keeping the letters as the `fallback` when no icon resolves.

## Test plan
- [x] `apps/dokploy/__test__/favicon/favicon-resolver.test.ts` — 18 unit tests covering `parseIconHref` (absolute/relative hrefs, `icon`/`shortcut icon`/`apple-touch-icon` rel handling and priority ordering, multiple-icons tie-break, no-icon, case-insensitive rel), `resolveIconUrl` (relative resolution, http/https passthrough, `data:`/`javascript:` rejection), and `findIconUrl` (end-to-end relative resolution, no-icon, data-URI rejection). All passing.
- [x] `tsc --noEmit` clean in both `apps/dokploy` and `packages/server`.
- [x] `pnpm-lock.yaml` unchanged — no new dependencies.