### PR TITLE
fix(security): prevent SSRF pivots in the favicon resolver

### DIFF
--- a/apps/dokploy/pages/api/favicon.ts
+++ b/apps/dokploy/pages/api/favicon.ts
@@ -7,6 +7,7 @@ import { domains } from "@/server/db/schema";
 
 const REQUEST_TIMEOUT_MS = 5000;
 const MAX_ICON_BYTES = 1024 * 1024; // 1 MB
+const MAX_REDIRECTS = 3;
 const SUCCESS_CACHE = "public, max-age=86400, stale-while-revalidate=604800";
 const FAILURE_CACHE = "public, max-age=3600";
 
@@ -19,50 +20,90 @@ const getStringParam = (value: unknown): string | null =>
 	typeof value === "string" && value.length > 0 ? value : null;
 
 /**
+ * True when `url` is an http(s) URL whose hostname equals `host`
+ * (case-insensitive). The SSRF guard on this route validates only the
+ * originally-requested host against the domains table; every subsequent URL we
+ * fetch — a `<link rel="icon">` href parsed from attacker-influenceable page
+ * HTML, or a redirect `Location` — must be re-checked against that same host so
+ * it can never be pivoted to `169.254.169.254`, `localhost`, or any other
+ * internal target the guard never approved.
+ */
+const isSameHost = (url: string, host: string): boolean => {
+	try {
+		const parsed = new URL(url);
+		return (
+			(parsed.protocol === "http:" || parsed.protocol === "https:") &&
+			parsed.hostname.toLowerCase() === host.toLowerCase()
+		);
+	} catch {
+		return false;
+	}
+};
+
+/**
  * Fetch a URL with a hard timeout and a byte cap enforced while streaming the
- * body, so a hostile or oversized response cannot exhaust memory. Returns the
- * buffered body plus its content-type, or `null` on any failure (non-ok
- * status, timeout, network error, or exceeding the cap).
+ * body, so a hostile or oversized response cannot exhaust memory. Redirects are
+ * followed manually (`redirect: "manual"`) and every hop is re-validated to
+ * stay on `host`, closing the redirect-based SSRF pivot. Returns the buffered
+ * body plus its content-type, or `null` on any failure (off-host hop, non-ok
+ * status, timeout, network error, too many redirects, or exceeding the cap).
  */
 const fetchCapped = async (
 	url: string,
 	accept: string,
+	host: string,
 ): Promise<{ body: Buffer; contentType: string } | null> => {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-	try {
-		const response = await fetch(url, {
-			signal: controller.signal,
-			headers: { accept },
-			redirect: "follow",
-		});
-		if (!response.ok || !response.body) {
+	let currentUrl = url;
+	for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+		if (!isSameHost(currentUrl, host)) {
 			return null;
 		}
-		const reader = response.body.getReader();
-		const chunks: Uint8Array[] = [];
-		let received = 0;
-		while (true) {
-			const { done, value } = await reader.read();
-			if (done) break;
-			if (value) {
-				received += value.length;
-				if (received > MAX_ICON_BYTES) {
-					await reader.cancel();
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+		try {
+			const response = await fetch(currentUrl, {
+				signal: controller.signal,
+				headers: { accept },
+				redirect: "manual",
+			});
+			if (response.status >= 300 && response.status < 400) {
+				const location = response.headers.get("location");
+				if (!location) {
 					return null;
 				}
-				chunks.push(value);
+				// Re-validated against `host` at the top of the next iteration.
+				currentUrl = new URL(location, currentUrl).toString();
+				continue;
 			}
+			if (!response.ok || !response.body) {
+				return null;
+			}
+			const reader = response.body.getReader();
+			const chunks: Uint8Array[] = [];
+			let received = 0;
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				if (value) {
+					received += value.length;
+					if (received > MAX_ICON_BYTES) {
+						await reader.cancel();
+						return null;
+					}
+					chunks.push(value);
+				}
+			}
+			return {
+				body: Buffer.concat(chunks),
+				contentType: response.headers.get("content-type") ?? "",
+			};
+		} catch {
+			return null;
+		} finally {
+			clearTimeout(timeout);
 		}
-		return {
-			body: Buffer.concat(chunks),
-			contentType: response.headers.get("content-type") ?? "",
-		};
-	} catch {
-		return null;
-	} finally {
-		clearTimeout(timeout);
 	}
+	return null;
 };
 
 const notFound = (res: NextApiResponse) => {
@@ -118,15 +159,21 @@ export default async function handler(
 	const base = `${scheme}://${host}/`;
 
 	let iconUrl: string | null = null;
-	const page = await fetchCapped(base, "text/html");
+	const page = await fetchCapped(base, "text/html", host);
 	if (page && /text\/html/i.test(page.contentType)) {
-		iconUrl = findIconUrl(page.body.toString("utf8"), base);
+		const parsed = findIconUrl(page.body.toString("utf8"), base);
+		// The page HTML is attacker-influenceable, so only trust an icon href
+		// that resolves back to the same managed host; anything else falls
+		// through to the /favicon.ico default below.
+		if (parsed && isSameHost(parsed, host)) {
+			iconUrl = parsed;
+		}
 	}
 	if (!iconUrl) {
 		iconUrl = `${scheme}://${host}/favicon.ico`;
 	}
 
-	const icon = await fetchCapped(iconUrl, "image/*");
+	const icon = await fetchCapped(iconUrl, "image/*", host);
 	if (!icon || !/^image\//i.test(icon.contentType)) {
 		notFound(res);
 		return;


### PR DESCRIPTION
## Security fix

Follow-up hardening for the favicon resolver added in #145. An automated security review flagged two SSRF vectors in `apps/dokploy/pages/api/favicon.ts`.

### Problem
The route validates that the **requested** `host` exists in the `domains` table, but then:
1. **Parsed-href SSRF** — fetches whatever URL the page''s `<link rel="icon" href="…">` declares. Since Dokploy users deploy arbitrary apps on managed domains, a managed page can declare `href="http://169.254.169.254/latest/meta-data/…"` (cloud metadata) or `http://localhost:6379/…` and the server would fetch it.
2. **Redirect SSRF** — used `redirect: "follow"`, so even the page/`favicon.ico` fetch could `302` to an internal address off the validated host.

The initial domains-table guard doesn''t help once we follow a link or redirect **off** that host.

### Fix
Constrain **every hop** to the originally-validated host:
- New `isSameHost(url, host)` helper — http(s) only, hostname must equal the managed host (case-insensitive).
- The parsed icon href is re-checked with `isSameHost` before fetching; anything off-host falls through to the `/favicon.ico` default.
- `fetchCapped` now follows redirects **manually** (`redirect: "manual"`, capped at 3), re-validating each `Location` against `host`.

Fails closed — any off-host hop returns null and the UI falls back to the letter/BookIcon. This deliberately keeps working for legitimate private-IP/`traefik.me` managed domains (which the fork supports) because it enforces *same-host*, not IP-range blocking.

Typecheck: apps/dokploy exit 0. No new dependencies.