### PR TITLE
feat: backup coverage tree — project icons, env filter, compose children

### DIFF
--- a/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
+++ b/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyDbImage,
+	extractComposeChildren,
+	isComposeVolumeCovered,
+	isProductionEnvironment,
+	isServiceShownByDefault,
+} from "@/lib/backup-coverage";
+
+describe("classifyDbImage", () => {
+	it("classifies official database images", () => {
+		expect(classifyDbImage("postgres")).toBe("postgres");
+		expect(classifyDbImage("postgres:16-alpine")).toBe("postgres");
+		expect(classifyDbImage("mysql:8")).toBe("mysql");
+		expect(classifyDbImage("mariadb:11")).toBe("mariadb");
+		expect(classifyDbImage("mongo:7")).toBe("mongo");
+		expect(classifyDbImage("redis:7-alpine")).toBe("redis");
+	});
+
+	it("classifies namespaced and registry-prefixed images", () => {
+		expect(classifyDbImage("bitnami/postgresql:16")).toBe("postgres");
+		expect(classifyDbImage("ghcr.io/acme/postgres:16")).toBe("postgres");
+		expect(classifyDbImage("registry.local:5000/team/mysql:8")).toBe("mysql");
+		expect(classifyDbImage("supabase/postgres:15.1.0")).toBe("postgres");
+	});
+
+	it("handles digests and tags without confusing registry ports", () => {
+		expect(classifyDbImage("postgres@sha256:deadbeef")).toBe("postgres");
+		expect(classifyDbImage("registry.local:5000/valkey/valkey:8")).toBe(
+			"redis",
+		);
+	});
+
+	it("classifies redis-family alternatives as redis", () => {
+		expect(classifyDbImage("valkey/valkey:8")).toBe("redis");
+		expect(classifyDbImage("docker.dragonflydb.io/dragonflydb/dragonfly")).toBe(
+			"redis",
+		);
+		expect(classifyDbImage("eqalpha/keydb")).toBe("redis");
+	});
+
+	it("prefers mongo/mariadb over the mysql-family patterns", () => {
+		expect(classifyDbImage("percona/percona-server-mongodb:7")).toBe("mongo");
+		expect(classifyDbImage("percona/percona-server:8")).toBe("mysql");
+		expect(classifyDbImage("mariadb:lts")).toBe("mariadb");
+	});
+
+	it("classifies postgres-family and libsql variants", () => {
+		expect(classifyDbImage("postgis/postgis:16-3.4")).toBe("postgres");
+		expect(classifyDbImage("timescale/timescaledb:latest-pg16")).toBe(
+			"postgres",
+		);
+		expect(classifyDbImage("pgvector/pgvector:pg16")).toBe("postgres");
+		expect(classifyDbImage("ghcr.io/tursodatabase/libsql-server")).toBe(
+			"libsql",
+		);
+	});
+
+	it("returns null for non-database images and empty input", () => {
+		expect(classifyDbImage("nginx:alpine")).toBeNull();
+		expect(classifyDbImage("ghcr.io/acme/web-app:1.2.3")).toBeNull();
+		expect(classifyDbImage("node:22-alpine")).toBeNull();
+		expect(classifyDbImage("")).toBeNull();
+		expect(classifyDbImage(null)).toBeNull();
+		expect(classifyDbImage(undefined)).toBeNull();
+	});
+});
+
+describe("isProductionEnvironment", () => {
+	it("matches the backup-policy production preset convention", () => {
+		expect(isProductionEnvironment("production")).toBe(true);
+		expect(isProductionEnvironment("Production")).toBe(true);
+		expect(isProductionEnvironment(" production ")).toBe(true);
+		expect(isProductionEnvironment("prod")).toBe(false);
+		expect(isProductionEnvironment("staging")).toBe(false);
+	});
+});
+
+describe("isServiceShownByDefault", () => {
+	it("shows everything in production environments", () => {
+		expect(
+			isServiceShownByDefault(
+				{ type: "application", hasVolumes: false },
+				"production",
+			),
+		).toBe(true);
+		expect(
+			isServiceShownByDefault(
+				{ type: "compose", hasVolumes: false },
+				"Production",
+			),
+		).toBe(true);
+	});
+
+	it("always shows databases in non-production environments", () => {
+		for (const type of [
+			"postgres",
+			"mysql",
+			"mariadb",
+			"mongo",
+			"redis",
+			"libsql",
+		] as const) {
+			expect(
+				isServiceShownByDefault({ type, hasVolumes: false }, "staging"),
+			).toBe(true);
+		}
+	});
+
+	it("shows non-prod applications/compose only when they have volumes", () => {
+		expect(
+			isServiceShownByDefault(
+				{ type: "application", hasVolumes: true },
+				"staging",
+			),
+		).toBe(true);
+		expect(
+			isServiceShownByDefault(
+				{ type: "application", hasVolumes: false },
+				"staging",
+			),
+		).toBe(false);
+		expect(
+			isServiceShownByDefault({ type: "compose", hasVolumes: true }, "dev"),
+		).toBe(true);
+		expect(
+			isServiceShownByDefault({ type: "compose", hasVolumes: false }, "dev"),
+		).toBe(false);
+	});
+});
+
+describe("extractComposeChildren", () => {
+	it("extracts services with images and named volumes (short syntax)", () => {
+		const children = extractComposeChildren({
+			services: {
+				web: { image: "ghcr.io/acme/web:1", volumes: ["./src:/app"] },
+				db: {
+					image: "postgres:16",
+					volumes: ["db-data:/var/lib/postgresql/data", "/etc/tz:/etc/tz:ro"],
+				},
+			},
+			volumes: { "db-data": null },
+		});
+		expect(children).toEqual([
+			{ name: "web", image: "ghcr.io/acme/web:1", dbKind: null, volumes: [] },
+			{
+				name: "db",
+				image: "postgres:16",
+				dbKind: "postgres",
+				volumes: ["db-data"],
+			},
+		]);
+	});
+
+	it("supports long-syntax volume entries and skips binds/anonymous", () => {
+		const children = extractComposeChildren({
+			services: {
+				cache: {
+					image: "redis:7",
+					volumes: [
+						{ type: "volume", source: "cache-data", target: "/data" },
+						{ type: "bind", source: "./conf", target: "/conf" },
+						"/data", // anonymous volume
+						"~/host:/container",
+						"$HOME/host:/container",
+					],
+				},
+			},
+		});
+		expect(children).toEqual([
+			{
+				name: "cache",
+				image: "redis:7",
+				dbKind: "redis",
+				volumes: ["cache-data"],
+			},
+		]);
+	});
+
+	it("deduplicates repeated volume sources", () => {
+		const children = extractComposeChildren({
+			services: {
+				app: {
+					image: "node:22",
+					volumes: ["shared:/a", "shared:/b"],
+				},
+			},
+		});
+		expect(children[0]?.volumes).toEqual(["shared"]);
+	});
+
+	it("tolerates services without image or volumes", () => {
+		const children = extractComposeChildren({
+			services: { built: { build: "." } },
+		});
+		expect(children).toEqual([
+			{ name: "built", image: null, dbKind: null, volumes: [] },
+		]);
+	});
+
+	it("returns an empty list for malformed documents", () => {
+		expect(extractComposeChildren(null)).toEqual([]);
+		expect(extractComposeChildren("not yaml objects")).toEqual([]);
+		expect(extractComposeChildren({})).toEqual([]);
+		expect(extractComposeChildren({ services: [] })).toEqual([]);
+		expect(extractComposeChildren({ services: { broken: null } })).toEqual([]);
+		expect(
+			extractComposeChildren({ services: { odd: { volumes: "no" } } }),
+		).toEqual([{ name: "odd", image: null, dbKind: null, volumes: [] }]);
+	});
+});
+
+describe("isComposeVolumeCovered", () => {
+	it("matches exact volume names", () => {
+		expect(isComposeVolumeCovered("db-data", ["db-data"])).toBe(true);
+	});
+
+	it("matches stack-prefixed deployed volume names", () => {
+		expect(isComposeVolumeCovered("db-data", ["myapp-abc123_db-data"])).toBe(
+			true,
+		);
+	});
+
+	it("does not match unrelated names", () => {
+		expect(isComposeVolumeCovered("db-data", [])).toBe(false);
+		expect(isComposeVolumeCovered("db-data", ["other"])).toBe(false);
+		expect(isComposeVolumeCovered("db-data", ["db-data-old"])).toBe(false);
+	});
+});

--- a/apps/dokploy/components/dashboard/backups/coverage-env-filter.tsx
+++ b/apps/dokploy/components/dashboard/backups/coverage-env-filter.tsx
@@ -1,0 +1,173 @@
+import { Check, ListFilter, Minus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+/**
+ * Visibility mode of an environment in the coverage tree:
+ * - "default": production environments show everything, other environments
+ *   show only databases and services with named volumes;
+ * - "all": show every service in the environment;
+ * - "hidden": hide the environment entirely.
+ */
+export type EnvironmentMode = "default" | "all" | "hidden";
+
+export interface FilterEnvironment {
+	id: string;
+	name: string;
+	projectName: string;
+	isProduction: boolean;
+}
+
+interface Props {
+	environments: FilterEnvironment[];
+	modes: Record<string, EnvironmentMode>;
+	onChange: (modes: Record<string, EnvironmentMode>) => void;
+}
+
+const modeOf = (
+	modes: Record<string, EnvironmentMode>,
+	envId: string,
+): EnvironmentMode => modes[envId] ?? "default";
+
+// For production environments "default" already shows everything, so the
+// toggle is binary (shown/hidden). Non-production environments cycle through
+// the three states.
+const nextMode = (
+	current: EnvironmentMode,
+	isProduction: boolean,
+): EnvironmentMode => {
+	if (isProduction) {
+		return current === "hidden" ? "default" : "hidden";
+	}
+	switch (current) {
+		case "default":
+			return "all";
+		case "all":
+			return "hidden";
+		default:
+			return "default";
+	}
+};
+
+const ModeBox = ({
+	mode,
+	isProduction,
+}: {
+	mode: EnvironmentMode;
+	isProduction: boolean;
+}) => {
+	const showsEverything = mode === "all" || (isProduction && mode === "default");
+	return (
+		<span
+			className={cn(
+				"flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary",
+				mode === "hidden"
+					? "bg-transparent"
+					: "bg-primary text-primary-foreground",
+			)}
+		>
+			{mode !== "hidden" &&
+				(showsEverything ? (
+					<Check className="size-3" />
+				) : (
+					<Minus className="size-3" />
+				))}
+		</span>
+	);
+};
+
+export const CoverageEnvFilter = ({ environments, modes, onChange }: Props) => {
+	const overrides = environments.filter(
+		(environment) => modeOf(modes, environment.id) !== "default",
+	).length;
+
+	const setAll = (mode: EnvironmentMode | "default") => {
+		if (mode === "default") {
+			onChange({});
+			return;
+		}
+		onChange(
+			Object.fromEntries(
+				environments.map((environment) => [environment.id, mode]),
+			),
+		);
+	};
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button variant="outline" size="sm" className="h-8 gap-2">
+					<ListFilter className="size-4" />
+					Environments
+					{overrides > 0 && (
+						<Badge variant="blue" className="px-1.5 text-[10px]">
+							{overrides}
+						</Badge>
+					)}
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-80 p-0">
+				<div className="flex items-center justify-between border-b px-3 py-2">
+					<span className="text-sm font-medium">Environments</span>
+					<div className="flex items-center gap-1">
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-7 px-2 text-xs"
+							onClick={() => setAll("all")}
+						>
+							Show all
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-7 px-2 text-xs"
+							onClick={() => setAll("default")}
+						>
+							Reset
+						</Button>
+					</div>
+				</div>
+				<div className="max-h-72 overflow-y-auto p-1">
+					{environments.map((environment) => {
+						const mode = modeOf(modes, environment.id);
+						return (
+							<button
+								key={environment.id}
+								type="button"
+								className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent"
+								onClick={() =>
+									onChange({
+										...modes,
+										[environment.id]: nextMode(
+											mode,
+											environment.isProduction,
+										),
+									})
+								}
+							>
+								<ModeBox mode={mode} isProduction={environment.isProduction} />
+								<span className="truncate">{environment.name}</span>
+								<span className="ml-auto truncate text-xs text-muted-foreground">
+									{environment.projectName}
+								</span>
+							</button>
+						);
+					})}
+				</div>
+				<div className="border-t px-3 py-2 text-[11px] leading-4 text-muted-foreground">
+					<span className="font-medium">✓</span> everything ·{" "}
+					<span className="font-medium">–</span> databases &amp; volumes only ·
+					empty = hidden. Non-production environments default to databases and
+					services with named volumes.
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+};

--- a/apps/dokploy/components/dashboard/backups/coverage-table.tsx
+++ b/apps/dokploy/components/dashboard/backups/coverage-table.tsx
@@ -1,6 +1,16 @@
-import { ExternalLink, Loader2, TableProperties } from "lucide-react";
+import {
+	Box,
+	CheckCircle2,
+	ChevronRight,
+	ExternalLink,
+	Folder,
+	Loader2,
+	TableProperties,
+	TriangleAlert,
+	X,
+} from "lucide-react";
 import Link from "next/link";
-import { Fragment, useMemo } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { AlertBlock } from "@/components/shared/alert-block";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -18,14 +28,29 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import {
+	isProductionEnvironment,
+	isServiceShownByDefault,
+} from "@/lib/backup-coverage";
 import { cn } from "@/lib/utils";
 import type { RouterOutputs } from "@/utils/api";
 import { api } from "@/utils/api";
+import {
+	getProjectFaviconUrls,
+	ProjectIcon,
+} from "../projects/project-icon";
+import {
+	CoverageEnvFilter,
+	type EnvironmentMode,
+	type FilterEnvironment,
+} from "./coverage-env-filter";
 import { ServiceTypeIcon } from "./service-type-icon";
 
 type CoverageService =
 	RouterOutputs["backupPolicy"]["coverage"]["services"][number];
 type CoverageEntry = CoverageService["dumpBackups"][number];
+
+const COLUMN_COUNT = 6;
 
 // Prefer a policy-managed entry so the cell shows the policy name; fall back to
 // the first manual entry.
@@ -41,9 +66,6 @@ const CoverageCell = ({
 }) => {
 	if (!capable) {
 		return <span className="text-xs text-muted-foreground">n/a</span>;
-	}
-	if (entries.length === 0) {
-		return <span className="text-muted-foreground">—</span>;
 	}
 	const entry = pickEntry(entries);
 	if (!entry) {
@@ -73,41 +95,254 @@ const statusDotClass = (status?: string) => {
 	}
 };
 
-export const CoverageTable = () => {
-	const { data, isLoading } = api.backupPolicy.coverage.useQuery();
+const isCovered = (service: CoverageService) =>
+	service.dumpBackups.length > 0 || service.volumeBackups.length > 0;
 
-	// Group the flat service list into project → environment → services while
-	// preserving first-seen order.
-	const grouped = useMemo(() => {
+/** Rollup shown on a collapsed project/environment node. */
+const RollupBadge = ({ uncovered }: { uncovered: number }) =>
+	uncovered > 0 ? (
+		<Badge variant="orange" className="gap-1">
+			<TriangleAlert className="size-3" />
+			{uncovered} not covered
+		</Badge>
+	) : (
+		<CheckCircle2 className="size-4 text-green-500" />
+	);
+
+const ExpandChevron = ({ expanded }: { expanded: boolean }) => (
+	<ChevronRight
+		className={cn(
+			"size-4 shrink-0 text-muted-foreground transition-transform",
+			expanded && "rotate-90",
+		)}
+	/>
+);
+
+interface EnvironmentNode {
+	id: string;
+	name: string;
+	isProduction: boolean;
+	projectName: string;
+	visibleServices: CoverageService[];
+	hiddenCount: number;
+	uncoveredCount: number;
+}
+
+interface ProjectNode {
+	id: string;
+	name: string;
+	logo: string | null;
+	faviconUrls: string[];
+	environments: EnvironmentNode[];
+	uncoveredCount: number;
+}
+
+// Child containers of a compose service, lazy-loaded on expand.
+const ComposeChildRows = ({ composeId }: { composeId: string }) => {
+	const { data, isPending } = api.backupPolicy.composeChildren.useQuery({
+		composeId,
+	});
+
+	if (isPending) {
+		return (
+			<TableRow>
+				<TableCell colSpan={COLUMN_COUNT} className="py-2 pl-[4.25rem]">
+					<span className="flex items-center gap-2 text-xs text-muted-foreground">
+						<Loader2 className="size-3.5 animate-spin" />
+						Loading compose services...
+					</span>
+				</TableCell>
+			</TableRow>
+		);
+	}
+
+	if (data?.error) {
+		return (
+			<TableRow>
+				<TableCell colSpan={COLUMN_COUNT} className="py-2 pl-[4.25rem]">
+					<span className="flex items-center gap-2 text-xs text-muted-foreground">
+						<TriangleAlert className="size-3.5 text-orange-500" />
+						{data.error}
+					</span>
+				</TableCell>
+			</TableRow>
+		);
+	}
+
+	return (
+		<>
+			{data?.children.map((child) => (
+				<TableRow key={child.name} className="bg-muted/20 hover:bg-muted/30">
+					<TableCell className="py-2 pl-[4.25rem]">
+						<div className="flex items-center gap-2">
+							{child.dbKind ? (
+								<ServiceTypeIcon type={child.dbKind} />
+							) : (
+								<Box className="size-4 text-muted-foreground" />
+							)}
+							<span className="text-sm">{child.name}</span>
+							{child.image && (
+								<span className="truncate text-xs text-muted-foreground">
+									{child.image}
+								</span>
+							)}
+						</div>
+					</TableCell>
+					<TableCell className="py-2">
+						<span className="text-xs text-muted-foreground">n/a</span>
+					</TableCell>
+					<TableCell className="py-2">
+						{child.volumes.length > 0 ? (
+							<div className="flex flex-wrap gap-1">
+								{child.volumes.map((volume) => (
+									<Badge
+										key={volume.name}
+										variant={volume.covered ? "green" : "orange"}
+										className="gap-1 text-[10px]"
+										title={
+											volume.covered
+												? "Covered by a volume backup"
+												: "No volume backup covers this volume"
+										}
+									>
+										{volume.covered ? (
+											<CheckCircle2 className="size-3" />
+										) : (
+											<X className="size-3" />
+										)}
+										{volume.name}
+									</Badge>
+								))}
+							</div>
+						) : (
+							<span className="text-muted-foreground">—</span>
+						)}
+					</TableCell>
+					<TableCell className="py-2" />
+					<TableCell className="py-2" />
+					<TableCell className="py-2" />
+				</TableRow>
+			))}
+		</>
+	);
+};
+
+export const CoverageTable = () => {
+	const { data, isPending } = api.backupPolicy.coverage.useQuery();
+
+	// Expansion overrides keyed by node id; absent = the node-type default
+	// (projects expanded, environments and compose nodes collapsed).
+	const [expandOverrides, setExpandOverrides] = useState<
+		Record<string, boolean>
+	>({});
+	const [envModes, setEnvModes] = useState<Record<string, EnvironmentMode>>(
+		{},
+	);
+
+	const isExpanded = (key: string, fallback: boolean) =>
+		expandOverrides[key] ?? fallback;
+	const toggle = (key: string, fallback: boolean) =>
+		setExpandOverrides((prev) => ({
+			...prev,
+			[key]: !(prev[key] ?? fallback),
+		}));
+
+	// Every environment (unfiltered) for the filter popover.
+	const filterEnvironments = useMemo<FilterEnvironment[]>(() => {
+		const seen = new Map<string, FilterEnvironment>();
+		for (const service of data?.services ?? []) {
+			if (!seen.has(service.environment.id)) {
+				seen.set(service.environment.id, {
+					id: service.environment.id,
+					name: service.environment.name,
+					projectName: service.project.name,
+					isProduction: isProductionEnvironment(service.environment.name),
+				});
+			}
+		}
+		return Array.from(seen.values());
+	}, [data]);
+
+	// Group the flat service list into project → environment nodes, applying
+	// the environment filter, while preserving first-seen order.
+	const tree = useMemo<ProjectNode[]>(() => {
 		const projects = new Map<
 			string,
-			{
-				name: string;
-				environments: Map<
+			ProjectNode & {
+				environmentMap: Map<
 					string,
-					{ id: string; name: string; services: CoverageService[] }
+					EnvironmentNode & { allServices: CoverageService[] }
 				>;
 			}
 		>();
 		for (const service of data?.services ?? []) {
 			let project = projects.get(service.project.id);
 			if (!project) {
-				project = { name: service.project.name, environments: new Map() };
+				project = {
+					id: service.project.id,
+					name: service.project.name,
+					logo: service.project.logo,
+					faviconUrls: [],
+					environments: [],
+					uncoveredCount: 0,
+					environmentMap: new Map(),
+				};
 				projects.set(service.project.id, project);
 			}
-			let environment = project.environments.get(service.environment.id);
+			let environment = project.environmentMap.get(service.environment.id);
 			if (!environment) {
 				environment = {
 					id: service.environment.id,
 					name: service.environment.name,
-					services: [],
+					isProduction: isProductionEnvironment(service.environment.name),
+					projectName: service.project.name,
+					visibleServices: [],
+					hiddenCount: 0,
+					uncoveredCount: 0,
+					allServices: [],
 				};
-				project.environments.set(service.environment.id, environment);
+				project.environmentMap.set(service.environment.id, environment);
 			}
-			environment.services.push(service);
+			environment.allServices.push(service);
 		}
-		return projects;
-	}, [data]);
+
+		const result: ProjectNode[] = [];
+		for (const project of projects.values()) {
+			const allProjectDomains: Array<{ host: string; https: boolean }> = [];
+			for (const environment of project.environmentMap.values()) {
+				for (const service of environment.allServices) {
+					allProjectDomains.push(...service.domains);
+				}
+			}
+			project.faviconUrls = getProjectFaviconUrls(allProjectDomains);
+
+			for (const environment of project.environmentMap.values()) {
+				const mode = envModes[environment.id] ?? "default";
+				if (mode === "hidden") continue;
+				environment.visibleServices =
+					mode === "all"
+						? environment.allServices
+						: environment.allServices.filter((service) =>
+								isServiceShownByDefault(service, environment.name),
+							);
+				environment.hiddenCount =
+					environment.allServices.length -
+					environment.visibleServices.length;
+				environment.uncoveredCount = environment.visibleServices.filter(
+					(service) => !isCovered(service),
+				).length;
+				// Keep fully-filtered environments visible so their "(N hidden)"
+				// hint reveals that the filter is active.
+				project.environments.push(environment);
+				project.uncoveredCount += environment.uncoveredCount;
+			}
+			if (project.environments.length > 0) {
+				const { environmentMap: _environmentMap, ...node } = project;
+				result.push(node);
+			}
+		}
+		return result;
+	}, [data, envModes]);
 
 	return (
 		<Card className="bg-background">
@@ -118,16 +353,16 @@ export const CoverageTable = () => {
 				</CardTitle>
 				<CardDescription>
 					Every service in the organization and how it is backed up. Redis and
-					applications are covered via volume backups; Compose databases via
-					volumes in v1.
+					applications are covered via volume backups; expand a compose to see
+					the databases and volumes inside it.
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">
-				{isLoading ? (
+				{isPending ? (
 					<div className="flex min-h-[20vh] items-center justify-center">
 						<Loader2 className="size-6 animate-spin text-muted-foreground" />
 					</div>
-				) : grouped.size === 0 ? (
+				) : (data?.services.length ?? 0) === 0 ? (
 					<div className="flex min-h-[20vh] flex-col items-center justify-center gap-3">
 						<TableProperties className="size-8 text-muted-foreground" />
 						<span className="text-base text-muted-foreground">
@@ -135,122 +370,257 @@ export const CoverageTable = () => {
 						</span>
 					</div>
 				) : (
-					<div className="overflow-x-auto">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead>Service</TableHead>
-									<TableHead>Dump</TableHead>
-									<TableHead>Volume</TableHead>
-									<TableHead>Destinations</TableHead>
-									<TableHead className="text-center">Last run</TableHead>
-									<TableHead />
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{Array.from(grouped.entries()).map(([projectId, project]) =>
-									Array.from(project.environments.values()).map(
-										(environment) => (
-											<Fragment key={`${projectId}-${environment.id}`}>
-												<TableRow className="bg-muted/40 hover:bg-muted/40">
-													<TableCell
-														colSpan={6}
-														className="py-2 text-xs font-medium text-muted-foreground"
+					<>
+						<div className="flex flex-wrap items-center gap-2">
+							<CoverageEnvFilter
+								environments={filterEnvironments}
+								modes={envModes}
+								onChange={setEnvModes}
+							/>
+							<span className="text-xs text-muted-foreground">
+								Non-production environments show databases and services with
+								volumes by default.
+							</span>
+						</div>
+						{tree.length === 0 ? (
+							<div className="flex min-h-[10vh] flex-col items-center justify-center gap-2">
+								<span className="text-sm text-muted-foreground">
+									Everything is hidden by the current environment filter.
+								</span>
+							</div>
+						) : (
+							<div className="overflow-x-auto">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Service</TableHead>
+											<TableHead>Dump</TableHead>
+											<TableHead>Volume</TableHead>
+											<TableHead>Destinations</TableHead>
+											<TableHead className="text-center">Last run</TableHead>
+											<TableHead />
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{tree.map((project) => {
+											const projectExpanded = isExpanded(
+												`p:${project.id}`,
+												true,
+											);
+											return (
+												<Fragment key={project.id}>
+													<TableRow
+														className="cursor-pointer bg-muted/40 hover:bg-muted/60"
+														onClick={() => toggle(`p:${project.id}`, true)}
 													>
-														{project.name} / {environment.name}
-													</TableCell>
-												</TableRow>
-												{environment.services.map((service) => {
-													const destinations = Array.from(
-														new Set(
-															[...service.dumpBackups, ...service.volumeBackups]
-																.map((entry) => entry.destinationName)
-																.filter((name) => !!name),
-														),
-													);
-													const lastRunStatus = [
-														...service.dumpBackups,
-														...service.volumeBackups,
-													].find((entry) => entry.lastRunStatus)?.lastRunStatus;
-													const notCovered =
-														service.dumpBackups.length === 0 &&
-														service.volumeBackups.length === 0;
-													return (
-														<TableRow
-															key={service.serviceId}
-															className={cn(
-																notCovered &&
-																	"bg-orange-500/5 hover:bg-orange-500/10",
-															)}
+														<TableCell
+															colSpan={COLUMN_COUNT}
+															className="py-2"
 														>
-															<TableCell>
-																<div className="flex items-center gap-2">
-																	<ServiceTypeIcon type={service.type} />
-																	<span className="font-medium">
-																		{service.name}
-																	</span>
-																	{notCovered && (
-																		<Badge variant="orange">Not covered</Badge>
-																	)}
-																</div>
-															</TableCell>
-															<TableCell>
-																<CoverageCell
-																	entries={service.dumpBackups}
-																	capable={service.dumpCapable}
+															<div className="flex items-center gap-2">
+																<ExpandChevron expanded={projectExpanded} />
+																<ProjectIcon
+																	logo={project.logo}
+																	faviconUrls={project.faviconUrls}
+																	className="size-4 rounded-sm object-contain"
+																	fallback={
+																		<Folder className="size-4 text-muted-foreground" />
+																	}
 																/>
-															</TableCell>
-															<TableCell>
-																<CoverageCell
-																	entries={service.volumeBackups}
-																	capable
-																/>
-															</TableCell>
-															<TableCell>
-																{destinations.length > 0 ? (
-																	<span className="text-sm text-muted-foreground">
-																		{destinations.join(", ")}
-																	</span>
-																) : (
-																	<span className="text-muted-foreground">
-																		—
-																	</span>
-																)}
-															</TableCell>
-															<TableCell className="text-center">
-																{lastRunStatus ? (
-																	<span
-																		className={cn(
-																			"inline-block size-2 rounded-full",
-																			statusDotClass(lastRunStatus),
-																		)}
-																		title={lastRunStatus}
+																<span className="font-medium">
+																	{project.name}
+																</span>
+																{!projectExpanded && (
+																	<RollupBadge
+																		uncovered={project.uncoveredCount}
 																	/>
-																) : (
-																	<span className="text-muted-foreground">
-																		—
-																	</span>
 																)}
-															</TableCell>
-															<TableCell className="text-right">
-																<Link
-																	href={`/dashboard/project/${projectId}/environment/${environment.id}`}
-																	className="inline-flex items-center text-muted-foreground hover:text-foreground"
-																	title="Open service"
-																>
-																	<ExternalLink className="size-4" />
-																</Link>
-															</TableCell>
-														</TableRow>
-													);
-												})}
-											</Fragment>
-										),
-									),
-								)}
-							</TableBody>
-						</Table>
-					</div>
+															</div>
+														</TableCell>
+													</TableRow>
+													{projectExpanded &&
+														project.environments.map((environment) => {
+															const envKey = `e:${environment.id}`;
+															const envExpanded = isExpanded(envKey, false);
+															return (
+																<Fragment key={environment.id}>
+																	<TableRow
+																		className="cursor-pointer hover:bg-muted/40"
+																		onClick={() => toggle(envKey, false)}
+																	>
+																		<TableCell
+																			colSpan={COLUMN_COUNT}
+																			className="py-2 pl-8"
+																		>
+																			<div className="flex items-center gap-2">
+																				<ExpandChevron
+																					expanded={envExpanded}
+																				/>
+																				<span className="text-sm">
+																					{environment.name}
+																				</span>
+																				{environment.hiddenCount > 0 && (
+																					<span className="text-xs text-muted-foreground">
+																						({environment.hiddenCount} hidden)
+																					</span>
+																				)}
+																				{!envExpanded &&
+																					environment.visibleServices.length >
+																						0 && (
+																						<RollupBadge
+																							uncovered={
+																								environment.uncoveredCount
+																							}
+																						/>
+																					)}
+																			</div>
+																		</TableCell>
+																	</TableRow>
+																	{envExpanded &&
+																		environment.visibleServices.map(
+																			(service) => {
+																				const destinations = Array.from(
+																					new Set(
+																						[
+																							...service.dumpBackups,
+																							...service.volumeBackups,
+																						]
+																							.map(
+																								(entry) =>
+																									entry.destinationName,
+																							)
+																							.filter((name) => !!name),
+																					),
+																				);
+																				const lastRunStatus = [
+																					...service.dumpBackups,
+																					...service.volumeBackups,
+																				].find(
+																					(entry) => entry.lastRunStatus,
+																				)?.lastRunStatus;
+																				const notCovered =
+																					!isCovered(service);
+																				const composeKey = `c:${service.serviceId}`;
+																				const composeExpanded =
+																					service.type === "compose" &&
+																					isExpanded(composeKey, false);
+																				return (
+																					<Fragment key={service.serviceId}>
+																						<TableRow
+																							className={cn(
+																								notCovered &&
+																									"bg-orange-500/5 hover:bg-orange-500/10",
+																								service.type === "compose" &&
+																									"cursor-pointer",
+																							)}
+																							onClick={
+																								service.type === "compose"
+																									? () =>
+																											toggle(
+																												composeKey,
+																												false,
+																											)
+																									: undefined
+																							}
+																						>
+																							<TableCell className="pl-12">
+																								<div className="flex items-center gap-2">
+																									{service.type ===
+																										"compose" && (
+																										<ExpandChevron
+																											expanded={
+																												composeExpanded
+																											}
+																										/>
+																									)}
+																									<ServiceTypeIcon
+																										type={service.type}
+																									/>
+																									<span className="font-medium">
+																										{service.name}
+																									</span>
+																									{notCovered && (
+																										<Badge variant="orange">
+																											Not covered
+																										</Badge>
+																									)}
+																								</div>
+																							</TableCell>
+																							<TableCell>
+																								<CoverageCell
+																									entries={service.dumpBackups}
+																									capable={service.dumpCapable}
+																								/>
+																							</TableCell>
+																							<TableCell>
+																								<CoverageCell
+																									entries={
+																										service.volumeBackups
+																									}
+																									capable
+																								/>
+																							</TableCell>
+																							<TableCell>
+																								{destinations.length > 0 ? (
+																									<span className="text-sm text-muted-foreground">
+																										{destinations.join(", ")}
+																									</span>
+																								) : (
+																									<span className="text-muted-foreground">
+																										—
+																									</span>
+																								)}
+																							</TableCell>
+																							<TableCell className="text-center">
+																								{lastRunStatus ? (
+																									<span
+																										className={cn(
+																											"inline-block size-2 rounded-full",
+																											statusDotClass(
+																												lastRunStatus,
+																											),
+																										)}
+																										title={lastRunStatus}
+																									/>
+																								) : (
+																									<span className="text-muted-foreground">
+																										—
+																									</span>
+																								)}
+																							</TableCell>
+																							<TableCell className="text-right">
+																								<Link
+																									href={`/dashboard/project/${project.id}/environment/${environment.id}`}
+																									className="inline-flex items-center text-muted-foreground hover:text-foreground"
+																									title="Open service"
+																									onClick={(event) =>
+																										event.stopPropagation()
+																									}
+																								>
+																									<ExternalLink className="size-4" />
+																								</Link>
+																							</TableCell>
+																						</TableRow>
+																						{composeExpanded && (
+																							<ComposeChildRows
+																								composeId={service.serviceId}
+																							/>
+																						)}
+																					</Fragment>
+																				);
+																			},
+																		)}
+																</Fragment>
+															);
+														})}
+												</Fragment>
+											);
+										})}
+									</TableBody>
+								</Table>
+							</div>
+						)}
+					</>
 				)}
 				<AlertBlock type="info">
 					A policy-managed backup and a manual backup can coexist on the same

--- a/apps/dokploy/lib/backup-coverage.ts
+++ b/apps/dokploy/lib/backup-coverage.ts
@@ -1,0 +1,184 @@
+// Pure helpers shared by the Backup Center coverage tree (client) and the
+// `backupPolicy.composeChildren` query (server). No React / DB imports here so
+// the logic stays unit-testable.
+
+/** Database families surfaced with a dedicated icon in the coverage tree. */
+export type DbKind =
+	| "postgres"
+	| "mysql"
+	| "mariadb"
+	| "mongo"
+	| "redis"
+	| "libsql";
+
+/** Convention shared with the backup-policy "production preset". */
+export const isProductionEnvironment = (environmentName: string): boolean =>
+	environmentName.trim().toLowerCase() === "production";
+
+// Ordered patterns: the first match wins. Mongo is tested before mysql so
+// `percona-server-mongodb` classifies as mongo (not the mysql-family percona),
+// and mariadb before mysql so `mariadb` never falls into the mysql bucket.
+const DB_IMAGE_PATTERNS: ReadonlyArray<[DbKind, RegExp]> = [
+	["mariadb", /mariadb/],
+	["mongo", /mongo/],
+	["postgres", /postgres|postgis|pgvector|timescaledb/],
+	["mysql", /mysql|percona/],
+	["redis", /redis|valkey|dragonfly|keydb/],
+	["libsql", /libsql|sqld/],
+];
+
+/**
+ * Classify a docker image reference into a database family, or null when it is
+ * not a recognized database image. Handles registries, namespaces, tags and
+ * digests (e.g. `ghcr.io/acme/postgres:16@sha256:...` → postgres).
+ */
+export const classifyDbImage = (
+	image: string | null | undefined,
+): DbKind | null => {
+	if (!image) return null;
+	// Strip digest, then tag (the tag colon is the last colon after the final
+	// slash — a leading `host:port/` must survive), then lowercase.
+	let ref = image.split("@")[0] ?? "";
+	const lastSlash = ref.lastIndexOf("/");
+	const lastColon = ref.lastIndexOf(":");
+	if (lastColon > lastSlash) {
+		ref = ref.slice(0, lastColon);
+	}
+	ref = ref.toLowerCase();
+	// Match against the final path segment so `mysql/mysql-server` works, but
+	// fall back to the whole reference for namespaced hits like
+	// `percona/percona-server`.
+	const name = ref.slice(ref.lastIndexOf("/") + 1);
+	for (const [kind, pattern] of DB_IMAGE_PATTERNS) {
+		if (pattern.test(name) || pattern.test(ref)) {
+			return kind;
+		}
+	}
+	return null;
+};
+
+/** Coverage service shape needed by the default-filter predicate. */
+export interface FilterableService {
+	type:
+		| "application"
+		| "postgres"
+		| "mysql"
+		| "mariadb"
+		| "mongo"
+		| "libsql"
+		| "redis"
+		| "compose";
+	hasVolumes: boolean;
+}
+
+const DB_SERVICE_TYPES: ReadonlySet<FilterableService["type"]> = new Set([
+	"postgres",
+	"mysql",
+	"mariadb",
+	"mongo",
+	"redis",
+	"libsql",
+]);
+
+/**
+ * The user-approved "hide non-prod plain apps" default:
+ * - production environments show every service;
+ * - other environments show databases and services with named volumes only —
+ *   a volume-less application/compose in a non-prod environment is hidden.
+ */
+export const isServiceShownByDefault = (
+	service: FilterableService,
+	environmentName: string,
+): boolean => {
+	if (isProductionEnvironment(environmentName)) return true;
+	if (DB_SERVICE_TYPES.has(service.type)) return true;
+	return service.hasVolumes;
+};
+
+/** A single container parsed out of a compose file. */
+export interface ComposeChildService {
+	name: string;
+	image: string | null;
+	dbKind: DbKind | null;
+	/** Named (top-level) volumes the container mounts, in declaration order. */
+	volumes: string[];
+}
+
+// Bind mounts and inline paths are not named volumes: absolute/relative paths,
+// home-relative paths and env-var driven sources are excluded.
+const isNamedVolumeSource = (source: string): boolean =>
+	source.length > 0 && !/^[./~$]/.test(source) && !source.includes("\\");
+
+/**
+ * Extract the child services of a parsed compose specification. Tolerates
+ * malformed documents: anything that does not look like `{ services: {...} }`
+ * yields an empty list, and malformed service/volume entries are skipped
+ * rather than throwing.
+ */
+export const extractComposeChildren = (
+	spec: unknown,
+): ComposeChildService[] => {
+	if (!spec || typeof spec !== "object") return [];
+	const services = (spec as { services?: unknown }).services;
+	if (!services || typeof services !== "object" || Array.isArray(services)) {
+		return [];
+	}
+
+	const children: ComposeChildService[] = [];
+	for (const [name, rawService] of Object.entries(
+		services as Record<string, unknown>,
+	)) {
+		if (!rawService || typeof rawService !== "object") continue;
+		const service = rawService as {
+			image?: unknown;
+			volumes?: unknown;
+		};
+		const image = typeof service.image === "string" ? service.image : null;
+
+		const volumes: string[] = [];
+		if (Array.isArray(service.volumes)) {
+			for (const entry of service.volumes) {
+				if (typeof entry === "string") {
+					// Short syntax `source:target[:mode]`. A colon-less entry is an
+					// anonymous volume; sources that look like paths are bind mounts.
+					const colonIndex = entry.indexOf(":");
+					if (colonIndex <= 0) continue;
+					const source = entry.slice(0, colonIndex).trim();
+					if (isNamedVolumeSource(source)) volumes.push(source);
+				} else if (entry && typeof entry === "object") {
+					// Long syntax `{ type: volume, source, target }`.
+					const long = entry as { type?: unknown; source?: unknown };
+					if (
+						long.type === "volume" &&
+						typeof long.source === "string" &&
+						isNamedVolumeSource(long.source)
+					) {
+						volumes.push(long.source);
+					}
+				}
+			}
+		}
+
+		children.push({
+			name,
+			image,
+			dbKind: classifyDbImage(image),
+			volumes: [...new Set(volumes)],
+		});
+	}
+	return children;
+};
+
+/**
+ * Whether a configured volume backup covers a compose named volume. Deployed
+ * compose volumes are usually prefixed with the stack/app name
+ * (`<appName>_<volume>`), so both the exact name and the prefixed form match.
+ */
+export const isComposeVolumeCovered = (
+	volumeName: string,
+	backedUpVolumeNames: readonly string[],
+): boolean =>
+	backedUpVolumeNames.some(
+		(backedUp) =>
+			backedUp === volumeName || backedUp.endsWith(`_${volumeName}`),
+	);

--- a/apps/dokploy/server/api/routers/backup-policy.ts
+++ b/apps/dokploy/server/api/routers/backup-policy.ts
@@ -2,6 +2,9 @@ import {
 	createBackupPolicy,
 	findBackupById,
 	findBackupPolicyById,
+	findComposeById,
+	loadDockerCompose,
+	loadDockerComposeRemote,
 	findLibsqlByBackupId,
 	findMariadbByBackupId,
 	findMongoByBackupId,
@@ -28,6 +31,12 @@ import {
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, inArray, or, type SQL, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
+import { parse } from "yaml";
+import { z } from "zod";
+import {
+	extractComposeChildren,
+	isComposeVolumeCovered,
+} from "@/lib/backup-coverage";
 import { createTRPCRouter, withPermission } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
 import {
@@ -45,6 +54,7 @@ import {
 	libsql,
 	mariadb,
 	mongo,
+	mounts,
 	mysql,
 	postgres,
 	projects,
@@ -107,9 +117,13 @@ interface CoverageService {
 	name: string;
 	appName: string | null;
 	serverId: string | null;
-	project: { id: string; name: string };
+	project: { id: string; name: string; logo: string | null };
 	environment: { id: string; name: string };
 	dumpCapable: boolean;
+	/** Whether the service has at least one named volume mount configured. */
+	hasVolumes: boolean;
+	/** Domains (applications/compose only) — used for the project favicon. */
+	domains: Array<{ host: string; https: boolean }>;
 	dumpBackups: CoverageBackupEntry[];
 	volumeBackups: CoverageBackupEntry[];
 }
@@ -612,7 +626,7 @@ export const backupPolicyRouter = createTRPCRouter({
 
 		const projectRows = await db.query.projects.findMany({
 			where: projectWhere,
-			columns: { projectId: true, name: true },
+			columns: { projectId: true, name: true, logo: true },
 			with: {
 				environments: {
 					where: environmentWhere,
@@ -621,6 +635,9 @@ export const backupPolicyRouter = createTRPCRouter({
 						applications: {
 							where: serviceFilter(applications.applicationId),
 							columns: { applicationId: true, ...serviceColumns },
+							with: {
+								domains: { columns: { host: true, https: true } },
+							},
 						},
 						postgres: {
 							where: serviceFilter(postgres.postgresId),
@@ -649,6 +666,9 @@ export const backupPolicyRouter = createTRPCRouter({
 						compose: {
 							where: serviceFilter(compose.composeId),
 							columns: { composeId: true, ...serviceColumns },
+							with: {
+								domains: { columns: { host: true, https: true } },
+							},
 						},
 					},
 				},
@@ -674,12 +694,20 @@ export const backupPolicyRouter = createTRPCRouter({
 							name: row.name as string,
 							appName: (row.appName as string) ?? null,
 							serverId: (row.serverId as string) ?? null,
-							project: { id: project.projectId, name: project.name },
+							project: {
+								id: project.projectId,
+								name: project.name,
+								logo: project.logo ?? null,
+							},
 							environment: {
 								id: environment.environmentId,
 								name: environment.name,
 							},
 							dumpCapable: DUMP_CAPABLE_TYPES.has(type),
+							hasVolumes: false,
+							domains:
+								(row.domains as Array<{ host: string; https: boolean }>) ??
+								[],
 							dumpBackups: [],
 							volumeBackups: [],
 						});
@@ -865,6 +893,126 @@ export const backupPolicyRouter = createTRPCRouter({
 			}
 		}
 
+		// --- Named volume mounts (drives the "databases & volumes" env filter) ---
+		const mountConditions: SQL[] = [];
+		if (idsByType.application.length)
+			mountConditions.push(
+				inArray(mounts.applicationId, idsByType.application),
+			);
+		if (idsByType.postgres.length)
+			mountConditions.push(inArray(mounts.postgresId, idsByType.postgres));
+		if (idsByType.mysql.length)
+			mountConditions.push(inArray(mounts.mysqlId, idsByType.mysql));
+		if (idsByType.mariadb.length)
+			mountConditions.push(inArray(mounts.mariadbId, idsByType.mariadb));
+		if (idsByType.mongo.length)
+			mountConditions.push(inArray(mounts.mongoId, idsByType.mongo));
+		if (idsByType.libsql.length)
+			mountConditions.push(inArray(mounts.libsqlId, idsByType.libsql));
+		if (idsByType.redis.length)
+			mountConditions.push(inArray(mounts.redisId, idsByType.redis));
+		if (idsByType.compose.length)
+			mountConditions.push(inArray(mounts.composeId, idsByType.compose));
+
+		if (mountConditions.length) {
+			const mountRows = await db.query.mounts.findMany({
+				where: and(eq(mounts.type, "volume"), or(...mountConditions)),
+				columns: {
+					applicationId: true,
+					postgresId: true,
+					mysqlId: true,
+					mariadbId: true,
+					mongoId: true,
+					libsqlId: true,
+					redisId: true,
+					composeId: true,
+				},
+			});
+			for (const row of mountRows) {
+				const serviceId =
+					row.applicationId ||
+					row.postgresId ||
+					row.mysqlId ||
+					row.mariadbId ||
+					row.mongoId ||
+					row.libsqlId ||
+					row.redisId ||
+					row.composeId;
+				if (!serviceId) continue;
+				const service = serviceById.get(serviceId);
+				if (service) service.hasVolumes = true;
+			}
+		}
+
 		return { services };
 	}),
+
+	// Children of a compose service, parsed from the compose file already on
+	// disk (never clones/fetches — the coverage tree lazy-loads this on
+	// expand). Same per-service authorization pattern as coverage/runNow.
+	// Parse failures degrade to `{ error }` instead of throwing so the Backup
+	// Center page never crashes on a malformed compose file.
+	composeChildren: withPermission("backup", "read")
+		.input(z.object({ composeId: z.string().min(1) }))
+		.query(async ({ input, ctx }) => {
+			await checkServicePermissionAndAccess(ctx, input.composeId, {
+				backup: ["read"],
+			});
+			const composeService = await findComposeById(input.composeId);
+			if (
+				composeService.environment.project.organizationId !==
+				ctx.session.activeOrganizationId
+			) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You are not allowed to access this compose",
+				});
+			}
+
+			let spec: unknown = null;
+			let error: string | null = null;
+			try {
+				if (composeService.sourceType === "raw") {
+					spec = parse(composeService.composeFile ?? "", {
+						maxAliasCount: 10000,
+					});
+				} else if (composeService.serverId) {
+					spec = await loadDockerComposeRemote(composeService);
+				} else {
+					spec = await loadDockerCompose(composeService);
+				}
+			} catch (parseError) {
+				error = `Could not parse compose file: ${errorMessage(parseError)}`;
+			}
+
+			let children = error ? [] : extractComposeChildren(spec);
+			if (!error && children.length === 0) {
+				error =
+					spec === null
+						? "Compose file not available yet — deploy this compose once to load its services"
+						: "Could not parse compose file: no services found";
+				children = [];
+			}
+
+			// Volume backups configured on this compose, to mark which named
+			// volumes are covered.
+			const volumeRows = await db.query.volumeBackups.findMany({
+				where: eq(volumeBackups.composeId, input.composeId),
+				columns: { volumeName: true },
+			});
+			const backedUpVolumeNames = volumeRows.map((row) => row.volumeName);
+
+			return {
+				error,
+				children: children.map((child) => ({
+					name: child.name,
+					image: child.image,
+					dbKind: child.dbKind,
+					volumes: child.volumes.map((volumeName) => ({
+						name: volumeName,
+						covered: isComposeVolumeCovered(volumeName, backedUpVolumeNames),
+					})),
+				})),
+			};
+		}),
 });


### PR DESCRIPTION
## Backup Center Coverage v2

Rebuilds the coverage section of the Backup Center as an expandable tree with four changes:

### 1. Tree structure with rollup badges
The flat "Project / environment" header-row table becomes an indented tree: **Project → Environment → Service → (compose children)** with chevron expand/collapse per node. Collapsed project/environment nodes show an orange **"⚠ N not covered"** badge when any descendant service lacks a backup, or a green check when everything visible underneath is covered. The per-service columns (Dump / Volume / Destinations / Last run / jump link) are unchanged. Expansion state is local component state.

### 2. Project icons
Project nodes reuse the `ProjectIcon` logo/favicon resolver shipped with the projects list (explicit logo wins, then domain favicons via `/api/favicon`, then a folder-icon fallback). The `backupPolicy.coverage` query now returns the project `logo` and each application/compose service's domains to drive it.

### 3. Environment filter (production-focused default)
A popover filter above the tree (consistent with the /deployments filter controls) with a tri-state per environment:
- **default** — `production` environments (same name convention as the backup-policy production preset) show all services; other environments show only databases (postgres/mysql/mariadb/mongo/redis/libsql) and services with named volumes — volume-less apps in non-prod are hidden;
- **all** — force everything in the environment visible;
- **hidden** — hide the environment entirely.

"Show all" / "Reset" affordances in the popover, and environments with filtered services show a subtle "(N hidden)" hint. The coverage query flags `hasVolumes` per service from its volume mounts.

### 4. Lazy-loaded compose children
Expanding a compose node fetches the new `backupPolicy.composeChildren` query (per-service `checkServicePermissionAndAccess` + org ownership check, mirroring coverage/runNow). It reuses the existing compose-file loaders (`loadDockerCompose` / `loadDockerComposeRemote` / raw `composeFile` parse) — no new YAML parser and no repo cloning — and returns each child container's service name, image, DB-image classification (postgres/mysql/mariadb/mongo/redis-family incl. valkey/dragonfly/keydb, libsql) and named volumes with per-volume backup-coverage status. Parse failures degrade to an inline "could not parse" row; the page never crashes.

### Notes
- No DB migration.
- Pure logic (DB-image classifier, default-filter predicate, compose child extraction, volume-coverage matching) extracted to `apps/dokploy/lib/backup-coverage.ts` with unit tests (`__test__/backup-policy/backup-coverage.test.ts`, 19 cases).
- Zod 4 input schema; react-query v5 (`isPending`).