### PR TITLE
feat(backups): limit concurrent scheduled backup runs per server

### DIFF
--- a/apps/dokploy/__test__/backup-policy/concurrency.test.ts
+++ b/apps/dokploy/__test__/backup-policy/concurrency.test.ts
@@ -1,0 +1,201 @@
+import {
+	BACKUP_CONCURRENCY,
+	createBackupLimiter,
+	DEFAULT_BACKUP_CONCURRENCY,
+	parseConcurrency,
+} from "@dokploy/server/utils/backups/concurrency";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// A promise plus its resolve/reject, to hold a task "running" until we release it.
+const deferred = () => {
+	let resolve!: () => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<void>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+};
+
+// Let queued microtasks settle so slot hand-offs take effect before asserting.
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe("parseConcurrency", () => {
+	it("parses valid positive integers", () => {
+		expect(parseConcurrency("1")).toBe(1);
+		expect(parseConcurrency("8")).toBe(8);
+	});
+
+	it("falls back to the default for invalid or absent values", () => {
+		const invalid: Array<string | undefined> = [
+			undefined,
+			"",
+			" ",
+			"abc",
+			"0",
+			"-3",
+			"2.5",
+			"NaN",
+			"1e3abc",
+		];
+		for (const value of invalid) {
+			expect(parseConcurrency(value)).toBe(DEFAULT_BACKUP_CONCURRENCY);
+		}
+	});
+
+	it("exposes an env-derived default limit >= 1", () => {
+		expect(BACKUP_CONCURRENCY).toBeGreaterThanOrEqual(1);
+		expect(Number.isInteger(BACKUP_CONCURRENCY)).toBe(true);
+	});
+});
+
+describe("createBackupLimiter", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		logSpy.mockRestore();
+	});
+
+	it("runs at most `limit` tasks concurrently per key", async () => {
+		const limiter = createBackupLimiter(2);
+		let active = 0;
+		let maxActive = 0;
+		const gates = [deferred(), deferred(), deferred(), deferred()];
+		const tasks = gates.map((gate, i) =>
+			limiter.withSlot("local", `b${i}`, async () => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				await gate.promise;
+				active--;
+			}),
+		);
+
+		await flush();
+		expect(active).toBe(2);
+
+		gates[0].resolve();
+		await flush();
+		// one finished, the next queued task took its slot — still capped at 2
+		expect(active).toBe(2);
+
+		for (const gate of gates) gate.resolve();
+		await Promise.all(tasks);
+		expect(maxActive).toBe(2);
+	});
+
+	it("wakes waiters in FIFO arrival order", async () => {
+		const limiter = createBackupLimiter(1);
+		const started: number[] = [];
+		const gates = [deferred(), deferred(), deferred()];
+		const tasks = [0, 1, 2].map((i) =>
+			limiter.withSlot("k", `t${i}`, async () => {
+				started.push(i);
+				await gates[i].promise;
+			}),
+		);
+
+		await flush();
+		expect(started).toEqual([0]);
+
+		gates[0].resolve();
+		await flush();
+		expect(started).toEqual([0, 1]);
+
+		gates[1].resolve();
+		await flush();
+		expect(started).toEqual([0, 1, 2]);
+
+		gates[2].resolve();
+		await Promise.all(tasks);
+	});
+
+	it("releases the slot when a task throws", async () => {
+		const limiter = createBackupLimiter(1);
+
+		await expect(
+			limiter.withSlot("k", "boom", async () => {
+				throw new Error("fail");
+			}),
+		).rejects.toThrow("fail");
+
+		let ran = false;
+		await limiter.withSlot("k", "ok", async () => {
+			ran = true;
+		});
+		expect(ran).toBe(true);
+	});
+
+	it("limits each server key independently", async () => {
+		const limiter = createBackupLimiter(1);
+		const gateA = deferred();
+		const gateB = deferred();
+		let aActive = false;
+		let bActive = false;
+
+		const a = limiter.withSlot("serverA", "a", async () => {
+			aActive = true;
+			await gateA.promise;
+		});
+		const b = limiter.withSlot("serverB", "b", async () => {
+			bActive = true;
+			await gateB.promise;
+		});
+
+		await flush();
+		// Different keys → neither blocks the other despite a limit of 1.
+		expect(aActive).toBe(true);
+		expect(bActive).toBe(true);
+
+		gateA.resolve();
+		gateB.resolve();
+		await Promise.all([a, b]);
+	});
+
+	it("treats null/undefined/empty server keys as the shared 'local' queue", async () => {
+		const limiter = createBackupLimiter(1);
+		const gate = deferred();
+		let secondStarted = false;
+
+		const first = limiter.withSlot(null, "first", async () => {
+			await gate.promise;
+		});
+		const second = limiter.withSlot(undefined, "second", async () => {
+			secondStarted = true;
+		});
+
+		await flush();
+		expect(secondStarted).toBe(false);
+
+		gate.resolve();
+		await Promise.all([first, second]);
+		expect(secondStarted).toBe(true);
+	});
+
+	it("logs on wait and stays quiet when a slot is free", async () => {
+		const limiter = createBackupLimiter(1);
+
+		await limiter.withSlot("k", "immediate", async () => {});
+		expect(logSpy).not.toHaveBeenCalled();
+
+		const gate = deferred();
+		const first = limiter.withSlot("k", "first", async () => {
+			await gate.promise;
+		});
+		const second = limiter.withSlot("k", "second", async () => {});
+
+		await flush();
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("second waiting (1 running on k)"),
+		);
+
+		gate.resolve();
+		await Promise.all([first, second]);
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("second started on k"),
+		);
+	});
+});

--- a/apps/dokploy/__test__/backup-policy/concurrency.test.ts
+++ b/apps/dokploy/__test__/backup-policy/concurrency.test.ts
@@ -17,6 +17,8 @@ const deferred = () => {
 	return { promise, resolve, reject };
 };
 
+type Deferred = ReturnType<typeof deferred>;
+
 // Let queued microtasks settle so slot hand-offs take effect before asserting.
 const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
 
@@ -64,25 +66,30 @@ describe("createBackupLimiter", () => {
 		const limiter = createBackupLimiter(2);
 		let active = 0;
 		let maxActive = 0;
-		const gates = [deferred(), deferred(), deferred(), deferred()];
-		const tasks = gates.map((gate, i) =>
-			limiter.withSlot("local", `b${i}`, async () => {
+		const run = (gate: Deferred, label: string) =>
+			limiter.withSlot("local", label, async () => {
 				active++;
 				maxActive = Math.max(maxActive, active);
 				await gate.promise;
 				active--;
-			}),
-		);
+			});
+		const g0 = deferred();
+		const g1 = deferred();
+		const g2 = deferred();
+		const g3 = deferred();
+		const tasks = [run(g0, "b0"), run(g1, "b1"), run(g2, "b2"), run(g3, "b3")];
 
 		await flush();
 		expect(active).toBe(2);
 
-		gates[0].resolve();
+		g0.resolve();
 		await flush();
 		// one finished, the next queued task took its slot — still capped at 2
 		expect(active).toBe(2);
 
-		for (const gate of gates) gate.resolve();
+		g1.resolve();
+		g2.resolve();
+		g3.resolve();
 		await Promise.all(tasks);
 		expect(maxActive).toBe(2);
 	});
@@ -90,26 +97,28 @@ describe("createBackupLimiter", () => {
 	it("wakes waiters in FIFO arrival order", async () => {
 		const limiter = createBackupLimiter(1);
 		const started: number[] = [];
-		const gates = [deferred(), deferred(), deferred()];
-		const tasks = [0, 1, 2].map((i) =>
+		const run = (i: number, gate: Deferred) =>
 			limiter.withSlot("k", `t${i}`, async () => {
 				started.push(i);
-				await gates[i].promise;
-			}),
-		);
+				await gate.promise;
+			});
+		const g0 = deferred();
+		const g1 = deferred();
+		const g2 = deferred();
+		const tasks = [run(0, g0), run(1, g1), run(2, g2)];
 
 		await flush();
 		expect(started).toEqual([0]);
 
-		gates[0].resolve();
+		g0.resolve();
 		await flush();
 		expect(started).toEqual([0, 1]);
 
-		gates[1].resolve();
+		g1.resolve();
 		await flush();
 		expect(started).toEqual([0, 1, 2]);
 
-		gates[2].resolve();
+		g2.resolve();
 		await Promise.all(tasks);
 	});
 

--- a/packages/server/src/utils/backups/concurrency.ts
+++ b/packages/server/src/utils/backups/concurrency.ts
@@ -1,0 +1,97 @@
+// Global concurrency limiter for SCHEDULED backup runs.
+//
+// Every backup row gets its own node-schedule job whose callback runs the dump
+// pipeline directly. Backup policies can materialize many backup rows on the
+// same cron, so without a limit 100+ backups firing in the same tick would spawn
+// 100 concurrent docker-exec/pg_dump/rclone pipelines and SSH connections.
+//
+// Slots are counted PER TARGET SERVER KEY (local = "local", remote = serverId)
+// so a slow remote server can't starve local backups: each server key gets its
+// own limit of DOKPLOY_BACKUP_CONCURRENCY running backups.
+
+export const DEFAULT_BACKUP_CONCURRENCY = 4;
+
+// Parse the configured limit. Anything that isn't an integer >= 1 (absent,
+// empty, non-numeric, zero, negative, fractional) falls back to the default.
+export const parseConcurrency = (raw: string | undefined): number => {
+	const n = Number(raw);
+	return Number.isInteger(n) && n >= 1 ? n : DEFAULT_BACKUP_CONCURRENCY;
+};
+
+interface Semaphore {
+	running: number;
+	waiters: Array<() => void>;
+}
+
+export interface BackupLimiter {
+	withSlot<T>(
+		serverKey: string | null | undefined,
+		label: string,
+		fn: () => Promise<T>,
+	): Promise<T>;
+}
+
+// A FIFO, per-key async semaphore. `limit` slots per key; callers past the limit
+// queue and are woken in arrival order as slots free.
+export const createBackupLimiter = (limit: number): BackupLimiter => {
+	const semaphores = new Map<string, Semaphore>();
+
+	const getSemaphore = (key: string): Semaphore => {
+		let sem = semaphores.get(key);
+		if (!sem) {
+			sem = { running: 0, waiters: [] };
+			semaphores.set(key, sem);
+		}
+		return sem;
+	};
+
+	const release = (sem: Semaphore): void => {
+		const next = sem.waiters.shift();
+		// Hand the just-freed slot straight to the next waiter (running stays put)
+		// so an interleaving acquire can never overshoot the limit.
+		if (next) {
+			next();
+		} else {
+			sem.running--;
+		}
+	};
+
+	return {
+		async withSlot(serverKey, label, fn) {
+			const key = serverKey || "local";
+			const sem = getSemaphore(key);
+
+			if (sem.running >= limit) {
+				console.log(
+					`[backup-queue] ${label} waiting (${sem.running} running on ${key})`,
+				);
+				await new Promise<void>((resolve) => {
+					sem.waiters.push(resolve);
+				});
+				console.log(`[backup-queue] ${label} started on ${key}`);
+			} else {
+				sem.running++;
+			}
+
+			try {
+				return await fn();
+			} finally {
+				release(sem);
+			}
+		},
+	};
+};
+
+export const BACKUP_CONCURRENCY = parseConcurrency(
+	process.env.DOKPLOY_BACKUP_CONCURRENCY,
+);
+
+const defaultLimiter = createBackupLimiter(BACKUP_CONCURRENCY);
+
+// Run `fn` once a slot is free for `serverKey`, always releasing the slot
+// afterwards (even on error). Used to throttle scheduled backup callbacks.
+export const withBackupSlot = <T>(
+	serverKey: string | null | undefined,
+	label: string,
+	fn: () => Promise<T>,
+): Promise<T> => defaultLimiter.withSlot(serverKey, label, fn);

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -3,14 +3,17 @@ import { logger } from "@dokploy/server/lib/logger";
 
 export { GENERIC_RCLONE_PROVIDER };
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { BackupSchedule } from "@dokploy/server/services/backup";
 import type { Destination } from "@dokploy/server/services/destination";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+
 const execFileP = promisify(execFile);
+
 import { keepLatestNBackups } from ".";
 import { runComposeBackup } from "./compose";
+import { withBackupSlot } from "./concurrency";
 import { runLibsqlBackup } from "./libsql";
 import { runMariadbBackup } from "./mariadb";
 import { runMongoBackup } from "./mongo";
@@ -31,31 +34,43 @@ export const scheduleBackup = (backup: BackupSchedule) => {
 		libsql,
 		compose,
 	} = backup;
+	// Scheduled runs share a global per-server concurrency limit so a burst of
+	// policy-materialized backups on the same cron can't fire all at once.
+	const serverKey =
+		backup.backupType === "compose"
+			? compose?.serverId
+			: (postgres?.serverId ??
+				mysql?.serverId ??
+				mongo?.serverId ??
+				mariadb?.serverId ??
+				libsql?.serverId);
 	scheduleJob(backupId, schedule, async () => {
-		if (backup.backupType === "database") {
-			if (databaseType === "postgres" && postgres) {
-				await runPostgresBackup(postgres, backup);
-				await keepLatestNBackups(backup, postgres.serverId);
-			} else if (databaseType === "mysql" && mysql) {
-				await runMySqlBackup(mysql, backup);
-				await keepLatestNBackups(backup, mysql.serverId);
-			} else if (databaseType === "mongo" && mongo) {
-				await runMongoBackup(mongo, backup);
-				await keepLatestNBackups(backup, mongo.serverId);
-			} else if (databaseType === "mariadb" && mariadb) {
-				await runMariadbBackup(mariadb, backup);
-				await keepLatestNBackups(backup, mariadb.serverId);
-			} else if (databaseType === "libsql" && libsql) {
-				await runLibsqlBackup(libsql, backup);
-				await keepLatestNBackups(backup, libsql.serverId);
-			} else if (databaseType === "web-server") {
-				await runWebServerBackup(backup);
-				await keepLatestNBackups(backup);
+		await withBackupSlot(serverKey, backupId, async () => {
+			if (backup.backupType === "database") {
+				if (databaseType === "postgres" && postgres) {
+					await runPostgresBackup(postgres, backup);
+					await keepLatestNBackups(backup, postgres.serverId);
+				} else if (databaseType === "mysql" && mysql) {
+					await runMySqlBackup(mysql, backup);
+					await keepLatestNBackups(backup, mysql.serverId);
+				} else if (databaseType === "mongo" && mongo) {
+					await runMongoBackup(mongo, backup);
+					await keepLatestNBackups(backup, mongo.serverId);
+				} else if (databaseType === "mariadb" && mariadb) {
+					await runMariadbBackup(mariadb, backup);
+					await keepLatestNBackups(backup, mariadb.serverId);
+				} else if (databaseType === "libsql" && libsql) {
+					await runLibsqlBackup(libsql, backup);
+					await keepLatestNBackups(backup, libsql.serverId);
+				} else if (databaseType === "web-server") {
+					await runWebServerBackup(backup);
+					await keepLatestNBackups(backup);
+				}
+			} else if (backup.backupType === "compose" && compose) {
+				await runComposeBackup(compose, backup);
+				await keepLatestNBackups(backup, compose.serverId);
 			}
-		} else if (backup.backupType === "compose" && compose) {
-			await runComposeBackup(compose, backup);
-			await keepLatestNBackups(backup, compose.serverId);
-		}
+		});
 	});
 };
 
@@ -194,8 +209,10 @@ const getCryptEnvVars = async (
  * destination has encryption enabled. `envVars` comes from getRclonePathAndFlags
  * (empty string when the destination is not encrypted).
  */
-export const buildRcloneCommand = (command: string, envVars?: string): string =>
-	envVars ? `${envVars} ${command}` : command;
+export const buildRcloneCommand = (
+	command: string,
+	envVars?: string,
+): string => (envVars ? `${envVars} ${command}` : command);
 
 export const getPostgresBackupCommand = (
 	database: string,
@@ -437,9 +454,7 @@ export const getRclonePathAndFlags = async (
 		// shell metacharacters, quotes and whitespace.
 		const genericPathSafe = /^[^"'$\\`;|&<>()\s]*$/;
 		if (!genericPathSafe.test(destination.bucket)) {
-			throw new Error(
-				"Invalid rclone remote: contains forbidden characters",
-			);
+			throw new Error("Invalid rclone remote: contains forbidden characters");
 		}
 		if (!genericPathSafe.test(subPath)) {
 			throw new Error(
@@ -467,7 +482,10 @@ export const getRclonePathAndFlags = async (
 			return {
 				flags,
 				path: `:crypt:${subPath}`,
-				envVars: await getCryptEnvVars(destination, `:s3:${destination.bucket}`),
+				envVars: await getCryptEnvVars(
+					destination,
+					`:s3:${destination.bucket}`,
+				),
 			};
 		}
 		const path = `:s3:${destination.bucket}/${subPath}`;

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -11,10 +11,8 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import {
-	getRclonePathAndFlags,
-	normalizeS3Path,
-} from "../backups/utils";
+import { withBackupSlot } from "../backups/concurrency";
+import { getRclonePathAndFlags, normalizeS3Path } from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
 
@@ -67,8 +65,15 @@ const getOrganizationId = (
 
 export const scheduleVolumeBackup = async (volumeBackupId: string) => {
 	const volumeBackup = await findVolumeBackupById(volumeBackupId);
+	// Throttle scheduled runs against the same global per-server limit as
+	// database/compose backups. Manual runs (runVolumeBackup called directly)
+	// stay immediate.
+	const serverKey =
+		volumeBackup.application?.serverId || volumeBackup.compose?.serverId;
 	scheduleJob(volumeBackupId, volumeBackup.cronExpression, async () => {
-		await runVolumeBackup(volumeBackupId);
+		await withBackupSlot(serverKey, volumeBackupId, () =>
+			runVolumeBackup(volumeBackupId),
+		);
 	});
 };
 


### PR DESCRIPTION
## Problem

Every backup row registers its own `node-schedule` job whose callback runs the dump pipeline directly — no queue, no limit. With the fork's **Backup Policies** feature materializing many backup rows on the same cron, 100+ backups can fire in a single tick, spawning 100 concurrent docker-exec/pg_dump/rclone pipelines and SSH connections.

## Change

A small, dependency-free FIFO async semaphore that caps **running** scheduled backups **per target server key** (`local` for the web server, `serverId` for remotes), so a slow remote can't starve local backups.

- **Limiter**: `packages/server/src/utils/backups/concurrency.ts` (~95 lines, no new deps).
  - Limit read from env `DOKPLOY_BACKUP_CONCURRENCY` (integer ≥ 1; absent/invalid → default **4**), per server key.
  - `withBackupSlot(serverKey, label, fn)` queues `fn` until a slot frees, runs it, always releases in `finally`, and propagates errors. A freed slot is handed directly to the next FIFO waiter so the limit is never overshot.
  - Logs only when a job actually waits: `[backup-queue] <id> waiting (N running on <key>)` and `... started on <key>`. Silent when a slot is free.
- **Wrapped call sites (scheduled paths only)**:
  - `scheduleBackup` callback (database + compose) — `packages/server/src/utils/backups/utils.ts`.
  - `scheduleVolumeBackup` callback — `packages/server/src/utils/volume-backups/utils.ts`.
  - Manual/one-off runs (UI `manualBackup*`, `runNow`, `runVolumeBackup` called directly) are **not** wrapped and stay immediate.

## Tests

`apps/dokploy/__test__/backup-policy/concurrency.test.ts` — 9 vitest cases: env parsing (valid + invalid/absent), respects the limit, FIFO wake order, releases the slot on error, per-key independence, null/undefined key → shared `local` queue, and wait-time logging.

## Notes

No migration, no UI changes. `pnpm --filter=@dokploy/server build`, server typecheck, app typecheck, and the full `backup-policy` suite (78 tests) all pass.