### PR TITLE
fix(code-editor): correct YAML auto-indentation on Enter

### DIFF
--- a/apps/dokploy/components/shared/code-editor.tsx
+++ b/apps/dokploy/components/shared/code-editor.tsx
@@ -7,7 +7,11 @@ import {
 import { css } from "@codemirror/lang-css";
 import { json } from "@codemirror/lang-json";
 import { yaml } from "@codemirror/lang-yaml";
-import { StreamLanguage } from "@codemirror/language";
+import {
+	getIndentUnit,
+	indentService,
+	StreamLanguage,
+} from "@codemirror/language";
 import { properties } from "@codemirror/legacy-modes/mode/properties";
 import { shell } from "@codemirror/legacy-modes/mode/shell";
 import { search, searchKeymap } from "@codemirror/search";
@@ -98,6 +102,27 @@ const dockerComposeServiceOptions = [
 	},
 }));
 
+// The indentNodeProp shipped with @codemirror/lang-yaml computes wrong
+// column-based indents on Enter (odd/inconsistent amounts, see #4650), so
+// indentation is resolved line-based here: keep the current indent, align
+// list-entry keys after the dash marker, and go one unit deeper after a
+// line that opens a block (ending in ":", "|" or ">").
+const yamlIndent = indentService.of((context, pos) => {
+	const line = context.state.doc.lineAt(pos);
+	const before = context.state.doc.sliceString(line.from, pos);
+	const indent = /^ */.exec(before)?.[0].length ?? 0;
+	const trimmed = before.trim();
+	if (!trimmed || trimmed.startsWith("#")) {
+		return indent;
+	}
+	const base =
+		trimmed.startsWith("- ") && /:\s/.test(trimmed) ? indent + 2 : indent;
+	if (/[:|>]$/.test(trimmed)) {
+		return base + getIndentUnit(context.state);
+	}
+	return base;
+});
+
 function dockerComposeComplete(
 	context: CompletionContext,
 ): CompletionResult | null {
@@ -160,7 +185,7 @@ export const CodeEditor = ({
 					search(),
 					keymap.of(searchKeymap),
 					language === "yaml"
-						? yaml()
+						? [yamlIndent, yaml()]
 						: language === "json"
 							? json()
 							: language === "css"


### PR DESCRIPTION
Port of upstream Dokploy PR [#4828](https://github.com/Dokploy/dokploy/pull/4828) (1:1).

## Upstream bug
The `indentNodeProp` bundled with `@codemirror/lang-yaml` computes indentation from the YAML syntax tree using a column-based heuristic that produces wrong / inconsistent indents when the user presses Enter (upstream issue #4650). Editing docker-compose YAML in the code editor drops the cursor at odd indentation levels, forcing manual re-indentation.

## How it manifests in the fork
The fork's `CodeEditor` uses `yaml()` from `@codemirror/lang-yaml` for compose editing, so it inherits the same broken Enter-key indentation.

## Fix
Register a line-based `indentService` (`yamlIndent`) that resolves indentation deterministically from the previous line instead of the parse tree:
- blank or comment lines keep the current indent,
- list-entry keys (`- key: value`) align the key two columns past the dash,
- a line that opens a block (ends in `:`, `|` or `>`) indents one `getIndentUnit` deeper.

`yamlIndent` is prepended to the yaml extension array (`[yamlIndent, yaml()]`) so it takes precedence over the built-in indent logic. Only YAML is affected; JSON/CSS/shell/env editors are untouched.

## Verification
- Confirmed `@codemirror/language@6.12.4` (installed) exports both `getIndentUnit` and `indentService` (present in dist runtime + `.d.ts`), so no dependency bump is needed.
- `tsc --noEmit` on `apps/dokploy` — clean.
- `biome check` on the LF-normalized file — no changes (`--write` produces byte-identical output). Local CRLF is a Windows working-tree artifact only; committed blob is LF.