### PR TITLE
fix(encryption): decrypt values written under the legacy hardcoded auth secret

### DIFF
--- a/apps/dokploy/__test__/env/encryption.test.ts
+++ b/apps/dokploy/__test__/env/encryption.test.ts
@@ -49,6 +49,37 @@ describe("encryptValue / decryptValue", () => {
 	});
 });
 
+describe("migrating off the hardcoded legacy BETTER_AUTH_SECRET", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	const loadWithAuthSecret = async (secret: string) => {
+		vi.stubEnv("BETTER_AUTH_SECRET", secret);
+		vi.resetModules();
+		return await import("@dokploy/server/lib/encryption");
+	};
+
+	it("still decrypts values written under the legacy secret", async () => {
+		// Encrypted while the install was still on the hardcoded default
+		const legacyEncrypted = encryptValue("KEY=legacy-value");
+
+		const migrated = await loadWithAuthSecret("a-real-auth-secret");
+		expect(migrated.decryptValue(legacyEncrypted)).toBe("KEY=legacy-value");
+	});
+
+	it("encrypts new values with the new secret, not the legacy one", async () => {
+		const migrated = await loadWithAuthSecret("a-real-auth-secret");
+		const encrypted = migrated.encryptValue("KEY=post-migration");
+
+		// The legacy-derived key alone cannot read it, proving the write used
+		// the migrated secret
+		expect(() => decryptValue(encrypted)).toThrow(/BETTER_AUTH_SECRET/);
+		expect(migrated.decryptValue(encrypted)).toBe("KEY=post-migration");
+	});
+});
+
 describe("dedicated ENCRYPTION_KEY", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();

--- a/packages/server/src/lib/auth-secret.ts
+++ b/packages/server/src/lib/auth-secret.ts
@@ -1,6 +1,6 @@
 import { readSecret } from "../db/constants";
 
-const HARDCODED_LEGACY_SECRET = "better-auth-secret-123456789";
+export const HARDCODED_LEGACY_SECRET = "better-auth-secret-123456789";
 
 const { BETTER_AUTH_SECRET, BETTER_AUTH_SECRET_FILE } = process.env;
 

--- a/packages/server/src/lib/encryption.ts
+++ b/packages/server/src/lib/encryption.ts
@@ -7,7 +7,7 @@ import {
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
-import { betterAuthSecret } from "./auth-secret";
+import { betterAuthSecret, HARDCODED_LEGACY_SECRET } from "./auth-secret";
 import { encryptionSecret } from "./encryption-secret";
 
 export const ENCRYPTION_KEY_BACKUP_FILE = "encryption.key";
@@ -21,12 +21,35 @@ const deriveKey = (secret: string) =>
 
 const primaryKey = deriveKey(encryptionSecret ?? betterAuthSecret);
 
+const dedupeKeys = (keys: Buffer[]) => {
+	const seen = new Set<string>();
+	return keys.filter((key) => {
+		const hex = key.toString("hex");
+		if (seen.has(hex)) {
+			return false;
+		}
+		seen.add(hex);
+		return true;
+	});
+};
+
 // Installs that adopt a dedicated ENCRYPTION_KEY still hold values encrypted
 // with the auth-secret-derived key; keep it as a decrypt fallback so they
 // lazily re-encrypt on the next write instead of becoming unreadable.
-const decryptionKeys = encryptionSecret
-	? [primaryKey, deriveKey(betterAuthSecret)]
-	: [primaryKey];
+//
+// The same applies to installs migrating off the deprecated hardcoded auth
+// secret, which the startup banner asks every affected user to do: their
+// values are encrypted with the legacy-derived key. HARDCODED_LEGACY_SECRET
+// is a published constant, so keeping it as a decrypt-only fallback discloses
+// nothing that was not already derivable from the source, while stopping the
+// migration from orphaning existing values. Encryption always uses
+// primaryKey, so values written after the migration are protected by the
+// real secret.
+const decryptionKeys = dedupeKeys([
+	primaryKey,
+	...(encryptionSecret ? [deriveKey(betterAuthSecret)] : []),
+	deriveKey(HARDCODED_LEGACY_SECRET),
+]);
 
 // Derived keys only — never the raw secrets. A leaked key can decrypt
 // stored values, but the raw BETTER_AUTH_SECRET could also forge sessions.


### PR DESCRIPTION
Port of upstream Dokploy PR [#4834](https://github.com/Dokploy/dokploy/pull/4834) (1:1).

## Upstream bug
Dokploy derives its DB-encryption key from `ENCRYPTION_KEY ?? BETTER_AUTH_SECRET`. Installs that never set `BETTER_AUTH_SECRET` fall back to the deprecated hardcoded default (`better-auth-secret-123456789`) and encrypt their stored secrets with a key derived from it. The startup banner urges those users to migrate to a real secret — but the moment they do, `primaryKey` changes and every value previously written under the legacy-derived key becomes undecryptable (throws "Failed to decrypt a stored secret").

## How it manifests in the fork
The fork ships the same `auth-secret.ts` fallback and the same `encryption.ts` key derivation, so a fork install running on the hardcoded default that then sets a real `BETTER_AUTH_SECRET` loses access to all previously encrypted values (env vars, provider tokens, etc.).

## Fix
- `auth-secret.ts`: export `HARDCODED_LEGACY_SECRET` so the encryption module can derive the legacy key.
- `encryption.ts`: add a `dedupeKeys` helper and rebuild `decryptionKeys` as `dedupeKeys([primaryKey, ...(encryptionSecret ? [deriveKey(betterAuthSecret)] : []), deriveKey(HARDCODED_LEGACY_SECRET)])`. The legacy-derived key is added as a **decrypt-only** fallback so migrated installs keep reading old values and lazily re-encrypt on the next write. `dedupeKeys` is required because when no env secret is set the legacy key equals `primaryKey`, and the duplicate would otherwise pollute exports/restore logic.

## Security invariant
Encryption is unchanged: `encryptValue` still uses `primaryKey` only, so every value written after migration is protected by the real secret. `HARDCODED_LEGACY_SECRET` is a published source constant, so exposing its derived key as a decrypt fallback discloses nothing not already derivable from the repo. The upstream diff's unrelated whitespace-only hunk in `handle-notifications.tsx` was intentionally omitted.

## Verification
- `pnpm --filter=@dokploy/server build` — succeeds.
- `tsc --noEmit` on `apps/dokploy` — clean.
- `vitest run __test__/env/encryption.test.ts` — 12/12 pass, including the two ported migration tests ("still decrypts values written under the legacy secret" and "encrypts new values with the new secret, not the legacy one").
- `biome check` on the changed files — clean.