### PR TITLE
fix(security): reject SVG favicons and pin same-origin in favicon resolver

### DIFF
--- a/apps/dokploy/__test__/favicon/favicon-resolver.test.ts
+++ b/apps/dokploy/__test__/favicon/favicon-resolver.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	findIconUrl,
+	isSafeImageContentType,
+	isSameOrigin,
 	parseIconHref,
 	resolveIconUrl,
 } from "@/lib/favicon-resolver";
@@ -121,5 +123,72 @@ describe("findIconUrl", () => {
 		const html =
 			'<html><head><link rel="icon" href="data:image/png;base64,AAAA"></head></html>';
 		expect(findIconUrl(html, "https://example.com")).toBeNull();
+	});
+});
+
+describe("isSameOrigin", () => {
+	const base = "https://example.com"; // new URL("https://example.com/").origin
+
+	it("accepts a same-origin absolute URL", () => {
+		expect(isSameOrigin("https://example.com/favicon.ico", base)).toBe(true);
+	});
+
+	it("accepts same origin with a path and query", () => {
+		expect(isSameOrigin("https://example.com/a/b?x=1", base)).toBe(true);
+	});
+
+	it("rejects a different host", () => {
+		expect(isSameOrigin("https://evil.com/favicon.ico", base)).toBe(false);
+		expect(isSameOrigin("https://169.254.169.254/latest", base)).toBe(false);
+	});
+
+	it("rejects a different PORT on the same host (internal port pivot)", () => {
+		expect(isSameOrigin("https://example.com:2375/", base)).toBe(false);
+		expect(isSameOrigin("https://example.com:5432/", base)).toBe(false);
+	});
+
+	it("rejects a scheme flip on the same host", () => {
+		expect(isSameOrigin("http://example.com/favicon.ico", base)).toBe(false);
+	});
+
+	it("rejects a userinfo-smuggled foreign host", () => {
+		// WHATWG URL parses the host as evil.com, not example.com.
+		expect(isSameOrigin("https://example.com@evil.com/", base)).toBe(false);
+	});
+
+	it("rejects protocol-relative and non-http(s) targets", () => {
+		expect(isSameOrigin("//evil.com/x", base)).toBe(false);
+		expect(isSameOrigin("data:image/png;base64,AAAA", base)).toBe(false);
+		expect(isSameOrigin("javascript:alert(1)", base)).toBe(false);
+	});
+
+	it("returns false for an unparseable URL", () => {
+		expect(isSameOrigin("not a url", base)).toBe(false);
+	});
+});
+
+describe("isSafeImageContentType", () => {
+	it("accepts raster image types", () => {
+		expect(isSafeImageContentType("image/png")).toBe(true);
+		expect(isSafeImageContentType("image/jpeg")).toBe(true);
+		expect(isSafeImageContentType("image/webp")).toBe(true);
+		expect(isSafeImageContentType("image/x-icon")).toBe(true);
+		expect(isSafeImageContentType("image/vnd.microsoft.icon")).toBe(true);
+	});
+
+	it("accepts an image type with charset/params and mixed case", () => {
+		expect(isSafeImageContentType("IMAGE/PNG; charset=binary")).toBe(true);
+	});
+
+	it("rejects image/svg+xml (executable on direct navigation)", () => {
+		expect(isSafeImageContentType("image/svg+xml")).toBe(false);
+		expect(isSafeImageContentType("image/svg+xml; charset=utf-8")).toBe(false);
+		expect(isSafeImageContentType("IMAGE/SVG+XML")).toBe(false);
+	});
+
+	it("rejects non-image types", () => {
+		expect(isSafeImageContentType("text/html")).toBe(false);
+		expect(isSafeImageContentType("application/json")).toBe(false);
+		expect(isSafeImageContentType("")).toBe(false);
 	});
 });

--- a/apps/dokploy/lib/favicon-resolver.ts
+++ b/apps/dokploy/lib/favicon-resolver.ts
@@ -87,3 +87,40 @@ export const findIconUrl = (html: string, pageUrl: string): string | null => {
 	if (!href) return null;
 	return resolveIconUrl(href, pageUrl);
 };
+
+/**
+ * True when `url` is an http(s) URL whose ENTIRE origin (scheme + host + port)
+ * equals `baseOrigin`. The SSRF guard on the favicon route validates only the
+ * originally-requested host against the domains table; every subsequent URL we
+ * fetch — a `<link rel="icon">` href parsed from attacker-influenceable page
+ * HTML, or a redirect `Location` — must match the full origin so it can never
+ * be pivoted to a different scheme, a different host (`169.254.169.254`,
+ * `localhost`), or, critically, a different PORT on the same resolved IP
+ * (`:2375` Docker, `:5432`, `:6379`, …) which a host-only check would allow.
+ * `baseOrigin` must be a canonical origin string (e.g. `new URL(base).origin`).
+ */
+export const isSameOrigin = (url: string, baseOrigin: string): boolean => {
+	try {
+		const parsed = new URL(url);
+		return (
+			(parsed.protocol === "http:" || parsed.protocol === "https:") &&
+			parsed.origin === baseOrigin
+		);
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * True when `contentType` is a raster/vector-free image type we can safely
+ * stream back from the same origin as the dashboard. `image/svg+xml` is
+ * REJECTED: an SVG served with its genuine content-type executes inline
+ * `<script>` on direct navigation (the global CSP only sets
+ * `frame-ancestors 'none'`, and `nosniff` does not stop a correctly-typed SVG),
+ * so an attacker-controlled favicon on a managed host would be a stored-XSS
+ * vector in the Dokploy origin. Any `image/*` except svg is allowed.
+ */
+export const isSafeImageContentType = (contentType: string): boolean => {
+	const type = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+	return type.startsWith("image/") && type !== "image/svg+xml";
+};

--- a/apps/dokploy/pages/api/favicon.ts
+++ b/apps/dokploy/pages/api/favicon.ts
@@ -2,14 +2,21 @@ import { db } from "@dokploy/server/db";
 import { validateRequest } from "@dokploy/server/lib/auth";
 import { eq } from "drizzle-orm";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { findIconUrl } from "@/lib/favicon-resolver";
+import {
+	findIconUrl,
+	isSafeImageContentType,
+	isSameOrigin,
+} from "@/lib/favicon-resolver";
 import { domains } from "@/server/db/schema";
 
 const REQUEST_TIMEOUT_MS = 5000;
 const MAX_ICON_BYTES = 1024 * 1024; // 1 MB
 const MAX_REDIRECTS = 3;
-const SUCCESS_CACHE = "public, max-age=86400, stale-while-revalidate=604800";
-const FAILURE_CACHE = "public, max-age=3600";
+// Auth-gated, per-session response: keep it out of shared/CDN caches so one
+// user's favicon (and the 200-vs-404 signal of which hosts an instance manages)
+// is never served to another.
+const SUCCESS_CACHE = "private, max-age=86400, stale-while-revalidate=604800";
+const FAILURE_CACHE = "private, max-age=3600";
 
 const parseHttps = (value: unknown): boolean => {
 	const raw = Array.isArray(value) ? value[0] : value;
@@ -20,42 +27,22 @@ const getStringParam = (value: unknown): string | null =>
 	typeof value === "string" && value.length > 0 ? value : null;
 
 /**
- * True when `url` is an http(s) URL whose hostname equals `host`
- * (case-insensitive). The SSRF guard on this route validates only the
- * originally-requested host against the domains table; every subsequent URL we
- * fetch — a `<link rel="icon">` href parsed from attacker-influenceable page
- * HTML, or a redirect `Location` — must be re-checked against that same host so
- * it can never be pivoted to `169.254.169.254`, `localhost`, or any other
- * internal target the guard never approved.
- */
-const isSameHost = (url: string, host: string): boolean => {
-	try {
-		const parsed = new URL(url);
-		return (
-			(parsed.protocol === "http:" || parsed.protocol === "https:") &&
-			parsed.hostname.toLowerCase() === host.toLowerCase()
-		);
-	} catch {
-		return false;
-	}
-};
-
-/**
  * Fetch a URL with a hard timeout and a byte cap enforced while streaming the
  * body, so a hostile or oversized response cannot exhaust memory. Redirects are
  * followed manually (`redirect: "manual"`) and every hop is re-validated to
- * stay on `host`, closing the redirect-based SSRF pivot. Returns the buffered
- * body plus its content-type, or `null` on any failure (off-host hop, non-ok
- * status, timeout, network error, too many redirects, or exceeding the cap).
+ * stay on `baseOrigin` (scheme + host + port), closing the redirect-based SSRF
+ * pivot. Returns the buffered body plus its content-type, or `null` on any
+ * failure (off-origin hop, non-ok status, timeout, network error, too many
+ * redirects, or exceeding the cap).
  */
 const fetchCapped = async (
 	url: string,
 	accept: string,
-	host: string,
+	baseOrigin: string,
 ): Promise<{ body: Buffer; contentType: string } | null> => {
 	let currentUrl = url;
 	for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
-		if (!isSameHost(currentUrl, host)) {
+		if (!isSameOrigin(currentUrl, baseOrigin)) {
 			return null;
 		}
 		const controller = new AbortController();
@@ -157,15 +144,17 @@ export default async function handler(
 
 	const scheme = https ? "https" : "http";
 	const base = `${scheme}://${host}/`;
+	// Canonical origin (scheme + host + port) every fetched URL is pinned to.
+	const baseOrigin = new URL(base).origin;
 
 	let iconUrl: string | null = null;
-	const page = await fetchCapped(base, "text/html", host);
+	const page = await fetchCapped(base, "text/html", baseOrigin);
 	if (page && /text\/html/i.test(page.contentType)) {
 		const parsed = findIconUrl(page.body.toString("utf8"), base);
 		// The page HTML is attacker-influenceable, so only trust an icon href
-		// that resolves back to the same managed host; anything else falls
+		// that resolves back to the same managed origin; anything else falls
 		// through to the /favicon.ico default below.
-		if (parsed && isSameHost(parsed, host)) {
+		if (parsed && isSameOrigin(parsed, baseOrigin)) {
 			iconUrl = parsed;
 		}
 	}
@@ -173,13 +162,18 @@ export default async function handler(
 		iconUrl = `${scheme}://${host}/favicon.ico`;
 	}
 
-	const icon = await fetchCapped(iconUrl, "image/*", host);
-	if (!icon || !/^image\//i.test(icon.contentType)) {
+	const icon = await fetchCapped(iconUrl, "image/*", baseOrigin);
+	// Reject non-images and, critically, image/svg+xml (executable on direct
+	// navigation) so an attacker-controlled favicon can't run script in our
+	// origin. Defense-in-depth CSP neutralizes anything that slips the check.
+	if (!icon || !isSafeImageContentType(icon.contentType)) {
 		notFound(res);
 		return;
 	}
 
 	res.setHeader("Content-Type", icon.contentType);
+	res.setHeader("X-Content-Type-Options", "nosniff");
+	res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
 	res.setHeader("Cache-Control", SUCCESS_CACHE);
 	res.status(200).send(icon.body);
 }


### PR DESCRIPTION
@
Follow-up hardening on the favicon resolver (#145, #146), from an adversarial re-review of the merged route.

## Findings addressed

**1. `image/svg+xml` favicon → stored XSS in the Dokploy origin (MED).** The route accepted any `image/*` and streamed the bytes back with that content-type. An SVG served with its genuine `image/svg+xml` type executes inline `<script>` on direct navigation — the global CSP only sets `frame-ancestors none` and `nosniff` does not stop a correctly-typed SVG. An authenticated tenant could deploy an app on a managed host serving a malicious SVG favicon, then lure an authenticated victim to `/api/favicon?host=<attacker-host>` to run script in our origin.
- `isSafeImageContentType()` now rejects `image/svg+xml` (any other `image/*` still allowed).
- The icon response now carries `Content-Security-Policy: default-src none; sandbox` + `X-Content-Type-Options: nosniff` as defense-in-depth.

**2. Port-agnostic same-host guard → internal port pivot (MED).** The `#146` guard compared hostname only. Since a managed domain resolves to the Dokploy server itself, attacker-controlled page HTML or a redirect `Location` could target another port on the same IP (`:2375` Docker, `:5432`, `:6379`, …) — a blind internal port-probe primitive.
- Replaced host-only `isSameHost` with `isSameOrigin()`, pinning the full origin (scheme + host + port). Consistent with the accepted same-host design (managed domains may legitimately be private IPs / traefik.me).

**3. `Cache-Control: public` on an auth-gated route (LOW).** Switched to `private` so one users favicon — and the 200-vs-404 signal of which hosts the instance manages — is never served from a shared/CDN cache.

## Tests
Added 12 unit cases for the two new pure guards (`isSameOrigin`: port pivot, scheme flip, userinfo smuggling, protocol-relative, unparseable; `isSafeImageContentType`: raster accept, svg reject with params/case, non-image reject). Full suite: 30/30 pass. `tsc --noEmit` clean (cold cache).

No behavior change for legitimate favicons (relative hrefs inherit the base origin; raster/ico types pass).
@