### PR TITLE
fix(ui): allow pointer events on clickable svg icons in badges

### DIFF
--- a/apps/dokploy/components/ui/badge.tsx
+++ b/apps/dokploy/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg:not(.cursor-pointer)]:pointer-events-none [&>svg]:size-3!",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
Port of upstream Dokploy PR [#4827](https://github.com/Dokploy/dokploy/pull/4827) (1:1).

## Upstream bug
The `badgeVariants` cva string applied `[&>svg]:pointer-events-none` to **every** direct `<svg>` child of a badge. This is correct for decorative icons, but it also swallows clicks on interactive icons rendered inside a badge (e.g. a close/remove icon on a dismissible badge), because `pointer-events: none` propagates to the icon regardless of intent.

## How it manifests in the fork
Any badge containing a clickable svg icon renders the icon visually but cannot receive click/hover events — the icon appears inert.

## Fix
Scope the rule to `[&>svg:not(.cursor-pointer)]:pointer-events-none`. Decorative svgs remain non-interactive, while an svg explicitly marked `cursor-pointer` (the convention for clickable icons) keeps receiving pointer events. The `[&>svg]:size-3!` sizing rule is unchanged, so icon sizing is unaffected.

## Verification
- `tsc --noEmit` on `apps/dokploy` — clean.
- Change is a single-token edit to the cva class string; git diff is 1 line.
- Local biome shows only the pre-existing Windows CRLF working-tree artifact (committed blob is LF via `core.autocrlf`); CI runs against LF content.