### PR TITLE
fix(backup-center): deep-link coverage rows to service backups tab + Coverage as first tab

### DIFF
--- a/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
+++ b/apps/dokploy/__test__/backup-policy/backup-coverage.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+	backupTabForServiceType,
 	buildBackupListPrefix,
+	buildServiceBackupHref,
 	type CoverageFacets,
 	classifyDbImage,
 	countBackupFiles,
@@ -508,5 +510,60 @@ describe("extractBackupArtifactPath", () => {
 		expect(extractBackupArtifactPath("")).toBeNull();
 		expect(extractBackupArtifactPath(null)).toBeNull();
 		expect(extractBackupArtifactPath(undefined)).toBeNull();
+	});
+});
+
+describe("backupTabForServiceType", () => {
+	it("uses the dump backups tab for databases and compose", () => {
+		for (const type of [
+			"postgres",
+			"mysql",
+			"mariadb",
+			"mongo",
+			"libsql",
+			"compose",
+		] as const) {
+			expect(backupTabForServiceType(type)).toBe("backups");
+		}
+	});
+
+	it("uses volume-backups for applications and advanced for redis", () => {
+		expect(backupTabForServiceType("application")).toBe("volume-backups");
+		expect(backupTabForServiceType("redis")).toBe("advanced");
+	});
+});
+
+describe("buildServiceBackupHref", () => {
+	it("links to the service's backups tab", () => {
+		expect(
+			buildServiceBackupHref({
+				type: "postgres",
+				projectId: "p1",
+				environmentId: "e1",
+				serviceId: "s1",
+			}),
+		).toBe(
+			"/dashboard/project/p1/environment/e1/services/postgres/s1?tab=backups",
+		);
+		expect(
+			buildServiceBackupHref({
+				type: "application",
+				projectId: "p1",
+				environmentId: "e1",
+				serviceId: "a1",
+			}),
+		).toBe(
+			"/dashboard/project/p1/environment/e1/services/application/a1?tab=volume-backups",
+		);
+		expect(
+			buildServiceBackupHref({
+				type: "redis",
+				projectId: "p1",
+				environmentId: "e1",
+				serviceId: "r1",
+			}),
+		).toBe(
+			"/dashboard/project/p1/environment/e1/services/redis/r1?tab=advanced",
+		);
 	});
 });

--- a/apps/dokploy/components/dashboard/backups/coverage-table.tsx
+++ b/apps/dokploy/components/dashboard/backups/coverage-table.tsx
@@ -31,6 +31,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import {
+	buildServiceBackupHref,
 	type CoverageFacets,
 	EMPTY_COVERAGE_FACETS,
 	isEnvironmentShownByFacets,
@@ -138,8 +139,15 @@ interface ProjectNode {
 	uncoveredCount: number;
 }
 
-// Child containers of a compose service, lazy-loaded on expand.
-const ComposeChildRows = ({ composeId }: { composeId: string }) => {
+// Child containers of a compose service, lazy-loaded on expand. `href` links
+// each child row to the parent compose's backups tab.
+const ComposeChildRows = ({
+	composeId,
+	href,
+}: {
+	composeId: string;
+	href: string;
+}) => {
 	const { data, isPending } = api.backupPolicy.composeChildren.useQuery({
 		composeId,
 	});
@@ -221,7 +229,15 @@ const ComposeChildRows = ({ composeId }: { composeId: string }) => {
 					</TableCell>
 					<TableCell className="py-2" />
 					<TableCell className="py-2" />
-					<TableCell className="py-2" />
+					<TableCell className="py-2 text-right">
+						<Link
+							href={href}
+							className="inline-flex items-center text-muted-foreground hover:text-foreground"
+							title="Open compose backups"
+						>
+							<ExternalLink className="size-4" />
+						</Link>
+					</TableCell>
 				</TableRow>
 			))}
 		</>
@@ -511,7 +527,7 @@ export const CoverageTable = ({ serverId }: { serverId?: string }) => {
 																									!!entry.destinationName,
 																							)
 																							.map((entry) => [
-																								`${entry.destinationName} ${entry.prefix}`,
+																								`${entry.destinationName} ${entry.prefix}`,
 																								{
 																									name: entry.destinationName,
 																									prefix: entry.prefix,
@@ -657,9 +673,16 @@ export const CoverageTable = ({ serverId }: { serverId?: string }) => {
 																									</span>
 																								)}
 																								<Link
-																									href={`/dashboard/project/${project.id}/environment/${environment.id}`}
+																									href={buildServiceBackupHref({
+																										type: service.type,
+																										projectId: project.id,
+																										environmentId:
+																											environment.id,
+																										serviceId:
+																											service.serviceId,
+																									})}
 																									className="inline-flex items-center text-muted-foreground hover:text-foreground"
-																									title="Open service"
+																									title="Open service backups"
 																									onClick={(event) =>
 																										event.stopPropagation()
 																									}
@@ -671,6 +694,12 @@ export const CoverageTable = ({ serverId }: { serverId?: string }) => {
 																						{composeExpanded && (
 																							<ComposeChildRows
 																								composeId={service.serviceId}
+																								href={buildServiceBackupHref({
+																									type: service.type,
+																									projectId: project.id,
+																									environmentId: environment.id,
+																									serviceId: service.serviceId,
+																								})}
 																							/>
 																						)}
 																					</Fragment>

--- a/apps/dokploy/components/dashboard/backups/show-backup-center.tsx
+++ b/apps/dokploy/components/dashboard/backups/show-backup-center.tsx
@@ -6,7 +6,7 @@ import { BackupPoliciesSection } from "./backup-policies-section";
 import { CoverageTable } from "./coverage-table";
 import { InstanceBackupCard } from "./instance-backup-card";
 
-const TABS = ["policies", "instance", "coverage", "activity"] as const;
+const TABS = ["coverage", "policies", "instance", "activity"] as const;
 type BackupTab = (typeof TABS)[number];
 
 export const ShowBackupCenter = () => {
@@ -15,7 +15,7 @@ export const ShowBackupCenter = () => {
 		typeof router.query.tab === "string" &&
 		(TABS as readonly string[]).includes(router.query.tab)
 			? (router.query.tab as BackupTab)
-			: "policies";
+			: "coverage";
 
 	const setTab = (value: string) => {
 		router.replace(
@@ -29,23 +29,23 @@ export const ShowBackupCenter = () => {
 		<div className="mx-auto flex w-full max-w-6xl flex-col gap-4">
 			<Tabs value={tab} onValueChange={setTab} className="w-full">
 				<TabsList>
+					<TabsTrigger value="coverage">Coverage</TabsTrigger>
 					<TabsTrigger value="policies">Policies</TabsTrigger>
 					<TabsTrigger value="instance">Instance</TabsTrigger>
-					<TabsTrigger value="coverage">Coverage</TabsTrigger>
 					<TabsTrigger value="activity">Activity</TabsTrigger>
 				</TabsList>
-				<TabsContent value="policies" className="mt-4">
-					<BackupPoliciesSection />
-				</TabsContent>
-				<TabsContent value="instance" className="mt-4">
-					<InstanceBackupCard />
-				</TabsContent>
 				{/* Coverage and Activity are scoped by the "Viewing server" selector;
 				    Policies and Instance are org-wide and never server-scoped. */}
 				<TabsContent value="coverage" className="mt-4">
 					<ServerFilter>
 						{(serverId) => <CoverageTable serverId={serverId} />}
 					</ServerFilter>
+				</TabsContent>
+				<TabsContent value="policies" className="mt-4">
+					<BackupPoliciesSection />
+				</TabsContent>
+				<TabsContent value="instance" className="mt-4">
+					<InstanceBackupCard />
 				</TabsContent>
 				<TabsContent value="activity" className="mt-4">
 					<ServerFilter>

--- a/apps/dokploy/lib/backup-coverage.ts
+++ b/apps/dokploy/lib/backup-coverage.ts
@@ -92,6 +92,35 @@ const DB_SERVICE_TYPES: ReadonlySet<FilterableService["type"]> = new Set(
 export const isDatabaseServiceType = (type: ServiceType): boolean =>
 	DB_SERVICE_TYPES.has(type);
 
+// The service-page tab that holds each type's backups. Databases and compose
+// expose a dump "backups" tab; applications have a dedicated "volume-backups"
+// tab; redis keeps its volume backups under "advanced" (it has no dedicated
+// backups tab). Verified against the service pages under
+// pages/dashboard/project/.../services/<type>.
+const BACKUP_TAB_BY_TYPE: Record<ServiceType, string> = {
+	postgres: "backups",
+	mysql: "backups",
+	mariadb: "backups",
+	mongo: "backups",
+	libsql: "backups",
+	compose: "backups",
+	application: "volume-backups",
+	redis: "advanced",
+};
+
+/** The `?tab=` value that opens a service type's backups. */
+export const backupTabForServiceType = (type: ServiceType): string =>
+	BACKUP_TAB_BY_TYPE[type];
+
+/** Deep link to a service's backups tab used by the coverage tree. */
+export const buildServiceBackupHref = (service: {
+	type: ServiceType;
+	projectId: string;
+	environmentId: string;
+	serviceId: string;
+}): string =>
+	`/dashboard/project/${service.projectId}/environment/${service.environmentId}/services/${service.type}/${service.serviceId}?tab=${backupTabForServiceType(service.type)}`;
+
 /**
  * The user-approved "hide non-prod plain apps" default:
  * - production environments show every service;


### PR DESCRIPTION
Two user-requested Backup Center changes (follow-up to #158).

## 1. Coverage rows deep-link to the service's backups tab
The external-link icon on each coverage service row now goes straight to that service's backups tab instead of the environment page. Verified the real `?tab=` key per type against the service pages under `pages/dashboard/project/.../services/<type>`:

| Service type | Tab key |
|---|---|
| postgres / mysql / mariadb / mongo / libsql | `backups` |
| compose | `backups` |
| application | `volume-backups` |
| redis | `advanced` (redis has no dedicated backups tab — its volume backups live under Advanced) |

URL shape: `/dashboard/project/<pid>/environment/<eid>/services/<type>/<serviceId>?tab=<key>`. Compose-children (lazy-expanded container) rows now also get an external-link that opens the parent compose's backups tab. Project/environment header rows are unchanged (expand toggles).

The mapping + URL builder are pure helpers in `apps/dokploy/lib/backup-coverage.ts` (`backupTabForServiceType`, `buildServiceBackupHref`) with vitest tests.

## 2. Coverage is now the first tab and the default
Tab order is now **Coverage / Policies / Instance / Activity**, and Coverage is the default when no `?tab=` is present. Deep-links for all four tabs still work.

## Also (incidental fix)
While editing coverage-table.tsx I found a stray literal NUL byte that my #158 change left as the Destinations dedupe-key separator (it shipped in community.13 — harmless at runtime but flagged the file as binary to tools like grep). Replaced it with a normal space separator.

## Verification
- pnpm --filter=dokploy typecheck clean
- pnpm --filter=dokploy test __test__/backup-policy/backup-coverage.test.ts -> 45/45 (42 + 3 new)
- biome clean

4 files: lib/backup-coverage.ts, __test__/backup-policy/backup-coverage.test.ts, components/dashboard/backups/{coverage-table,show-backup-center}.tsx. No migration.