### PR TITLE
fix(backup-center): real Web Server Backups on Instance tab + prefix in Destinations

### DIFF
--- a/apps/dokploy/components/dashboard/backups/coverage-table.tsx
+++ b/apps/dokploy/components/dashboard/backups/coverage-table.tsx
@@ -497,18 +497,27 @@ export const CoverageTable = ({ serverId }: { serverId?: string }) => {
 																	{envExpanded &&
 																		environment.visibleServices.map(
 																			(service) => {
+																				// Dedupe by destination name + prefix so each
+																				// distinct target (e.g. same bucket, different
+																				// prefix) is listed once.
 																				const destinations = Array.from(
-																					new Set(
+																					new Map(
 																						[
 																							...service.dumpBackups,
 																							...service.volumeBackups,
 																						]
-																							.map(
+																							.filter(
 																								(entry) =>
-																									entry.destinationName,
+																									!!entry.destinationName,
 																							)
-																							.filter((name) => !!name),
-																					),
+																							.map((entry) => [
+																								`${entry.destinationName} ${entry.prefix}`,
+																								{
+																									name: entry.destinationName,
+																									prefix: entry.prefix,
+																								},
+																							]),
+																					).values(),
 																				);
 																				const lastRunStatus = [
 																					...service.dumpBackups,
@@ -574,9 +583,28 @@ export const CoverageTable = ({ serverId }: { serverId?: string }) => {
 																							</TableCell>
 																							<TableCell>
 																								{destinations.length > 0 ? (
-																									<span className="text-sm text-muted-foreground">
-																										{destinations.join(", ")}
-																									</span>
+																									<div className="flex flex-col gap-0.5">
+																										{destinations.map(
+																											(destination) => (
+																												<span
+																													key={`${destination.name} ${destination.prefix}`}
+																													className="block max-w-[18rem] truncate text-sm text-muted-foreground"
+																													title={
+																														destination.prefix
+																															? `${destination.name} · ${destination.prefix}`
+																															: destination.name
+																													}
+																												>
+																													{destination.name}
+																													{destination.prefix ? (
+																														<span className="text-muted-foreground/70">
+																															{` · ${destination.prefix}`}
+																														</span>
+																													) : null}
+																												</span>
+																											),
+																										)}
+																									</div>
 																								) : (
 																									<span className="text-muted-foreground">
 																										—

--- a/apps/dokploy/components/dashboard/backups/instance-backup-card.tsx
+++ b/apps/dokploy/components/dashboard/backups/instance-backup-card.tsx
@@ -1,74 +1,45 @@
-import { ArrowRight, Server } from "lucide-react";
-import Link from "next/link";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Server } from "lucide-react";
 import {
 	Card,
-	CardContent,
 	CardDescription,
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
 import { api } from "@/utils/api";
+import { ShowBackups } from "../database/backups/show-backups";
 
-// Read-only summary of the Dokploy instance (web-server) backup. It is not
-// policy-managed — it keeps its own toggle under Web Server settings — so the
-// Center only surfaces its state and links out.
+// The Instance tab renders the exact Web Server Backups card used on
+// Settings → Server (schedules, destination/database/prefix, run/edit/delete
+// actions and Restore). Web-server backups are local-only and admin-managed, so
+// this is hidden on cloud and for non-privileged members.
 export const InstanceBackupCard = () => {
 	const { data: user } = api.user.get.useQuery();
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 
 	const isPrivileged = user?.role === "owner" || user?.role === "admin";
-	const canView = isPrivileged && !isCloud;
 
-	const { data: backupUser } = api.user.getBackups.useQuery(undefined, {
-		enabled: canView,
-	});
-
-	if (!canView) {
-		return null;
-	}
-
-	const backups = backupUser?.backups ?? [];
-	const enabledCount = backups.filter((backup) => backup.enabled).length;
-
-	return (
-		<Card className="bg-background">
-			<CardHeader className="flex flex-row flex-wrap items-start justify-between gap-4">
-				<div className="flex flex-col gap-0.5">
+	if (isCloud || !isPrivileged) {
+		return (
+			<Card className="bg-background">
+				<CardHeader>
 					<CardTitle className="flex flex-row items-center gap-2 text-xl">
 						<Server className="size-6 text-muted-foreground" />
 						Instance backup
 					</CardTitle>
 					<CardDescription>
-						The Dokploy web server backup keeps its own schedule under Web
-						Server settings.
+						The Dokploy web server backup is managed by an administrator on a
+						self-hosted instance.
 					</CardDescription>
-				</div>
-				<Button variant="outline" size="sm" asChild>
-					<Link href="/dashboard/settings/server">
-						Manage
-						<ArrowRight className="size-4" />
-					</Link>
-				</Button>
-			</CardHeader>
-			<CardContent>
-				{backups.length === 0 ? (
-					<p className="text-sm text-muted-foreground">
-						No web server backup configured.
-					</p>
-				) : (
-					<div className="flex items-center gap-2 text-sm">
-						<Badge variant={enabledCount > 0 ? "green" : "blank"}>
-							{enabledCount > 0 ? "Active" : "Inactive"}
-						</Badge>
-						<span className="text-muted-foreground">
-							{backups.length} schedule{backups.length === 1 ? "" : "s"}
-							{enabledCount !== backups.length && ` (${enabledCount} enabled)`}
-						</span>
-					</div>
-				)}
-			</CardContent>
-		</Card>
+				</CardHeader>
+			</Card>
+		);
+	}
+
+	return (
+		<ShowBackups
+			id={user?.userId ?? ""}
+			databaseType="web-server"
+			backupType="database"
+		/>
 	);
 };

--- a/apps/dokploy/server/api/routers/backup-policy.ts
+++ b/apps/dokploy/server/api/routers/backup-policy.ts
@@ -121,6 +121,8 @@ interface CoverageBackupEntry {
 	source: "policy" | "manual";
 	policyName?: string;
 	destinationName: string;
+	/** Storage prefix under the destination (shown after the destination name). */
+	prefix: string;
 	schedule: string;
 	enabled: boolean;
 	lastRunStatus?: string;
@@ -760,6 +762,7 @@ export const backupPolicyRouter = createTRPCRouter({
 			schedule: string;
 			enabled: boolean | null;
 			backupPolicyId: string | null;
+			prefix?: string | null;
 			destination?: { name: string } | null;
 			backupPolicy?: { name: string } | null;
 			deployments?: Array<{ status: string | null }>;
@@ -768,6 +771,7 @@ export const backupPolicyRouter = createTRPCRouter({
 			source: row.backupPolicyId ? "policy" : "manual",
 			policyName: row.backupPolicy?.name,
 			destinationName: row.destination?.name ?? "",
+			prefix: row.prefix ?? "",
 			schedule: row.schedule,
 			enabled: row.enabled ?? false,
 			lastRunStatus: row.deployments?.[0]?.status ?? undefined,
@@ -796,6 +800,7 @@ export const backupPolicyRouter = createTRPCRouter({
 					schedule: true,
 					enabled: true,
 					backupPolicyId: true,
+					prefix: true,
 					postgresId: true,
 					mysqlId: true,
 					mariadbId: true,
@@ -865,6 +870,7 @@ export const backupPolicyRouter = createTRPCRouter({
 					cronExpression: true,
 					enabled: true,
 					backupPolicyId: true,
+					prefix: true,
 					applicationId: true,
 					postgresId: true,
 					mysqlId: true,


### PR DESCRIPTION
Two small user-requested tweaks to the Backup Center (follow-up to #157).

## 1. Instance tab = the real Web Server Backups card
The Instance tab now renders the exact `ShowBackups` component used on Settings → Server (`databaseType="web-server"`) — the "Backups" card with the Restore Backup button, backup entries (Active status, Destination, Database, Schedule, Prefix Storage, Keep Latest) and the clipboard/run/edit/delete actions. Reused as-is; the only wrapper adjustment is the existing cloud/role gate (web-server backups are local-only and admin-managed, so on cloud or for non-privileged members the tab shows a short muted note instead). Replaces the previous read-only summary card.

## 2. Prefix shown in the coverage Destinations column
Each destination in the coverage tree's Destinations column now shows the backup's storage prefix in muted text after the name, e.g. `Devino Dokploy S3 Backup · /unotes-prod`, for both dump and volume entries. Entries are deduped by name+prefix, and each line truncates (with a full-value `title`) so long prefixes don't widen the column.

- `prefix` is added to the coverage query's per-entry payload (additive to `CoverageBackupEntry`; `prefix: true` added to the dump/volume column selects). **No migration.**

## Verification
- `pnpm --filter=dokploy typecheck` clean
- `pnpm --filter=dokploy test __test__/backup-policy/backup-coverage.test.ts` → 42/42 (unchanged; no new pure logic)
- biome clean

Tight diff: 3 files (backup-policy.ts, coverage-table.tsx, instance-backup-card.tsx).