### PR TITLE
fix(settings): allow clearing the server domain

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-domain.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-domain.tsx
@@ -43,7 +43,8 @@ const addServerDomain = z
 			.string()
 			.trim()
 			.toLowerCase()
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
+			// empty clears the server domain and reverts to IP-only access
+			.refine((val) => val === "" || VALID_HOSTNAME_REGEX.test(val), {
 				message: INVALID_HOSTNAME_MESSAGE,
 			}),
 		letsEncryptEmail: z.string(),
@@ -51,7 +52,7 @@ const addServerDomain = z
 		certificateType: z.enum(["letsencrypt", "none", "custom"]),
 	})
 	.superRefine((data, ctx) => {
-		if (data.https && !data.certificateType) {
+		if (data.domain && data.https && !data.certificateType) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ["certificateType"],
@@ -59,6 +60,7 @@ const addServerDomain = z
 			});
 		}
 		if (
+			data.domain &&
 			data.https &&
 			data.certificateType === "letsencrypt" &&
 			!data.letsEncryptEmail


### PR DESCRIPTION
## What

Port of upstream Dokploy PR #4825 (merged 2026-07-14).

Allows clearing the Dokploy server domain in **Settings -> Web Server** so an admin can revert to IP-only access after having set a domain.

## Bug

`apps/dokploy/components/dashboard/settings/web-domain.tsx` defines the form's zod schema `addServerDomain`. The hostname field's `.refine` only accepted values matching `VALID_HOSTNAME_REGEX`; the empty string failed it.

**Manifestation:** once a domain was configured, an admin who cleared the field and hit save got the "invalid hostname" validation error and the `assignDomainServer` mutation never fired — there was no way to remove a previously-set domain from the UI. Additionally the two `.superRefine` certificate checks (HTTPS-requires-certificateType, and letsencrypt-requires-email) still ran when clearing, demanding certificate config for a domain that was being removed.

## Fix (mirrors upstream)

- Hostname refine now accepts empty: `val === "" || VALID_HOSTNAME_REGEX.test(val)`.
- Both certificate `superRefine` checks are gated on a non-empty `data.domain`, so clearing the domain no longer trips certificate validation.

## Server-side validation finding

The form submits to `api.settings.assignDomainServer`. Traced end-to-end — no server change is needed:

- The mutation validates input against `apiAssignDomain` (`packages/server/src/db/schema/web-server-settings.ts:190-204`), whose `host` field is a plain `z.string()` — the empty string is already accepted.
- The mutation (`apps/dokploy/server/api/routers/settings.ts:325-356`) persists the cleared host via `updateWebServerSettings` and calls `updateServerTraefik(settings, input.host)`.
- `updateServerTraefik` (`packages/server/src/utils/traefik/web-server.ts:82-86`) branches on the host: when it is empty/falsy it calls `removeTraefikConfig(appName)`, deleting the `dokploy` Traefik router entirely. Observed backend behavior for an empty domain: the Traefik host-routing config is removed and the panel reverts to IP-only access.

So the backend already fully supported an empty domain; the bug was purely the client-side zod schema blocking submission. Nothing was refactored server-side.

## Verification

- `tsc --noEmit` from `apps/dokploy` — clean.
- Biome check on the changed file — the only finding is CRLF line-terminators in the local Windows working tree (git `core.autocrlf=true`); the committed blob is LF and the diff is exactly the upstream +4/-2 with no line-ending churn.
- No tests reference this form/schema/mutation.