### PR TITLE
feat(backup-center): verify bucket contents, browse and restore backups

### DIFF
--- a/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
+++ b/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
-	classifyDbImage,
+	buildBackupListPrefix,
 	type CoverageFacets,
+	classifyDbImage,
+	countBackupFiles,
 	DATABASE_SERVICE_TYPES,
 	EMPTY_COVERAGE_FACETS,
 	extractComposeChildren,
@@ -11,6 +13,7 @@ import {
 	isProductionEnvironment,
 	isServiceShownByDefault,
 	isServiceShownByFacets,
+	parseBackupTimestamp,
 } from "@/lib/backup-coverage";
 
 describe("classifyDbImage", () => {
@@ -371,5 +374,62 @@ describe("isComposeVolumeCovered", () => {
 		expect(isComposeVolumeCovered("db-data", [])).toBe(false);
 		expect(isComposeVolumeCovered("db-data", ["other"])).toBe(false);
 		expect(isComposeVolumeCovered("db-data", ["db-data-old"])).toBe(false);
+	});
+});
+
+describe("buildBackupListPrefix", () => {
+	it("appends a trailing slash to a bare prefix", () => {
+		expect(buildBackupListPrefix("backups")).toBe("backups/");
+		expect(buildBackupListPrefix("team/postgres")).toBe("team/postgres/");
+	});
+
+	it("strips surrounding whitespace and leading/trailing slashes", () => {
+		expect(buildBackupListPrefix("  backups  ")).toBe("backups/");
+		expect(buildBackupListPrefix("/backups/")).toBe("backups/");
+		expect(buildBackupListPrefix("///team/db///")).toBe("team/db/");
+	});
+
+	it("returns an empty string for an empty or slash-only prefix", () => {
+		expect(buildBackupListPrefix("")).toBe("");
+		expect(buildBackupListPrefix("   ")).toBe("");
+		expect(buildBackupListPrefix("/")).toBe("");
+	});
+});
+
+describe("parseBackupTimestamp", () => {
+	it("recovers the date from a dump file name", () => {
+		expect(
+			parseBackupTimestamp("2026-07-17T12-30-45-123Z.sql.gz")?.toISOString(),
+		).toBe("2026-07-17T12:30:45.123Z");
+		expect(
+			parseBackupTimestamp("2026-01-02T03-04-05-006Z.bson.gz")?.toISOString(),
+		).toBe("2026-01-02T03:04:05.006Z");
+	});
+
+	it("finds the timestamp even under a prefixed path", () => {
+		expect(
+			parseBackupTimestamp(
+				"team/db/2026-07-17T12-30-45-123Z.sql.gz",
+			)?.toISOString(),
+		).toBe("2026-07-17T12:30:45.123Z");
+	});
+
+	it("returns null when there is no recognizable timestamp", () => {
+		expect(parseBackupTimestamp("latest.sql.gz")).toBeNull();
+		expect(parseBackupTimestamp("")).toBeNull();
+		expect(parseBackupTimestamp("2026-07-17.sql.gz")).toBeNull();
+	});
+});
+
+describe("countBackupFiles", () => {
+	it("counts files and ignores directories", () => {
+		expect(
+			countBackupFiles([{ IsDir: false }, { IsDir: true }, { IsDir: false }]),
+		).toBe(2);
+	});
+
+	it("is zero for an empty or directory-only listing", () => {
+		expect(countBackupFiles([])).toBe(0);
+		expect(countBackupFiles([{ IsDir: true }, { IsDir: true }])).toBe(0);
 	});
 });

--- a/apps/dokploy/components/dashboard/backups/backup-browser-dialog.tsx
+++ b/apps/dokploy/components/dashboard/backups/backup-browser-dialog.tsx
@@ -1,0 +1,361 @@
+import {
+	DatabaseBackup,
+	FileArchive,
+	Loader2,
+	RotateCcw,
+	TriangleAlert,
+} from "lucide-react";
+import { useState } from "react";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { DialogAction } from "@/components/shared/dialog-action";
+import { DrawerLogs } from "@/components/shared/drawer-logs";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+	buildBackupListPrefix,
+	countBackupFiles,
+	parseBackupTimestamp,
+} from "@/lib/backup-coverage";
+import type { RouterOutputs } from "@/utils/api";
+import { api } from "@/utils/api";
+import { formatBytes } from "../database/backups/restore-backup";
+import { type LogLine, parseLogs } from "../docker/logs/utils";
+
+type BackupContext = RouterOutputs["backup"]["backupContext"];
+
+/** The subset of a coverage dump-backup entry the browser needs. */
+export interface BrowseableBackup {
+	backupId: string;
+	destinationName: string;
+	source: "policy" | "manual";
+	policyName?: string;
+}
+
+interface Props {
+	serviceName: string;
+	serverId: string | null;
+	dumpBackups: BrowseableBackup[];
+}
+
+/**
+ * Backup Center browser: lists the real backup files present in the destination
+ * bucket for a covered service (one section per backup config) and offers a
+ * double-confirmed restore per file. Everything is lazy — nothing is fetched
+ * until the dialog is opened.
+ */
+export const BackupBrowserDialog = ({
+	serviceName,
+	serverId,
+	dumpBackups,
+}: Props) => {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="size-8"
+					title="Browse backups in the bucket"
+				>
+					<DatabaseBackup className="size-4" />
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-2xl">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<DatabaseBackup className="size-5 text-muted-foreground" />
+						Backups · {serviceName}
+					</DialogTitle>
+					<DialogDescription>
+						Files actually present in the destination bucket. Restoring a file
+						overwrites the live database and cannot be undone.
+					</DialogDescription>
+				</DialogHeader>
+				<ScrollArea className="max-h-[60vh]">
+					<div className="flex flex-col gap-4 pr-3">
+						{dumpBackups.map((entry) => (
+							<BackupConfigFiles
+								key={entry.backupId}
+								entry={entry}
+								serverId={serverId}
+								enabled={open}
+							/>
+						))}
+					</div>
+				</ScrollArea>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+const BackupConfigFiles = ({
+	entry,
+	serverId,
+	enabled,
+}: {
+	entry: BrowseableBackup;
+	serverId: string | null;
+	enabled: boolean;
+}) => {
+	const {
+		data: context,
+		isPending: isContextPending,
+		error: contextError,
+	} = api.backup.backupContext.useQuery(
+		{ backupId: entry.backupId },
+		{ enabled },
+	);
+
+	const {
+		data: files = [],
+		isPending: isFilesPending,
+		isRefetching,
+		error: filesError,
+		refetch,
+	} = api.backup.listBackupFiles.useQuery(
+		{
+			destinationId: context?.destinationId ?? "",
+			search: context ? buildBackupListPrefix(context.prefix) : "",
+			serverId: serverId ?? "",
+		},
+		{ enabled: enabled && !!context?.destinationId },
+	);
+
+	const backupFiles = files.filter((file) => !file.IsDir);
+	const count = countBackupFiles(files);
+	const error = contextError ?? filesError;
+	const loading = isContextPending || (!!context && isFilesPending);
+
+	return (
+		<div className="rounded-lg border">
+			<div className="flex flex-wrap items-center justify-between gap-2 border-b bg-muted/40 px-3 py-2">
+				<div className="flex items-center gap-2">
+					<FileArchive className="size-4 text-muted-foreground" />
+					<span className="text-sm font-medium">
+						{entry.destinationName || "Destination"}
+					</span>
+					<Badge variant={entry.source === "policy" ? "blue" : "blank"}>
+						{entry.source === "policy"
+							? `Policy${entry.policyName ? ` · ${entry.policyName}` : ""}`
+							: "Manual"}
+					</Badge>
+					{context?.prefix ? (
+						<span className="truncate text-xs text-muted-foreground">
+							{context.prefix}
+						</span>
+					) : null}
+				</div>
+				<div className="flex items-center gap-2">
+					{!loading && !error ? (
+						count > 0 ? (
+							<Badge variant="green">{count} in bucket</Badge>
+						) : (
+							<Badge variant="orange" className="gap-1">
+								<TriangleAlert className="size-3" />
+								Nothing in bucket
+							</Badge>
+						)
+					) : null}
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-7 gap-1.5 text-xs"
+						disabled={!context?.destinationId || isRefetching}
+						onClick={() => refetch()}
+					>
+						<Loader2
+							className={isRefetching ? "size-3.5 animate-spin" : "hidden"}
+						/>
+						Refresh
+					</Button>
+				</div>
+			</div>
+
+			<div className="px-3 py-2">
+				{loading ? (
+					<span className="flex items-center gap-2 text-xs text-muted-foreground">
+						<Loader2 className="size-3.5 animate-spin" />
+						Checking the bucket…
+					</span>
+				) : error ? (
+					<AlertBlock type="error">
+						{error.message || "Could not read the destination bucket."}
+					</AlertBlock>
+				) : count === 0 ? (
+					<span className="text-xs text-muted-foreground">
+						This backup is configured, but no files were found under its prefix.
+						Run the backup to create one.
+					</span>
+				) : (
+					<div className="flex flex-col divide-y">
+						{backupFiles.map((file) => {
+							const timestamp = parseBackupTimestamp(file.Name);
+							return (
+								<div
+									key={file.Path}
+									className="flex flex-wrap items-center justify-between gap-2 py-2"
+								>
+									<div className="flex min-w-0 flex-col">
+										<span className="truncate text-sm">{file.Name}</span>
+										<span className="text-xs text-muted-foreground">
+											{formatBytes(file.Size)}
+											{timestamp ? ` · ${timestamp.toLocaleString()}` : ""}
+										</span>
+									</div>
+									{context?.canRestore ? (
+										<RestoreFileButton
+											context={context}
+											backupFile={file.Path}
+										/>
+									) : null}
+								</div>
+							);
+						})}
+						{count >= 100 ? (
+							<span className="py-2 text-xs text-muted-foreground">
+								Showing the first 100 files.
+							</span>
+						) : null}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};
+
+const RestoreFileButton = ({
+	context,
+	backupFile,
+}: {
+	context: BackupContext;
+	backupFile: string;
+}) => {
+	const [confirmStep, setConfirmStep] = useState(false);
+	const [confirmName, setConfirmName] = useState("");
+	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+	const [logs, setLogs] = useState<LogLine[]>([]);
+	const [isDeploying, setIsDeploying] = useState(false);
+
+	// The token the user must retype to confirm — the target database name.
+	const target = context.databaseName;
+
+	api.backup.restoreBackupWithLogs.useSubscription(
+		{
+			databaseId: context.databaseId,
+			databaseType: context.databaseType,
+			databaseName: context.databaseName,
+			backupFile,
+			destinationId: context.destinationId,
+			backupType: context.backupType,
+			metadata:
+				context.backupType === "compose"
+					? {
+							serviceName: context.serviceName ?? undefined,
+							...(context.metadata ?? {}),
+						}
+					: undefined,
+		},
+		{
+			enabled: isDeploying,
+			onData(log) {
+				if (!isDrawerOpen) setIsDrawerOpen(true);
+				if (log === "Restore completed successfully!") setIsDeploying(false);
+				setLogs((prev) => [...prev, ...parseLogs(log)]);
+			},
+			onError() {
+				setIsDeploying(false);
+			},
+		},
+	);
+
+	return (
+		<>
+			{/* Step 1: acknowledge the destructive overwrite. */}
+			<DialogAction
+				title="Restore this backup?"
+				description="This overwrites the live database with the contents of this backup file. The service must be running. This action cannot be undone."
+				type="destructive"
+				onClick={() => {
+					setConfirmName("");
+					setConfirmStep(true);
+				}}
+			>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-7 gap-1.5 text-xs"
+					disabled={isDeploying}
+				>
+					<RotateCcw className="size-3.5" />
+					Restore
+				</Button>
+			</DialogAction>
+
+			{/* Step 2: type-to-confirm the database name. */}
+			<Dialog open={confirmStep} onOpenChange={setConfirmStep}>
+				<DialogContent className="sm:max-w-md">
+					<DialogHeader>
+						<DialogTitle>Confirm restore</DialogTitle>
+						<DialogDescription>
+							Type{" "}
+							<span className="font-mono font-semibold text-foreground">
+								{target}
+							</span>{" "}
+							to confirm overwriting this database.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="grid gap-2">
+						<span className="truncate text-xs text-muted-foreground">
+							{backupFile}
+						</span>
+						<Input
+							value={confirmName}
+							onChange={(event) => setConfirmName(event.target.value)}
+							placeholder={target}
+						/>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setConfirmStep(false)}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							isLoading={isDeploying}
+							disabled={confirmName.trim() !== target || isDeploying}
+							onClick={() => {
+								setConfirmStep(false);
+								setLogs([]);
+								setIsDeploying(true);
+							}}
+						>
+							Restore
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<DrawerLogs
+				isOpen={isDrawerOpen}
+				onClose={() => {
+					setIsDrawerOpen(false);
+					setLogs([]);
+					setIsDeploying(false);
+				}}
+				filteredLogs={logs}
+			/>
+		</>
+	);
+};

--- a/apps/dokploy/components/dashboard/backups/coverage-table.tsx
+++ b/apps/dokploy/components/dashboard/backups/coverage-table.tsx
@@ -39,10 +39,8 @@ import {
 import { cn } from "@/lib/utils";
 import type { RouterOutputs } from "@/utils/api";
 import { api } from "@/utils/api";
-import {
-	getProjectFaviconUrls,
-	ProjectIcon,
-} from "../projects/project-icon";
+import { getProjectFaviconUrls, ProjectIcon } from "../projects/project-icon";
+import { BackupBrowserDialog } from "./backup-browser-dialog";
 import { CoverageFilters } from "./coverage-filters";
 import { ServiceTypeIcon } from "./service-type-icon";
 
@@ -327,8 +325,7 @@ export const CoverageTable = () => {
 						),
 				);
 				environment.hiddenCount =
-					environment.allServices.length -
-					environment.visibleServices.length;
+					environment.allServices.length - environment.visibleServices.length;
 				environment.uncoveredCount = environment.visibleServices.filter(
 					(service) => !isCovered(service),
 				).length;
@@ -408,10 +405,7 @@ export const CoverageTable = () => {
 														className="cursor-pointer bg-muted/40 hover:bg-muted/60"
 														onClick={() => toggle(`p:${project.id}`, true)}
 													>
-														<TableCell
-															colSpan={COLUMN_COUNT}
-															className="py-2"
-														>
+														<TableCell colSpan={COLUMN_COUNT} className="py-2">
 															<div className="flex items-center gap-2">
 																<ExpandChevron expanded={projectExpanded} />
 																<ProjectIcon
@@ -448,9 +442,7 @@ export const CoverageTable = () => {
 																			className="py-2 pl-8"
 																		>
 																			<div className="flex items-center gap-2">
-																				<ExpandChevron
-																					expanded={envExpanded}
-																				/>
+																				<ExpandChevron expanded={envExpanded} />
 																				<span className="text-sm">
 																					{environment.name}
 																				</span>
@@ -493,8 +485,7 @@ export const CoverageTable = () => {
 																				].find(
 																					(entry) => entry.lastRunStatus,
 																				)?.lastRunStatus;
-																				const notCovered =
-																					!isCovered(service);
+																				const notCovered = !isCovered(service);
 																				const composeKey = `c:${service.serviceId}`;
 																				const composeExpanded =
 																					service.type === "compose" &&
@@ -511,10 +502,7 @@ export const CoverageTable = () => {
 																							onClick={
 																								service.type === "compose"
 																									? () =>
-																											toggle(
-																												composeKey,
-																												false,
-																											)
+																											toggle(composeKey, false)
 																									: undefined
 																							}
 																						>
@@ -523,9 +511,7 @@ export const CoverageTable = () => {
 																									{service.type ===
 																										"compose" && (
 																										<ExpandChevron
-																											expanded={
-																												composeExpanded
-																											}
+																											expanded={composeExpanded}
 																										/>
 																									)}
 																									<ServiceTypeIcon
@@ -584,6 +570,33 @@ export const CoverageTable = () => {
 																								)}
 																							</TableCell>
 																							<TableCell className="text-right">
+																								{service.dumpBackups.length >
+																									0 && (
+																									<span
+																										className="mr-1 inline-flex"
+																										onClick={(event) =>
+																											event.stopPropagation()
+																										}
+																									>
+																										<BackupBrowserDialog
+																											serviceName={service.name}
+																											serverId={
+																												service.serverId
+																											}
+																											dumpBackups={service.dumpBackups.map(
+																												(entry) => ({
+																													backupId:
+																														entry.backupId,
+																													destinationName:
+																														entry.destinationName,
+																													source: entry.source,
+																													policyName:
+																														entry.policyName,
+																												}),
+																											)}
+																										/>
+																									</span>
+																								)}
 																								<Link
 																									href={`/dashboard/project/${project.id}/environment/${environment.id}`}
 																									className="inline-flex items-center text-muted-foreground hover:text-foreground"

--- a/apps/dokploy/lib/backup-coverage.ts
+++ b/apps/dokploy/lib/backup-coverage.ts
@@ -266,3 +266,39 @@ export const isComposeVolumeCovered = (
 		(backedUp) =>
 			backedUp === volumeName || backedUp.endsWith(`_${volumeName}`),
 	);
+
+// --- Backup Center: verifying real files in the destination bucket ---
+
+/**
+ * Build the `search` argument for `backup.listBackupFiles` that lists exactly
+ * the files stored under a backup's prefix. Mirrors the server-side
+ * `normalizeS3Path`: surrounding whitespace and leading/trailing slashes are
+ * stripped, then a trailing slash is appended so the listing targets the prefix
+ * as a directory. An empty prefix lists the bucket root.
+ */
+export const buildBackupListPrefix = (prefix: string): string => {
+	const normalized = prefix.trim().replace(/^\/+|\/+$/g, "");
+	return normalized ? `${normalized}/` : "";
+};
+
+/**
+ * Recover the backup timestamp from a dump file name. Backup files are written
+ * as `<ISO-with-`:`-and-`.`-replaced-by-`-`>.<ext>.gz` (see `getBackupTimestamp`),
+ * e.g. `2026-07-17T12-30-45-123Z.sql.gz`. `listBackupFiles` lists with
+ * `--no-modtime`, so the name is the only timestamp source. Returns null when
+ * the name carries no recognizable timestamp.
+ */
+export const parseBackupTimestamp = (fileName: string): Date | null => {
+	const match = fileName.match(
+		/(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z/,
+	);
+	if (!match) return null;
+	const iso = `${match[1]}T${match[2]}:${match[3]}:${match[4]}.${match[5]}Z`;
+	const date = new Date(iso);
+	return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/** Count the actual backup files (excluding directories) in an rclone listing. */
+export const countBackupFiles = (
+	files: ReadonlyArray<{ IsDir: boolean }>,
+): number => files.reduce((total, file) => (file.IsDir ? total : total + 1), 0);

--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -569,6 +569,78 @@ export const backupRouter = createTRPCRouter({
 			}
 		}),
 
+	// Lazy per-backup context for the Backup Center browser: everything the
+	// client needs to (a) list the files under this backup's prefix via
+	// `listBackupFiles` and (b) restore one of them via `restoreBackupWithLogs`,
+	// without exposing the destination credentials. Read-gated on the owning
+	// service; `canRestore` reflects the stricter restore permission so the UI
+	// can hide the restore affordance for members who lack it (the restore
+	// subscription re-checks it server-side regardless).
+	backupContext: withPermission("backup", "read")
+		.input(apiFindOneBackup)
+		.query(async ({ input, ctx }) => {
+			const backup = await findBackupById(input.backupId);
+			const serviceId =
+				backup.postgresId ||
+				backup.mysqlId ||
+				backup.mariadbId ||
+				backup.mongoId ||
+				backup.libsqlId ||
+				backup.composeId ||
+				"";
+			if (serviceId) {
+				await checkServicePermissionAndAccess(ctx, serviceId, {
+					backup: ["read"],
+				});
+			}
+
+			if (
+				backup.destination &&
+				backup.destination.organizationId !== ctx.session.activeOrganizationId
+			) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You don't have access to this destination.",
+				});
+			}
+
+			const serverId =
+				backup.postgres?.serverId ??
+				backup.mysql?.serverId ??
+				backup.mariadb?.serverId ??
+				backup.mongo?.serverId ??
+				backup.libsql?.serverId ??
+				backup.compose?.serverId ??
+				null;
+
+			let canRestore = false;
+			if (serviceId) {
+				try {
+					await checkServicePermissionAndAccess(ctx, serviceId, {
+						backup: ["restore"],
+					});
+					canRestore = true;
+				} catch {
+					canRestore = false;
+				}
+			}
+
+			return {
+				backupId: backup.backupId,
+				databaseId: serviceId,
+				backupType: backup.backupType,
+				databaseType: backup.databaseType,
+				databaseName: backup.database,
+				serviceName: backup.serviceName ?? null,
+				destinationId: backup.destinationId,
+				destinationName: backup.destination?.name ?? "",
+				prefix: backup.prefix,
+				serverId,
+				metadata: backup.metadata ?? null,
+				canRestore,
+			};
+		}),
+
 	restoreBackupWithLogs: protectedProcedure
 		.meta({
 			openapi: {


### PR DESCRIPTION
## What

Extends the Backup Center coverage tree so a covered service no longer just *claims* coverage — you can verify the real files sitting in the destination bucket, browse them, and restore one, all lazily and per-service.

### Verify + Browse
- Each covered database/compose service gets a **Browse backups** button (database-backup icon) in its row. Opening the dialog lazily fetches, per backup config, the actual files under the backup's `prefix` in the bucket (reusing the existing `backup.listBackupFiles` rclone path so counts match reality). Nothing is fetched until the dialog opens — no eager per-row calls.
- Shows an **`N in bucket`** badge per config, a muted **"configured, but nothing in bucket"** hint when a backup exists but has no files yet, and a graceful error block when the bucket can't be read. Each file lists name, size, and date (parsed from the timestamped filename, since `listBackupFiles` runs with `--no-modtime`). A Refresh affordance re-lists on demand.

### Restore
- Each listed file has a **Restore** button with **double confirmation**: (1) a destructive confirm dialog explaining it overwrites the live database, then (2) a type-to-confirm dialog requiring the database name — mirroring Dokploy's delete pattern. On confirm it reuses the existing `backup.restoreBackupWithLogs` subscription + `DrawerLogs`, pre-filling `databaseId`/`databaseType`/`databaseName`/`destinationId`/`backupFile` (and compose service metadata) from the row so the user picks nothing.
- Restore is gated on the `backup:restore` permission: the UI hides the button for members without it, and the restore subscription re-checks it server-side regardless.

## How
- **Additive tRPC endpoint** `backup.backupContext` (read-gated on the owning service): returns the destination id, prefix, serverId, restore inputs, and a `canRestore` flag for a backup, without exposing destination credentials. No new endpoints beyond this — verify/browse/restore reuse `listBackupFiles` and `restoreBackupWithLogs`.
- **No migration.**
- New pure helpers in `apps/dokploy/lib/backup-coverage.ts` (`buildBackupListPrefix`, `parseBackupTimestamp`, `countBackupFiles`) with vitest coverage — 34 tests pass (26 existing + 8 new).

## Scope / left out
- Verify/browse/restore covers **database dump backups** (postgres/mysql/mariadb/mongo/libsql) and **compose DB backups**. **Volume backups are intentionally left out** — they use a separate storage layout and restore flow (`restore-volume-backups.tsx`); volume-only services (apps/redis) get no Browse button. This keeps the change scoped and low-risk; volume verify/restore can be a follow-up.

## Verification
- `pnpm --filter=dokploy typecheck` — clean
- `pnpm --filter=dokploy test __test__/backup-policy/backup-coverage.test.ts` — 34 passing
- biome check — clean

Filters/facets untouched; the lazy `enabled: open` pattern matches the existing compose-children lazy load.