### PR TITLE
feat(backup-center): tabbed layout with search, activity feed and server scoping

### DIFF
--- a/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
+++ b/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
@@ -6,6 +6,7 @@ import {
 	countBackupFiles,
 	DATABASE_SERVICE_TYPES,
 	EMPTY_COVERAGE_FACETS,
+	extractBackupArtifactPath,
 	extractComposeChildren,
 	hasExplicitFacets,
 	isComposeVolumeCovered,
@@ -14,6 +15,8 @@ import {
 	isServiceShownByDefault,
 	isServiceShownByFacets,
 	parseBackupTimestamp,
+	serviceMatchesSearch,
+	textMatchesQuery,
 } from "@/lib/backup-coverage";
 
 describe("classifyDbImage", () => {
@@ -431,5 +434,79 @@ describe("countBackupFiles", () => {
 	it("is zero for an empty or directory-only listing", () => {
 		expect(countBackupFiles([])).toBe(0);
 		expect(countBackupFiles([{ IsDir: true }, { IsDir: true }])).toBe(0);
+	});
+});
+
+describe("textMatchesQuery", () => {
+	it("matches case-insensitively and ignores surrounding whitespace", () => {
+		expect(textMatchesQuery("Production API", "api")).toBe(true);
+		expect(textMatchesQuery("Production API", "  PROD ")).toBe(true);
+		expect(textMatchesQuery("Production API", "staging")).toBe(false);
+	});
+
+	it("treats an empty or whitespace-only query as matching everything", () => {
+		expect(textMatchesQuery("anything", "")).toBe(true);
+		expect(textMatchesQuery("anything", "   ")).toBe(true);
+	});
+});
+
+describe("serviceMatchesSearch", () => {
+	const service = {
+		name: "orders-db",
+		projectName: "Checkout",
+		environmentName: "production",
+	};
+
+	it("matches against the service, project, or environment name", () => {
+		expect(serviceMatchesSearch(service, "orders")).toBe(true);
+		expect(serviceMatchesSearch(service, "checkout")).toBe(true);
+		expect(serviceMatchesSearch(service, "prod")).toBe(true);
+	});
+
+	it("returns false when nothing matches and true for an empty query", () => {
+		expect(serviceMatchesSearch(service, "payments")).toBe(false);
+		expect(serviceMatchesSearch(service, "  ")).toBe(true);
+	});
+});
+
+describe("extractBackupArtifactPath", () => {
+	it("pulls the artifact path from a run log for each backup kind", () => {
+		expect(
+			extractBackupArtifactPath(
+				"[date] Streaming...\nUploaded to team/db/2026-07-17T12-30-45-123Z.sql.gz\nBackup done",
+			),
+		).toBe("team/db/2026-07-17T12-30-45-123Z.sql.gz");
+		expect(
+			extractBackupArtifactPath("copied :s3:bucket/mongo/dump.bson.gz ok"),
+		).toBe(":s3:bucket/mongo/dump.bson.gz");
+		expect(
+			extractBackupArtifactPath("Transferred: data-2026.tar.gz done"),
+		).toBe("data-2026.tar.gz");
+		expect(extractBackupArtifactPath("wrote volume-data.tar")).toBe(
+			"volume-data.tar",
+		);
+	});
+
+	it("returns the last artifact when several appear", () => {
+		expect(extractBackupArtifactPath("old/a.sql.gz\nnew/b.sql.gz")).toBe(
+			"new/b.sql.gz",
+		);
+	});
+
+	it("strips surrounding quotes and trailing punctuation", () => {
+		expect(extractBackupArtifactPath('to "team/db/x.sql.gz".')).toBe(
+			"team/db/x.sql.gz",
+		);
+	});
+
+	it("returns null when no artifact path is present", () => {
+		expect(
+			extractBackupArtifactPath(
+				"[date] Streaming backup to S3...\n[date] Upload completed successfully",
+			),
+		).toBeNull();
+		expect(extractBackupArtifactPath("")).toBeNull();
+		expect(extractBackupArtifactPath(null)).toBeNull();
+		expect(extractBackupArtifactPath(undefined)).toBeNull();
 	});
 });

--- a/apps/dokploy/components/dashboard/backups/activity-tab.tsx
+++ b/apps/dokploy/components/dashboard/backups/activity-tab.tsx
@@ -1,0 +1,224 @@
+import copy from "copy-to-clipboard";
+import { Activity, Copy, FolderClosed, HardDrive, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import type { RouterOutputs } from "@/utils/api";
+import { api } from "@/utils/api";
+import { ShowDeploymentsModal } from "../application/deployments/show-deployments-modal";
+import { ServiceTypeIcon } from "./service-type-icon";
+
+type BackupRun =
+	RouterOutputs["backupPolicy"]["recentActivity"]["runs"][number];
+
+const statusDotClass = (status: string) => {
+	switch (status) {
+		case "done":
+			return "bg-green-500";
+		case "error":
+			return "bg-red-500";
+		case "running":
+			return "bg-blue-500 animate-pulse";
+		case "cancelled":
+			return "bg-muted-foreground/60";
+		default:
+			return "bg-muted-foreground/40";
+	}
+};
+
+const formatDate = (iso: string | null) => {
+	if (!iso) return "—";
+	const date = new Date(iso);
+	return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+};
+
+const ArtifactCell = ({ run }: { run: BackupRun }) => {
+	if (run.artifactPath) {
+		return (
+			<button
+				type="button"
+				className="flex max-w-[22rem] items-center gap-1.5 text-left text-xs text-muted-foreground hover:text-foreground"
+				title={`${run.artifactPath} (click to copy)`}
+				onClick={() => {
+					copy(run.artifactPath ?? "");
+					toast.success("Artifact path copied to clipboard");
+				}}
+			>
+				<span className="truncate font-mono">{run.artifactPath}</span>
+				<Copy className="size-3 shrink-0" />
+			</button>
+		);
+	}
+	if (run.prefix) {
+		return (
+			<span
+				className="flex max-w-[22rem] items-center gap-1.5 text-xs text-muted-foreground"
+				title="Destination prefix (exact file not recorded in this run's log)"
+			>
+				<FolderClosed className="size-3 shrink-0" />
+				<span className="truncate font-mono">{run.prefix}</span>
+			</span>
+		);
+	}
+	return <span className="text-muted-foreground">—</span>;
+};
+
+const RunRow = ({ run }: { run: BackupRun }) => {
+	const modalType = run.kind === "volume" ? "volumeBackup" : "backup";
+	const modalId = run.kind === "volume" ? run.volumeBackupId : run.backupId;
+	return (
+		<TableRow>
+			<TableCell>
+				<div className="flex items-center gap-2">
+					{run.serviceType ? (
+						<ServiceTypeIcon type={run.serviceType} />
+					) : (
+						<HardDrive className="size-4 text-muted-foreground" />
+					)}
+					<div className="flex flex-col">
+						<span className="text-sm font-medium">{run.serviceName}</span>
+						<span className="text-xs text-muted-foreground">
+							{run.projectName}
+							{run.environmentName ? ` · ${run.environmentName}` : ""}
+							{run.kind === "volume" ? " · volume" : ""}
+						</span>
+					</div>
+				</div>
+			</TableCell>
+			<TableCell>
+				<span className="text-sm text-muted-foreground">
+					{run.destinationName || "—"}
+				</span>
+			</TableCell>
+			<TableCell>
+				<Badge variant={run.source === "policy" ? "blue" : "blank"}>
+					{run.source === "policy"
+						? `Policy${run.policyName ? ` · ${run.policyName}` : ""}`
+						: "Manual"}
+				</Badge>
+			</TableCell>
+			<TableCell>
+				<span className="flex items-center gap-2 text-sm">
+					<span
+						className={cn(
+							"inline-block size-2 rounded-full",
+							statusDotClass(run.status),
+						)}
+					/>
+					<span className="capitalize text-muted-foreground">{run.status}</span>
+				</span>
+			</TableCell>
+			<TableCell>
+				<span className="text-xs text-muted-foreground">
+					{formatDate(run.createdAt)}
+				</span>
+			</TableCell>
+			<TableCell>
+				<ArtifactCell run={run} />
+			</TableCell>
+			<TableCell className="text-right">
+				{modalId ? (
+					<ShowDeploymentsModal
+						id={modalId}
+						type={modalType}
+						serverId={run.serverId ?? undefined}
+					>
+						<Button variant="ghost" size="sm" className="h-7 text-xs">
+							Open log
+						</Button>
+					</ShowDeploymentsModal>
+				) : null}
+			</TableCell>
+		</TableRow>
+	);
+};
+
+export const ActivityTab = ({ serverId }: { serverId?: string }) => {
+	const [limit, setLimit] = useState(50);
+	const { data, isPending, isFetching } =
+		api.backupPolicy.recentActivity.useQuery({ limit, serverId });
+
+	const runs = data?.runs ?? [];
+
+	return (
+		<Card className="bg-background">
+			<CardHeader>
+				<CardTitle className="flex flex-row items-center gap-2 text-xl">
+					<Activity className="size-6 text-muted-foreground" />
+					Activity
+				</CardTitle>
+				<CardDescription>
+					Recent backup runs on the selected server. Each row links to the full
+					run log; the artifact column shows the uploaded file (or the
+					destination prefix when the run log did not record an exact path).
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="flex flex-col gap-4">
+				{isPending ? (
+					<div className="flex min-h-[20vh] items-center justify-center">
+						<Loader2 className="size-6 animate-spin text-muted-foreground" />
+					</div>
+				) : runs.length === 0 ? (
+					<div className="flex min-h-[20vh] flex-col items-center justify-center gap-3">
+						<Activity className="size-8 text-muted-foreground" />
+						<span className="text-base text-muted-foreground">
+							No backup runs yet on this server
+						</span>
+					</div>
+				) : (
+					<>
+						<div className="overflow-x-auto">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Service</TableHead>
+										<TableHead>Destination</TableHead>
+										<TableHead>Source</TableHead>
+										<TableHead>Status</TableHead>
+										<TableHead>Started</TableHead>
+										<TableHead>Artifact</TableHead>
+										<TableHead />
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{runs.map((run) => (
+										<RunRow key={run.deploymentId} run={run} />
+									))}
+								</TableBody>
+							</Table>
+						</div>
+						{data?.nextOffset !== null && data?.nextOffset !== undefined ? (
+							<div className="flex justify-center">
+								<Button
+									variant="outline"
+									size="sm"
+									isLoading={isFetching}
+									onClick={() => setLimit((current) => current + 50)}
+								>
+									Load more
+								</Button>
+							</div>
+						) : null}
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+};

--- a/apps/dokploy/components/dashboard/backups/coverage-table.tsx
+++ b/apps/dokploy/components/dashboard/backups/coverage-table.tsx
@@ -5,6 +5,7 @@ import {
 	ExternalLink,
 	Folder,
 	Loader2,
+	Search,
 	TableProperties,
 	TriangleAlert,
 	X,
@@ -20,6 +21,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
 	Table,
 	TableBody,
@@ -35,6 +37,7 @@ import {
 	isProductionEnvironment,
 	isServiceShownByFacets,
 	normalizeEnvironmentName,
+	serviceMatchesSearch,
 } from "@/lib/backup-coverage";
 import { cn } from "@/lib/utils";
 import type { RouterOutputs } from "@/utils/api";
@@ -225,7 +228,7 @@ const ComposeChildRows = ({ composeId }: { composeId: string }) => {
 	);
 };
 
-export const CoverageTable = () => {
+export const CoverageTable = ({ serverId }: { serverId?: string }) => {
 	const { data, isPending } = api.backupPolicy.coverage.useQuery();
 
 	// Expansion overrides keyed by node id; absent = the node-type default
@@ -234,6 +237,7 @@ export const CoverageTable = () => {
 		Record<string, boolean>
 	>({});
 	const [facets, setFacets] = useState<CoverageFacets>(EMPTY_COVERAGE_FACETS);
+	const [search, setSearch] = useState("");
 
 	const isExpanded = (key: string, fallback: boolean) =>
 		expandOverrides[key] ?? fallback;
@@ -271,6 +275,22 @@ export const CoverageTable = () => {
 			}
 		>();
 		for (const service of data?.services ?? []) {
+			// The server facet and the free-text search fully remove services from
+			// the tree (they do not contribute to the facet "(N hidden)" hint).
+			// undefined serverId means the local Dokploy server (null serverId).
+			if ((service.serverId ?? null) !== (serverId ?? null)) continue;
+			if (
+				!serviceMatchesSearch(
+					{
+						name: service.name,
+						projectName: service.project.name,
+						environmentName: service.environment.name,
+					},
+					search,
+				)
+			) {
+				continue;
+			}
 			let project = projects.get(service.project.id);
 			if (!project) {
 				project = {
@@ -340,7 +360,7 @@ export const CoverageTable = () => {
 			}
 		}
 		return result;
-	}, [data, facets]);
+	}, [data, facets, serverId, search]);
 
 	return (
 		<Card className="bg-background">
@@ -369,6 +389,15 @@ export const CoverageTable = () => {
 					</div>
 				) : (
 					<>
+						<div className="relative">
+							<Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								value={search}
+								onChange={(event) => setSearch(event.target.value)}
+								placeholder="Search by project, service or environment..."
+								className="pl-8"
+							/>
+						</div>
 						<CoverageFilters
 							environmentNames={environmentNames}
 							facets={facets}
@@ -377,7 +406,9 @@ export const CoverageTable = () => {
 						{tree.length === 0 ? (
 							<div className="flex min-h-[10vh] flex-col items-center justify-center gap-2">
 								<span className="text-sm text-muted-foreground">
-									Everything is hidden by the current filters.
+									{search.trim()
+										? "No services match your search and filters."
+										: "Everything is hidden by the current filters."}
 								</span>
 							</div>
 						) : (

--- a/apps/dokploy/components/dashboard/backups/show-backup-center.tsx
+++ b/apps/dokploy/components/dashboard/backups/show-backup-center.tsx
@@ -1,13 +1,58 @@
+import { useRouter } from "next/router";
+import { ServerFilter } from "@/components/shared/server-filter";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ActivityTab } from "./activity-tab";
 import { BackupPoliciesSection } from "./backup-policies-section";
 import { CoverageTable } from "./coverage-table";
 import { InstanceBackupCard } from "./instance-backup-card";
 
+const TABS = ["policies", "instance", "coverage", "activity"] as const;
+type BackupTab = (typeof TABS)[number];
+
 export const ShowBackupCenter = () => {
+	const router = useRouter();
+	const tab: BackupTab =
+		typeof router.query.tab === "string" &&
+		(TABS as readonly string[]).includes(router.query.tab)
+			? (router.query.tab as BackupTab)
+			: "policies";
+
+	const setTab = (value: string) => {
+		router.replace(
+			{ pathname: router.pathname, query: { ...router.query, tab: value } },
+			undefined,
+			{ shallow: true },
+		);
+	};
+
 	return (
 		<div className="mx-auto flex w-full max-w-6xl flex-col gap-4">
-			<BackupPoliciesSection />
-			<InstanceBackupCard />
-			<CoverageTable />
+			<Tabs value={tab} onValueChange={setTab} className="w-full">
+				<TabsList>
+					<TabsTrigger value="policies">Policies</TabsTrigger>
+					<TabsTrigger value="instance">Instance</TabsTrigger>
+					<TabsTrigger value="coverage">Coverage</TabsTrigger>
+					<TabsTrigger value="activity">Activity</TabsTrigger>
+				</TabsList>
+				<TabsContent value="policies" className="mt-4">
+					<BackupPoliciesSection />
+				</TabsContent>
+				<TabsContent value="instance" className="mt-4">
+					<InstanceBackupCard />
+				</TabsContent>
+				{/* Coverage and Activity are scoped by the "Viewing server" selector;
+				    Policies and Instance are org-wide and never server-scoped. */}
+				<TabsContent value="coverage" className="mt-4">
+					<ServerFilter>
+						{(serverId) => <CoverageTable serverId={serverId} />}
+					</ServerFilter>
+				</TabsContent>
+				<TabsContent value="activity" className="mt-4">
+					<ServerFilter>
+						{(serverId) => <ActivityTab serverId={serverId} />}
+					</ServerFilter>
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 };

--- a/apps/dokploy/lib/backup-coverage.ts
+++ b/apps/dokploy/lib/backup-coverage.ts
@@ -302,3 +302,56 @@ export const parseBackupTimestamp = (fileName: string): Date | null => {
 export const countBackupFiles = (
 	files: ReadonlyArray<{ IsDir: boolean }>,
 ): number => files.reduce((total, file) => (file.IsDir ? total : total + 1), 0);
+
+// --- Backup Center: coverage-tree search ---
+
+/**
+ * Case-insensitive, whitespace-trimmed substring match. An empty query matches
+ * everything, so callers can pass the raw search box value unconditionally.
+ */
+export const textMatchesQuery = (text: string, query: string): boolean => {
+	const normalized = query.trim().toLowerCase();
+	if (normalized === "") return true;
+	return text.toLowerCase().includes(normalized);
+};
+
+/**
+ * Whether a coverage service is surfaced by the free-text coverage search. The
+ * query matches against the service name and its owning project/environment
+ * names (compose children are matched separately, as they load lazily).
+ */
+export const serviceMatchesSearch = (
+	fields: { name: string; projectName: string; environmentName: string },
+	query: string,
+): boolean => {
+	if (query.trim() === "") return true;
+	return (
+		textMatchesQuery(fields.name, query) ||
+		textMatchesQuery(fields.projectName, query) ||
+		textMatchesQuery(fields.environmentName, query)
+	);
+};
+
+// --- Backup Center: activity log parsing ---
+
+// A path/key ending in a known backup artifact extension. `[^\s"'`()]+` walks
+// back to the previous separator so the whole path (including any `bucket/` or
+// `:s3:` remote prefix) is captured. `tar.gz` precedes bare `tar` so a gzipped
+// tarball is not truncated.
+const BACKUP_ARTIFACT_PATTERN =
+	/[^\s"'`()]+\.(?:sql\.gz|bson\.gz|dump\.gz|tar\.gz|zip|tar)/gi;
+
+/**
+ * Extract the uploaded artifact path from a backup run log, or null when none
+ * is present (database/compose dump runs do not echo the path on success). The
+ * last match wins — it is the final upload line for the run.
+ */
+export const extractBackupArtifactPath = (
+	log: string | null | undefined,
+): string | null => {
+	if (!log) return null;
+	const matches = log.match(BACKUP_ARTIFACT_PATTERN);
+	if (!matches || matches.length === 0) return null;
+	const last = matches[matches.length - 1]?.replace(/[.,;]+$/, "");
+	return last || null;
+};

--- a/apps/dokploy/server/api/routers/backup-policy.ts
+++ b/apps/dokploy/server/api/routers/backup-policy.ts
@@ -1,16 +1,17 @@
+import { existsSync, promises as fsPromises } from "node:fs";
 import {
 	createBackupPolicy,
 	findBackupById,
 	findBackupPolicyById,
 	findComposeById,
-	loadDockerCompose,
-	loadDockerComposeRemote,
 	findLibsqlByBackupId,
 	findMariadbByBackupId,
 	findMongoByBackupId,
 	findMySqlByBackupId,
 	findPostgresByBackupId,
 	keepLatestNBackups,
+	loadDockerCompose,
+	loadDockerComposeRemote,
 	removeBackupPolicy,
 	runLibsqlBackup,
 	runMariadbBackup,
@@ -29,11 +30,12 @@ import {
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq, inArray, or, type SQL, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, or, type SQL, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { parse } from "yaml";
 import { z } from "zod";
 import {
+	extractBackupArtifactPath,
 	extractComposeChildren,
 	isComposeVolumeCovered,
 } from "@/lib/backup-coverage";
@@ -87,6 +89,19 @@ const DUMP_CAPABLE_TYPES: ReadonlySet<CoverageServiceType> = new Set([
 
 const errorMessage = (error: unknown) =>
 	error instanceof Error ? error.message : String(error);
+
+// Read the tail of a LOCAL deployment log for artifact-path extraction. Remote
+// logs are skipped (each would need an SSH round-trip); missing/rotated files
+// degrade to null rather than throwing.
+const readLocalLogTail = async (logPath: string): Promise<string | null> => {
+	try {
+		if (!logPath || logPath === "." || !existsSync(logPath)) return null;
+		const content = await fsPromises.readFile(logPath, "utf-8");
+		return content.split("\n").slice(-80).join("\n");
+	} catch {
+		return null;
+	}
+};
 
 // Mirrors the (unexported) `buildServiceFilter` in the project router: restrict
 // a service relation to the ids a non-privileged member may access.
@@ -706,8 +721,7 @@ export const backupPolicyRouter = createTRPCRouter({
 							dumpCapable: DUMP_CAPABLE_TYPES.has(type),
 							hasVolumes: false,
 							domains:
-								(row.domains as Array<{ host: string; https: boolean }>) ??
-								[],
+								(row.domains as Array<{ host: string; https: boolean }>) ?? [],
 							dumpBackups: [],
 							volumeBackups: [],
 						});
@@ -1013,6 +1027,332 @@ export const backupPolicyRouter = createTRPCRouter({
 						covered: isComposeVolumeCovered(volumeName, backedUpVolumeNames),
 					})),
 				})),
+			};
+		}),
+
+	// Recent backup + volume-backup runs across the organization, derived from
+	// the deployment rows each run persists (no new table). Permission-filtered
+	// for non-owner/admin members exactly like `coverage`, and scoped to one
+	// server (the "Viewing server" facet — undefined means the local Dokploy
+	// server). The artifact path is best-effort parsed from the run log tail for
+	// LOCAL runs only (remote logs would each need an SSH round-trip), falling
+	// back to the configured prefix folder.
+	recentActivity: withPermission("backup", "read")
+		.input(
+			z.object({
+				limit: z.number().min(1).max(100).default(50),
+				offset: z.number().min(0).default(0),
+				serverId: z.string().optional(),
+			}),
+		)
+		.query(async ({ input, ctx }) => {
+			const organizationId = ctx.session.activeOrganizationId;
+			const isPrivileged =
+				ctx.user.role === "owner" || ctx.user.role === "admin";
+			const empty = { runs: [], nextOffset: null as number | null };
+
+			let accessedProjects: string[] = [];
+			let accessedEnvironments: string[] = [];
+			let accessedServices: string[] = [];
+			if (!isPrivileged) {
+				const member = await findMemberByUserId(ctx.user.id, organizationId);
+				accessedProjects = member.accessedProjects;
+				accessedEnvironments = member.accessedEnvironments;
+				accessedServices = member.accessedServices;
+				if (accessedProjects.length === 0) return empty;
+			}
+
+			const projectWhere = isPrivileged
+				? eq(projects.organizationId, organizationId)
+				: and(
+						sql`${projects.projectId} IN (${sql.join(
+							accessedProjects.map((projectId) => sql`${projectId}`),
+							sql`, `,
+						)})`,
+						eq(projects.organizationId, organizationId),
+					);
+			const environmentWhere = isPrivileged
+				? undefined
+				: accessedEnvironments.length === 0
+					? sql`false`
+					: sql`${environments.environmentId} IN (${sql.join(
+							accessedEnvironments.map((envId) => sql`${envId}`),
+							sql`, `,
+						)})`;
+			const serviceFilter = (fieldName: AnyPgColumn) =>
+				isPrivileged
+					? undefined
+					: buildServiceFilter(fieldName, accessedServices);
+
+			const serviceColumns = { name: true, serverId: true } as const;
+			const projectRows = await db.query.projects.findMany({
+				where: projectWhere,
+				columns: { projectId: true, name: true },
+				with: {
+					environments: {
+						where: environmentWhere,
+						columns: { environmentId: true, name: true },
+						with: {
+							applications: {
+								where: serviceFilter(applications.applicationId),
+								columns: { applicationId: true, ...serviceColumns },
+							},
+							postgres: {
+								where: serviceFilter(postgres.postgresId),
+								columns: { postgresId: true, ...serviceColumns },
+							},
+							mysql: {
+								where: serviceFilter(mysql.mysqlId),
+								columns: { mysqlId: true, ...serviceColumns },
+							},
+							mariadb: {
+								where: serviceFilter(mariadb.mariadbId),
+								columns: { mariadbId: true, ...serviceColumns },
+							},
+							mongo: {
+								where: serviceFilter(mongo.mongoId),
+								columns: { mongoId: true, ...serviceColumns },
+							},
+							libsql: {
+								where: serviceFilter(libsql.libsqlId),
+								columns: { libsqlId: true, ...serviceColumns },
+							},
+							redis: {
+								where: serviceFilter(redis.redisId),
+								columns: { redisId: true, ...serviceColumns },
+							},
+							compose: {
+								where: serviceFilter(compose.composeId),
+								columns: { composeId: true, ...serviceColumns },
+							},
+						},
+					},
+				},
+			});
+
+			interface ServiceMeta {
+				type: CoverageServiceType;
+				name: string;
+				serverId: string | null;
+				projectName: string;
+				environmentName: string;
+			}
+			const serviceMetaById = new Map<string, ServiceMeta>();
+			for (const project of projectRows) {
+				for (const environment of project.environments) {
+					const record = environment as Record<string, unknown>;
+					for (const type of COVERAGE_SERVICE_TYPES) {
+						const rows = record[RELATION_KEY_BY_TYPE[type]] as
+							| Array<Record<string, unknown>>
+							| undefined;
+						if (!rows) continue;
+						for (const row of rows) {
+							serviceMetaById.set(row[ID_COLUMN_BY_TYPE[type]] as string, {
+								type,
+								name: row.name as string,
+								serverId: (row.serverId as string) ?? null,
+								projectName: project.name,
+								environmentName: environment.name,
+							});
+						}
+					}
+				}
+			}
+			if (serviceMetaById.size === 0) return empty;
+			const serviceIds = Array.from(serviceMetaById.keys());
+
+			interface RunMeta {
+				serviceId: string;
+				source: "policy" | "manual";
+				policyName: string | null;
+				destinationName: string;
+				prefix: string;
+			}
+			const backupMetaById = new Map<string, RunMeta>();
+			const volumeMetaById = new Map<string, RunMeta>();
+
+			// Service ids are unique nanoids across types, so the same id list is
+			// safe to test against every polymorphic FK column.
+			const backupRows = await db.query.backups.findMany({
+				where: or(
+					inArray(backups.postgresId, serviceIds),
+					inArray(backups.mysqlId, serviceIds),
+					inArray(backups.mariadbId, serviceIds),
+					inArray(backups.mongoId, serviceIds),
+					inArray(backups.libsqlId, serviceIds),
+					inArray(backups.composeId, serviceIds),
+				),
+				columns: {
+					backupId: true,
+					prefix: true,
+					backupPolicyId: true,
+					postgresId: true,
+					mysqlId: true,
+					mariadbId: true,
+					mongoId: true,
+					libsqlId: true,
+					composeId: true,
+				},
+				with: {
+					destination: { columns: { name: true } },
+					backupPolicy: { columns: { name: true } },
+				},
+			});
+			for (const row of backupRows) {
+				const serviceId =
+					row.postgresId ||
+					row.mysqlId ||
+					row.mariadbId ||
+					row.mongoId ||
+					row.libsqlId ||
+					row.composeId;
+				if (!serviceId || !serviceMetaById.has(serviceId)) continue;
+				backupMetaById.set(row.backupId, {
+					serviceId,
+					source: row.backupPolicyId ? "policy" : "manual",
+					policyName: row.backupPolicy?.name ?? null,
+					destinationName: row.destination?.name ?? "",
+					prefix: row.prefix,
+				});
+			}
+
+			const volumeRows = await db.query.volumeBackups.findMany({
+				where: or(
+					inArray(volumeBackups.applicationId, serviceIds),
+					inArray(volumeBackups.postgresId, serviceIds),
+					inArray(volumeBackups.mysqlId, serviceIds),
+					inArray(volumeBackups.mariadbId, serviceIds),
+					inArray(volumeBackups.mongoId, serviceIds),
+					inArray(volumeBackups.libsqlId, serviceIds),
+					inArray(volumeBackups.redisId, serviceIds),
+					inArray(volumeBackups.composeId, serviceIds),
+				),
+				columns: {
+					volumeBackupId: true,
+					prefix: true,
+					backupPolicyId: true,
+					applicationId: true,
+					postgresId: true,
+					mysqlId: true,
+					mariadbId: true,
+					mongoId: true,
+					libsqlId: true,
+					redisId: true,
+					composeId: true,
+				},
+				with: {
+					destination: { columns: { name: true } },
+					backupPolicy: { columns: { name: true } },
+				},
+			});
+			for (const row of volumeRows) {
+				const serviceId =
+					row.applicationId ||
+					row.postgresId ||
+					row.mysqlId ||
+					row.mariadbId ||
+					row.mongoId ||
+					row.libsqlId ||
+					row.redisId ||
+					row.composeId;
+				if (!serviceId || !serviceMetaById.has(serviceId)) continue;
+				volumeMetaById.set(row.volumeBackupId, {
+					serviceId,
+					source: row.backupPolicyId ? "policy" : "manual",
+					policyName: row.backupPolicy?.name ?? null,
+					destinationName: row.destination?.name ?? "",
+					prefix: row.prefix ?? "",
+				});
+			}
+
+			const backupIds = Array.from(backupMetaById.keys());
+			const volumeIds = Array.from(volumeMetaById.keys());
+			if (backupIds.length === 0 && volumeIds.length === 0) return empty;
+
+			const runConditions: SQL[] = [];
+			if (backupIds.length)
+				runConditions.push(inArray(deployments.backupId, backupIds));
+			if (volumeIds.length)
+				runConditions.push(inArray(deployments.volumeBackupId, volumeIds));
+
+			const serverCondition = input.serverId
+				? eq(deployments.serverId, input.serverId)
+				: isNull(deployments.serverId);
+
+			const deploymentRows = await db.query.deployments.findMany({
+				where: and(or(...runConditions), serverCondition),
+				columns: {
+					deploymentId: true,
+					backupId: true,
+					volumeBackupId: true,
+					status: true,
+					logPath: true,
+					serverId: true,
+					errorMessage: true,
+					createdAt: true,
+					startedAt: true,
+					finishedAt: true,
+				},
+				orderBy: [desc(deployments.createdAt)],
+				limit: input.limit + 1,
+				offset: input.offset,
+			});
+
+			const hasMore = deploymentRows.length > input.limit;
+			const page = hasMore
+				? deploymentRows.slice(0, input.limit)
+				: deploymentRows;
+
+			const runs = await Promise.all(
+				page.map(async (deployment) => {
+					const isVolume = Boolean(deployment.volumeBackupId);
+					const meta = isVolume
+						? deployment.volumeBackupId
+							? volumeMetaById.get(deployment.volumeBackupId)
+							: undefined
+						: deployment.backupId
+							? backupMetaById.get(deployment.backupId)
+							: undefined;
+					const service = meta
+						? serviceMetaById.get(meta.serviceId)
+						: undefined;
+
+					// Only local logs are read (no per-row SSH); remote runs fall back
+					// to the configured prefix folder.
+					const artifactPath =
+						!deployment.serverId && deployment.logPath
+							? extractBackupArtifactPath(
+									await readLocalLogTail(deployment.logPath),
+								)
+							: null;
+
+					return {
+						deploymentId: deployment.deploymentId,
+						kind: isVolume ? ("volume" as const) : ("database" as const),
+						backupId: deployment.backupId ?? null,
+						volumeBackupId: deployment.volumeBackupId ?? null,
+						serverId: deployment.serverId ?? null,
+						serviceName: service?.name ?? "Unknown service",
+						serviceType: service?.type ?? null,
+						projectName: service?.projectName ?? "",
+						environmentName: service?.environmentName ?? "",
+						destinationName: meta?.destinationName ?? "",
+						source: meta?.source ?? ("manual" as const),
+						policyName: meta?.policyName ?? null,
+						prefix: meta?.prefix ?? null,
+						status: deployment.status ?? "running",
+						createdAt: deployment.createdAt,
+						startedAt: deployment.startedAt ?? null,
+						finishedAt: deployment.finishedAt ?? null,
+						errorMessage: deployment.errorMessage ?? null,
+						artifactPath,
+					};
+				}),
+			);
+
+			return {
+				runs,
+				nextOffset: hasMore ? input.offset + input.limit : null,
 			};
 		}),
 });


### PR DESCRIPTION
## What

Reshapes the Backup Center to a swarm-style shell and adds the three features requested from the teammate feedback: a tabbed layout, coverage search, an Activity feed, and a "Viewing server" scope.

### 1. Tabbed layout (swarm shell)
`ShowBackupCenter` is now `Tabs` with **Policies / Instance / Coverage / Activity**, mapping the existing sections:
- **Policies** — the backup-policies list/editor (unchanged).
- **Instance** — the instance/web-server backup summary card (unchanged).
- **Coverage** — the coverage tree + facets (functionally unchanged) plus search and server scoping.
- **Activity** — new (below).

Deep-linkable via `?tab=` (shallow `router.replace`, like other Dokploy pages). Coverage and Activity are each wrapped in the shared `ServerFilter` (same component the swarm page uses), so the "Viewing server" selector only appears on the server-scoped tabs and Policies/Instance never hit `ServerFilter`'s cloud "no servers" gate.

### 2. Coverage search
A text input on the Coverage tab filters the tree by project / service / environment name (case-insensitive substring), composing with the existing global facets and the server scope (AND). Pure matching logic (`textMatchesQuery`, `serviceMatchesSearch`) lives in `apps/dokploy/lib/backup-coverage.ts` with vitest tests.

### 3. Activity tab
Derived entirely from the existing `deployment` rows each backup run persists (runs set `backupId`; volume runs set `volumeBackupId` — there is no `deploymentType` column, so the kind is inferred from which FK is set). **No migration, no new table.** New endpoint `backupPolicy.recentActivity` (read-gated, org-scoped, permission-filtered exactly like `coverage`):
- Returns recent runs: service name + type, project/env, destination, policy-vs-manual, status, started/finished time, and the **uploaded artifact path**.
- Artifact path: a pure extractor `extractBackupArtifactPath` parses the run's log tail for a path ending in a backup extension (`.sql.gz` / `.bson.gz` / `.tar(.gz)` / `.zip` / `.dump.gz`). Database/compose dump runs do not echo the exact path on success, so those fall back to the configured destination **prefix** (folder) from the DB — the UI labels which it is, and the actual files stay browsable via the Browse dialog from #156.
- Log reads are bounded: only **local** logs are tailed (remote logs would each need an SSH round-trip), capped to the returned page, missing/rotated files degrade to null. Paginated with `limit`/`offset` (50 + "Load more").
- Each row opens the full run log by reusing the existing `ShowDeploymentsModal` (`type: "backup" | "volumeBackup"`). Volume-backup runs are included.

### 4. "Viewing server" selector
Reuses the swarm page's `ServerFilter` as a global facet scoping Coverage and Activity to the selected server (default = Dokploy Server / local, matching swarm). Coverage filters services by `serverId`; Activity scopes deployments by `serverId`.

## Tests
- `apps/dokploy/lib/backup-coverage.ts`: 8 new pure helpers/cases → **42 tests pass** (34 existing + 8 new: `textMatchesQuery`, `serviceMatchesSearch`, `extractBackupArtifactPath`).
- `pnpm --filter=dokploy typecheck` clean; biome clean.

## Scope / notes
- **No migration.** Only additive tRPC endpoint is `backupPolicy.recentActivity`; server responses are org-scoped + `backup:read`-gated and never leak destination credentials or full log bodies (only the extracted artifact path / prefix).
- **Compose-child search** is limited to services whose own/project/environment name matches — surfacing a collapsed compose purely by a lazy-loaded child name would require eagerly loading every compose, which the tree deliberately avoids.
- Facets/coverage behavior itself is untouched.