### PR TITLE
feat(registry): image-restorability view + per-registry push counts on the Registry page

### DIFF
--- a/apps/dokploy/__test__/backup-policy/image-provenance.test.ts
+++ b/apps/dokploy/__test__/backup-policy/image-provenance.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyApplicationProvenance,
+	classifyComposeChildImage,
+	DEFAULT_REGISTRY_HOST,
+	parseRegistryHost,
+} from "@/lib/image-provenance";
+
+describe("parseRegistryHost", () => {
+	it("defaults bare and namespaced Docker Hub images to docker.io", () => {
+		expect(parseRegistryHost("nginx")).toBe("docker.io");
+		expect(parseRegistryHost("nginx:1.25")).toBe("docker.io");
+		expect(parseRegistryHost("bitnami/nginx")).toBe("docker.io");
+		expect(parseRegistryHost("bitnami/nginx:1.25")).toBe("docker.io");
+		expect(parseRegistryHost("library/postgres@sha256:deadbeef")).toBe(
+			"docker.io",
+		);
+	});
+
+	it("extracts explicit registry hosts", () => {
+		expect(parseRegistryHost("ghcr.io/acme/app")).toBe("ghcr.io");
+		expect(parseRegistryHost("ghcr.io/acme/app:1.2.3")).toBe("ghcr.io");
+		expect(parseRegistryHost("registry.example.com/team/app")).toBe(
+			"registry.example.com",
+		);
+		expect(parseRegistryHost("registry.example.com/team/app@sha256:abc")).toBe(
+			"registry.example.com",
+		);
+	});
+
+	it("handles host:port and localhost", () => {
+		expect(parseRegistryHost("localhost:5000/app")).toBe("localhost:5000");
+		expect(parseRegistryHost("registry.local:5000/team/app:tag")).toBe(
+			"registry.local:5000",
+		);
+		// localhost without a slash is an image name, not a host.
+		expect(parseRegistryHost("localhost")).toBe("docker.io");
+	});
+
+	it("returns null for empty input", () => {
+		expect(parseRegistryHost("")).toBeNull();
+		expect(parseRegistryHost("   ")).toBeNull();
+		expect(parseRegistryHost(null)).toBeNull();
+		expect(parseRegistryHost(undefined)).toBeNull();
+	});
+
+	it("exposes the default host constant", () => {
+		expect(DEFAULT_REGISTRY_HOST).toBe("docker.io");
+	});
+});
+
+describe("classifyApplicationProvenance", () => {
+	it("marks docker-source apps re-pullable with their registry host", () => {
+		expect(
+			classifyApplicationProvenance({
+				sourceType: "docker",
+				dockerImage: "ghcr.io/acme/api:1.2",
+				registryId: null,
+			}),
+		).toEqual({
+			restorability: "re-pullable",
+			image: "ghcr.io/acme/api:1.2",
+			registryHost: "ghcr.io",
+		});
+	});
+
+	it("marks source-built apps with a registry as in-registry", () => {
+		expect(
+			classifyApplicationProvenance({
+				sourceType: "github",
+				dockerImage: null,
+				registryId: "reg_1",
+			}),
+		).toEqual({
+			restorability: "in-registry",
+			image: null,
+			registryHost: null,
+		});
+	});
+
+	it("marks source-built apps without a registry as rebuild-only", () => {
+		for (const sourceType of [
+			"git",
+			"github",
+			"gitlab",
+			"bitbucket",
+			"gitea",
+			"drop",
+		] as const) {
+			expect(
+				classifyApplicationProvenance({
+					sourceType,
+					dockerImage: null,
+					registryId: null,
+				}).restorability,
+			).toBe("rebuild-only");
+		}
+	});
+});
+
+describe("classifyComposeChildImage", () => {
+	it("is re-pullable when the child declares an image", () => {
+		expect(classifyComposeChildImage({ image: "redis:7" })).toEqual({
+			restorability: "re-pullable",
+			registryHost: "docker.io",
+		});
+		expect(classifyComposeChildImage({ image: "ghcr.io/acme/web:1" })).toEqual({
+			restorability: "re-pullable",
+			registryHost: "ghcr.io",
+		});
+	});
+
+	it("is rebuild-only when the child has no image (build context)", () => {
+		expect(classifyComposeChildImage({ image: null })).toEqual({
+			restorability: "rebuild-only",
+			registryHost: null,
+		});
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/cluster/registry/registry-image-provenance.tsx
+++ b/apps/dokploy/components/dashboard/settings/cluster/registry/registry-image-provenance.tsx
@@ -1,0 +1,503 @@
+import {
+	Boxes,
+	CheckCircle2,
+	ChevronRight,
+	Folder,
+	Layers,
+	Loader2,
+	Search,
+	TriangleAlert,
+} from "lucide-react";
+import { Fragment, useMemo, useState } from "react";
+import { ServiceTypeIcon } from "@/components/dashboard/backups/service-type-icon";
+import {
+	getProjectFaviconUrls,
+	ProjectIcon,
+} from "@/components/dashboard/projects/project-icon";
+import { Badge } from "@/components/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { serviceMatchesSearch } from "@/lib/backup-coverage";
+import {
+	classifyApplicationProvenance,
+	classifyComposeChildImage,
+	type ImageRestorability,
+} from "@/lib/image-provenance";
+import { cn } from "@/lib/utils";
+import type { RouterOutputs } from "@/utils/api";
+import { api } from "@/utils/api";
+
+type ImageService =
+	RouterOutputs["backupPolicy"]["imageProvenance"]["services"][number];
+
+const COLUMN_COUNT = 2;
+
+const RESTORABILITY_META: Record<
+	ImageRestorability,
+	{ label: string; variant: "green" | "orange"; warn: boolean }
+> = {
+	"re-pullable": { label: "Re-pullable", variant: "green", warn: false },
+	"in-registry": { label: "In registry", variant: "green", warn: false },
+	"rebuild-only": { label: "Rebuild only", variant: "orange", warn: true },
+};
+
+const RestorabilityBadge = ({
+	restorability,
+	detail,
+}: {
+	restorability: ImageRestorability;
+	detail?: string | null;
+}) => {
+	const meta = RESTORABILITY_META[restorability];
+	return (
+		<div className="flex items-center gap-2">
+			<Badge variant={meta.variant} className="gap-1">
+				{meta.warn ? <TriangleAlert className="size-3" /> : null}
+				{meta.label}
+			</Badge>
+			{detail ? (
+				<span
+					className="max-w-[16rem] truncate font-mono text-xs text-muted-foreground"
+					title={detail}
+				>
+					{detail}
+				</span>
+			) : null}
+		</div>
+	);
+};
+
+const ExpandChevron = ({ expanded }: { expanded: boolean }) => (
+	<ChevronRight
+		className={cn(
+			"size-4 shrink-0 text-muted-foreground transition-transform",
+			expanded && "rotate-90",
+		)}
+	/>
+);
+
+// Compose children are lazy-loaded on expand (same pattern as the Backup Center
+// coverage tree). A child with an `image:` is re-pullable; a `build:` child is
+// rebuild-only.
+const ComposeImageChildren = ({ composeId }: { composeId: string }) => {
+	const { data, isPending } = api.backupPolicy.composeChildren.useQuery({
+		composeId,
+	});
+
+	if (isPending) {
+		return (
+			<TableRow>
+				<TableCell colSpan={COLUMN_COUNT} className="py-2 pl-16">
+					<span className="flex items-center gap-2 text-xs text-muted-foreground">
+						<Loader2 className="size-3.5 animate-spin" />
+						Loading compose services...
+					</span>
+				</TableCell>
+			</TableRow>
+		);
+	}
+
+	if (data?.error) {
+		return (
+			<TableRow>
+				<TableCell colSpan={COLUMN_COUNT} className="py-2 pl-16">
+					<span className="flex items-center gap-2 text-xs text-muted-foreground">
+						<TriangleAlert className="size-3.5 text-orange-500" />
+						{data.error}
+					</span>
+				</TableCell>
+			</TableRow>
+		);
+	}
+
+	return (
+		<>
+			{data?.children.map((child) => {
+				const provenance = classifyComposeChildImage({ image: child.image });
+				return (
+					<TableRow key={child.name} className="bg-muted/10">
+						<TableCell className="py-2 pl-16">
+							<div className="flex items-center gap-2">
+								{child.dbKind ? (
+									<ServiceTypeIcon type={child.dbKind} />
+								) : (
+									<Boxes className="size-4 text-muted-foreground" />
+								)}
+								<span className="text-sm">{child.name}</span>
+							</div>
+						</TableCell>
+						<TableCell className="py-2">
+							<RestorabilityBadge
+								restorability={provenance.restorability}
+								detail={child.image}
+							/>
+						</TableCell>
+					</TableRow>
+				);
+			})}
+		</>
+	);
+};
+
+interface EnvironmentNode {
+	id: string;
+	name: string;
+	services: ImageService[];
+	rebuildOnly: number;
+}
+
+interface ProjectNode {
+	id: string;
+	name: string;
+	logo: string | null;
+	environments: EnvironmentNode[];
+	rebuildOnly: number;
+}
+
+// An application's restorability is known up-front; a compose's depends on its
+// (lazy) children, so it does not contribute to the up-front counts.
+const applicationRestorability = (
+	service: ImageService,
+): ImageRestorability | null =>
+	service.type === "application"
+		? classifyApplicationProvenance({
+				sourceType: service.sourceType as Parameters<
+					typeof classifyApplicationProvenance
+				>[0]["sourceType"],
+				dockerImage: service.dockerImage,
+				registryId: service.registryId,
+			}).restorability
+		: null;
+
+const RollupBadge = ({ rebuildOnly }: { rebuildOnly: number }) =>
+	rebuildOnly > 0 ? (
+		<Badge variant="orange" className="gap-1">
+			<TriangleAlert className="size-3" />
+			{rebuildOnly} rebuild-only
+		</Badge>
+	) : (
+		<CheckCircle2 className="size-4 text-green-500" />
+	);
+
+const ApplicationRow = ({ service }: { service: ImageService }) => {
+	const provenance = classifyApplicationProvenance({
+		sourceType: service.sourceType as Parameters<
+			typeof classifyApplicationProvenance
+		>[0]["sourceType"],
+		dockerImage: service.dockerImage,
+		registryId: service.registryId,
+	});
+	const detail =
+		provenance.restorability === "in-registry"
+			? service.registryName
+			: provenance.image;
+	return (
+		<TableRow>
+			<TableCell className="pl-12">
+				<div className="flex items-center gap-2">
+					<ServiceTypeIcon type="application" />
+					<span className="font-medium">{service.name}</span>
+				</div>
+			</TableCell>
+			<TableCell>
+				<RestorabilityBadge
+					restorability={provenance.restorability}
+					detail={detail}
+				/>
+			</TableCell>
+		</TableRow>
+	);
+};
+
+export const RegistryImageProvenance = () => {
+	const { data, isPending } = api.backupPolicy.imageProvenance.useQuery();
+	const [expandOverrides, setExpandOverrides] = useState<
+		Record<string, boolean>
+	>({});
+	const [search, setSearch] = useState("");
+
+	const isExpanded = (key: string, fallback: boolean) =>
+		expandOverrides[key] ?? fallback;
+	const toggle = (key: string, fallback: boolean) =>
+		setExpandOverrides((prev) => ({
+			...prev,
+			[key]: !(prev[key] ?? fallback),
+		}));
+
+	const services = data?.services ?? [];
+
+	const totals = useMemo(() => {
+		let rePullable = 0;
+		let inRegistry = 0;
+		let rebuildOnly = 0;
+		for (const service of services) {
+			const restorability = applicationRestorability(service);
+			if (restorability === "re-pullable") rePullable++;
+			else if (restorability === "in-registry") inRegistry++;
+			else if (restorability === "rebuild-only") rebuildOnly++;
+		}
+		return { rePullable, inRegistry, rebuildOnly };
+	}, [services]);
+
+	const tree = useMemo<ProjectNode[]>(() => {
+		const projects = new Map<
+			string,
+			ProjectNode & { environmentMap: Map<string, EnvironmentNode> }
+		>();
+		for (const service of services) {
+			if (
+				!serviceMatchesSearch(
+					{
+						name: service.name,
+						projectName: service.project.name,
+						environmentName: service.environment.name,
+					},
+					search,
+				)
+			) {
+				continue;
+			}
+			let project = projects.get(service.project.id);
+			if (!project) {
+				project = {
+					id: service.project.id,
+					name: service.project.name,
+					logo: service.project.logo,
+					environments: [],
+					rebuildOnly: 0,
+					environmentMap: new Map(),
+				};
+				projects.set(service.project.id, project);
+			}
+			let environment = project.environmentMap.get(service.environment.id);
+			if (!environment) {
+				environment = {
+					id: service.environment.id,
+					name: service.environment.name,
+					services: [],
+					rebuildOnly: 0,
+				};
+				project.environmentMap.set(service.environment.id, environment);
+				project.environments.push(environment);
+			}
+			environment.services.push(service);
+			if (applicationRestorability(service) === "rebuild-only") {
+				environment.rebuildOnly++;
+				project.rebuildOnly++;
+			}
+		}
+		return Array.from(projects.values()).map(
+			({ environmentMap: _drop, ...node }) => node,
+		);
+	}, [services, search]);
+
+	return (
+		<Card className="h-full max-w-5xl mx-auto rounded-xl bg-sidebar p-2.5">
+			<div className="rounded-xl bg-background shadow-md">
+				<CardHeader>
+					<CardTitle className="flex flex-row items-center gap-2 text-xl">
+						<Layers className="size-6 self-center text-muted-foreground" />
+						Image restorability
+					</CardTitle>
+					<CardDescription>
+						Whether each service's image can be pulled back without rebuilding,
+						and from where. Databases and Redis run standard public images and
+						are omitted.
+					</CardDescription>
+					{!isPending && services.length > 0 ? (
+						<div className="flex flex-wrap gap-2 pt-1">
+							<Badge variant="green">{totals.rePullable} re-pullable</Badge>
+							<Badge variant="green">{totals.inRegistry} in registry</Badge>
+							<Badge variant={totals.rebuildOnly > 0 ? "orange" : "blank"}>
+								{totals.rebuildOnly} rebuild-only
+							</Badge>
+						</div>
+					) : null}
+				</CardHeader>
+				<CardContent className="flex flex-col gap-4 border-t py-6">
+					{isPending ? (
+						<div className="flex min-h-[20vh] items-center justify-center">
+							<Loader2 className="size-6 animate-spin text-muted-foreground" />
+						</div>
+					) : services.length === 0 ? (
+						<div className="flex min-h-[20vh] flex-col items-center justify-center gap-3">
+							<Layers className="size-8 text-muted-foreground" />
+							<span className="text-base text-muted-foreground">
+								No applications or compose services yet
+							</span>
+						</div>
+					) : (
+						<>
+							<div className="relative">
+								<Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+								<Input
+									value={search}
+									onChange={(event) => setSearch(event.target.value)}
+									placeholder="Search by project, service or environment..."
+									className="pl-8"
+								/>
+							</div>
+							{tree.length === 0 ? (
+								<div className="flex min-h-[10vh] items-center justify-center">
+									<span className="text-sm text-muted-foreground">
+										No services match your search.
+									</span>
+								</div>
+							) : (
+								<div className="overflow-x-auto">
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Service</TableHead>
+												<TableHead>Restorability</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{tree.map((project) => {
+												const projectExpanded = isExpanded(
+													`p:${project.id}`,
+													true,
+												);
+												return (
+													<Fragment key={project.id}>
+														<TableRow
+															className="cursor-pointer bg-muted/40 hover:bg-muted/60"
+															onClick={() => toggle(`p:${project.id}`, true)}
+														>
+															<TableCell
+																colSpan={COLUMN_COUNT}
+																className="py-2"
+															>
+																<div className="flex items-center gap-2">
+																	<ExpandChevron expanded={projectExpanded} />
+																	<ProjectIcon
+																		logo={project.logo}
+																		faviconUrls={getProjectFaviconUrls([])}
+																		className="size-4 rounded-sm object-contain"
+																		fallback={
+																			<Folder className="size-4 text-muted-foreground" />
+																		}
+																	/>
+																	<span className="font-medium">
+																		{project.name}
+																	</span>
+																	{!projectExpanded && (
+																		<RollupBadge
+																			rebuildOnly={project.rebuildOnly}
+																		/>
+																	)}
+																</div>
+															</TableCell>
+														</TableRow>
+														{projectExpanded &&
+															project.environments.map((environment) => {
+																const envKey = `e:${environment.id}`;
+																const envExpanded = isExpanded(envKey, false);
+																return (
+																	<Fragment key={environment.id}>
+																		<TableRow
+																			className="cursor-pointer hover:bg-muted/40"
+																			onClick={() => toggle(envKey, false)}
+																		>
+																			<TableCell
+																				colSpan={COLUMN_COUNT}
+																				className="py-2 pl-8"
+																			>
+																				<div className="flex items-center gap-2">
+																					<ExpandChevron
+																						expanded={envExpanded}
+																					/>
+																					<span className="text-sm">
+																						{environment.name}
+																					</span>
+																					{!envExpanded && (
+																						<RollupBadge
+																							rebuildOnly={
+																								environment.rebuildOnly
+																							}
+																						/>
+																					)}
+																				</div>
+																			</TableCell>
+																		</TableRow>
+																		{envExpanded &&
+																			environment.services.map((service) => {
+																				if (service.type === "application") {
+																					return (
+																						<ApplicationRow
+																							key={service.serviceId}
+																							service={service}
+																						/>
+																					);
+																				}
+																				const composeKey = `c:${service.serviceId}`;
+																				const composeExpanded = isExpanded(
+																					composeKey,
+																					false,
+																				);
+																				return (
+																					<Fragment key={service.serviceId}>
+																						<TableRow
+																							className="cursor-pointer"
+																							onClick={() =>
+																								toggle(composeKey, false)
+																							}
+																						>
+																							<TableCell className="pl-12">
+																								<div className="flex items-center gap-2">
+																									<ExpandChevron
+																										expanded={composeExpanded}
+																									/>
+																									<ServiceTypeIcon type="compose" />
+																									<span className="font-medium">
+																										{service.name}
+																									</span>
+																								</div>
+																							</TableCell>
+																							<TableCell>
+																								<span className="text-xs text-muted-foreground">
+																									{service.hasComposeFile
+																										? "Expand to inspect services"
+																										: "No compose file yet"}
+																								</span>
+																							</TableCell>
+																						</TableRow>
+																						{composeExpanded && (
+																							<ComposeImageChildren
+																								composeId={service.serviceId}
+																							/>
+																						)}
+																					</Fragment>
+																				);
+																			})}
+																	</Fragment>
+																);
+															})}
+													</Fragment>
+												);
+											})}
+										</TableBody>
+									</Table>
+								</div>
+							)}
+						</>
+					)}
+				</CardContent>
+			</div>
+		</Card>
+	);
+};

--- a/apps/dokploy/components/dashboard/settings/cluster/registry/show-registry.tsx
+++ b/apps/dokploy/components/dashboard/settings/cluster/registry/show-registry.tsx
@@ -17,6 +17,15 @@ export const ShowRegistry = () => {
 		api.registry.remove.useMutation();
 	const { data, isPending, refetch } = api.registry.all.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();
+	// Reuses the Registry-page image-provenance query (deduped with the
+	// provenance table below) for the per-registry "services push here" count.
+	const { data: provenance } = api.backupPolicy.imageProvenance.useQuery();
+	const pushCountById = new Map(
+		(provenance?.registries ?? []).map((entry) => [
+			entry.registryId,
+			entry.pushCount,
+		]),
+	);
 
 	return (
 		<div className="w-full">
@@ -66,6 +75,16 @@ export const ShowRegistry = () => {
 																		{registry.registryUrl}
 																	</div>
 																)}
+																<div className="text-xs text-muted-foreground">
+																	{(() => {
+																		const count =
+																			pushCountById.get(registry.registryId) ??
+																			0;
+																		return count === 1
+																			? "1 service pushes here"
+																			: `${count} services push here`;
+																	})()}
+																</div>
 															</div>
 														</div>
 

--- a/apps/dokploy/lib/image-provenance.ts
+++ b/apps/dokploy/lib/image-provenance.ts
@@ -1,0 +1,107 @@
+// Pure classification for the image-restorability view: can a service's image
+// be pulled back without rebuilding, and from which registry? No React / DB
+// imports so the logic stays unit-testable.
+
+/** The default registry when an image reference carries no host. */
+export const DEFAULT_REGISTRY_HOST = "docker.io";
+
+/**
+ * Parse the registry host from a docker image reference, defaulting to
+ * `docker.io` when none is present. Follows Docker's own rule: the first
+ * path component is a registry host only when it contains a `.` or `:` or is
+ * exactly `localhost` AND the reference has a `/`. Otherwise the first
+ * component is a Docker Hub namespace/official image.
+ *
+ * Handles bare names (`nginx`), namespaced repos (`bitnami/nginx`), hosts
+ * (`ghcr.io/acme/app`), host:port (`localhost:5000/app`), tags (`:1.2`) and
+ * digests (`@sha256:...`). Returns null for empty input.
+ */
+export const parseRegistryHost = (
+	imageRef: string | null | undefined,
+): string | null => {
+	const ref = imageRef?.trim();
+	if (!ref) return null;
+	const firstComponent = ref.split("/")[0] ?? "";
+	const looksLikeHost =
+		firstComponent === "localhost" ||
+		firstComponent.includes(".") ||
+		firstComponent.includes(":");
+	if (ref.includes("/") && looksLikeHost) {
+		return firstComponent;
+	}
+	return DEFAULT_REGISTRY_HOST;
+};
+
+/**
+ * Image restorability of a service:
+ * - `re-pullable`: the image is a ready reference (docker-source app, or a
+ *   compose child with `image:`) — pull it back, no rebuild needed.
+ * - `in-registry`: a source-built app that pushes to an assigned registry —
+ *   the built image lives in that registry.
+ * - `rebuild-only`: a source-built app with no registry, or a compose child
+ *   with `build:` — the image exists only in the local docker daemon.
+ */
+export type ImageRestorability = "re-pullable" | "in-registry" | "rebuild-only";
+
+/** Application source types that are built from source (vs. a docker image). */
+export type ApplicationSourceType =
+	| "docker"
+	| "git"
+	| "github"
+	| "gitlab"
+	| "bitbucket"
+	| "gitea"
+	| "drop";
+
+export interface ApplicationProvenanceInput {
+	sourceType: ApplicationSourceType;
+	dockerImage: string | null;
+	registryId: string | null;
+}
+
+export interface ApplicationProvenance {
+	restorability: ImageRestorability;
+	/** The image reference for docker-source apps. */
+	image: string | null;
+	/** Parsed registry host for docker-source apps. */
+	registryHost: string | null;
+}
+
+/** Classify an application's image restorability from its source/registry. */
+export const classifyApplicationProvenance = (
+	app: ApplicationProvenanceInput,
+): ApplicationProvenance => {
+	if (app.sourceType === "docker") {
+		return {
+			restorability: "re-pullable",
+			image: app.dockerImage ?? null,
+			registryHost: parseRegistryHost(app.dockerImage),
+		};
+	}
+	// Built from source: recoverable only if it is pushed to a registry.
+	if (app.registryId) {
+		return { restorability: "in-registry", image: null, registryHost: null };
+	}
+	return { restorability: "rebuild-only", image: null, registryHost: null };
+};
+
+export interface ComposeChildProvenance {
+	restorability: Extract<ImageRestorability, "re-pullable" | "rebuild-only">;
+	registryHost: string | null;
+}
+
+/**
+ * Classify a compose child container by whether it declares an `image:`
+ * (re-pullable) or is built from a `build:` context (rebuild-only). Mirrors the
+ * `image` field returned by `extractComposeChildren`, where a build-only
+ * service has no image.
+ */
+export const classifyComposeChildImage = (child: {
+	image: string | null;
+}): ComposeChildProvenance =>
+	child.image
+		? {
+				restorability: "re-pullable",
+				registryHost: parseRegistryHost(child.image),
+			}
+		: { restorability: "rebuild-only", registryHost: null };

--- a/apps/dokploy/pages/dashboard/settings/registry.tsx
+++ b/apps/dokploy/pages/dashboard/settings/registry.tsx
@@ -3,6 +3,7 @@ import { createServerSideHelpers } from "@trpc/react-query/server";
 import type { GetServerSidePropsContext } from "next";
 import type { ReactElement } from "react";
 import superjson from "superjson";
+import { RegistryImageProvenance } from "@/components/dashboard/settings/cluster/registry/registry-image-provenance";
 import { ShowRegistry } from "@/components/dashboard/settings/cluster/registry/show-registry";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { appRouter } from "@/server/api/root";
@@ -11,6 +12,7 @@ const Page = () => {
 	return (
 		<div className="flex flex-col gap-4 w-full">
 			<ShowRegistry />
+			<RegistryImageProvenance />
 		</div>
 	);
 };

--- a/apps/dokploy/server/api/routers/backup-policy.ts
+++ b/apps/dokploy/server/api/routers/backup-policy.ts
@@ -61,6 +61,7 @@ import {
 	postgres,
 	projects,
 	redis,
+	registry,
 	volumeBackups,
 } from "@/server/db/schema";
 
@@ -1361,4 +1362,172 @@ export const backupPolicyRouter = createTRPCRouter({
 				nextOffset: hasMore ? input.offset + input.limit : null,
 			};
 		}),
+
+	// Image-restorability view for the Registry settings page: for every
+	// application and compose service the user can see, the provenance fields
+	// needed to classify whether its image can be pulled back without a rebuild
+	// (classified client-side by lib/image-provenance). Plus a credential-free
+	// summary of the org's registries and how many applications push to each.
+	// Gated by `registry:read` to match the Registry page (owner/admin), and
+	// service-ACL-scoped for members exactly like `coverage`.
+	imageProvenance: withPermission("registry", "read").query(async ({ ctx }) => {
+		const organizationId = ctx.session.activeOrganizationId;
+		const isPrivileged = ctx.user.role === "owner" || ctx.user.role === "admin";
+		const empty = { services: [], registries: [] };
+
+		let accessedProjects: string[] = [];
+		let accessedEnvironments: string[] = [];
+		let accessedServices: string[] = [];
+		if (!isPrivileged) {
+			const member = await findMemberByUserId(ctx.user.id, organizationId);
+			accessedProjects = member.accessedProjects;
+			accessedEnvironments = member.accessedEnvironments;
+			accessedServices = member.accessedServices;
+			if (accessedProjects.length === 0) return empty;
+		}
+
+		const projectWhere = isPrivileged
+			? eq(projects.organizationId, organizationId)
+			: and(
+					sql`${projects.projectId} IN (${sql.join(
+						accessedProjects.map((projectId) => sql`${projectId}`),
+						sql`, `,
+					)})`,
+					eq(projects.organizationId, organizationId),
+				);
+		const environmentWhere = isPrivileged
+			? undefined
+			: accessedEnvironments.length === 0
+				? sql`false`
+				: sql`${environments.environmentId} IN (${sql.join(
+						accessedEnvironments.map((envId) => sql`${envId}`),
+						sql`, `,
+					)})`;
+		const serviceFilter = (fieldName: AnyPgColumn) =>
+			isPrivileged
+				? undefined
+				: buildServiceFilter(fieldName, accessedServices);
+
+		const projectRows = await db.query.projects.findMany({
+			where: projectWhere,
+			columns: { projectId: true, name: true, logo: true },
+			with: {
+				environments: {
+					where: environmentWhere,
+					columns: { environmentId: true, name: true },
+					with: {
+						applications: {
+							where: serviceFilter(applications.applicationId),
+							columns: {
+								applicationId: true,
+								name: true,
+								sourceType: true,
+								buildType: true,
+								dockerImage: true,
+								registryId: true,
+							},
+							with: { registry: { columns: { registryName: true } } },
+						},
+						compose: {
+							where: serviceFilter(compose.composeId),
+							columns: {
+								composeId: true,
+								name: true,
+								sourceType: true,
+								composeFile: true,
+							},
+						},
+					},
+				},
+			},
+		});
+
+		interface ImageService {
+			serviceId: string;
+			type: "application" | "compose";
+			name: string;
+			project: { id: string; name: string; logo: string | null };
+			environment: { id: string; name: string };
+			sourceType: string;
+			buildType: string | null;
+			dockerImage: string | null;
+			registryId: string | null;
+			registryName: string | null;
+			hasComposeFile: boolean;
+		}
+		const services: ImageService[] = [];
+		const registryPushCounts = new Map<string, number>();
+
+		for (const project of projectRows) {
+			const projectRef = {
+				id: project.projectId,
+				name: project.name,
+				logo: project.logo ?? null,
+			};
+			for (const environment of project.environments) {
+				const envRef = {
+					id: environment.environmentId,
+					name: environment.name,
+				};
+				for (const app of environment.applications) {
+					if (app.registryId) {
+						registryPushCounts.set(
+							app.registryId,
+							(registryPushCounts.get(app.registryId) ?? 0) + 1,
+						);
+					}
+					services.push({
+						serviceId: app.applicationId,
+						type: "application",
+						name: app.name,
+						project: projectRef,
+						environment: envRef,
+						sourceType: app.sourceType,
+						buildType: app.buildType,
+						dockerImage: app.dockerImage ?? null,
+						registryId: app.registryId ?? null,
+						registryName: app.registry?.registryName ?? null,
+						hasComposeFile: false,
+					});
+				}
+				for (const comp of environment.compose) {
+					services.push({
+						serviceId: comp.composeId,
+						type: "compose",
+						name: comp.name,
+						project: projectRef,
+						environment: envRef,
+						sourceType: comp.sourceType,
+						buildType: null,
+						dockerImage: null,
+						registryId: null,
+						registryName: null,
+						hasComposeFile: Boolean(comp.composeFile?.trim()),
+					});
+				}
+			}
+		}
+
+		// Credential-free registry summary (no password / AWS secret fields).
+		const registryRows = await db.query.registry.findMany({
+			where: eq(registry.organizationId, organizationId),
+			columns: {
+				registryId: true,
+				registryName: true,
+				registryUrl: true,
+				username: true,
+				registryType: true,
+			},
+		});
+		const registries = registryRows.map((row) => ({
+			registryId: row.registryId,
+			name: row.registryName,
+			url: row.registryUrl,
+			username: row.username,
+			type: row.registryType,
+			pushCount: registryPushCounts.get(row.registryId) ?? 0,
+		}));
+
+		return { services, registries };
+	}),
 });


### PR DESCRIPTION
Adds an "can I restore this app's image without rebuilding, and from where?" view. Per user direction, it lives entirely on the existing **Settings → Registry** page — no new Backup Center tab, and the Backup Center is untouched.

## What
**Settings → Registry page** now has:
1. **Per-registry push count** — each existing registry card shows "N services push here" (count of applications assigned that registry).
2. **Image restorability table (below the registries list)** — every application + compose service, grouped by project → environment (project icons, search box, lazy compose children, rollup badges, header totals), each with a restorability badge:
   - **Re-pullable** (green) — docker-source app, or a compose child with `image:` — pull it back, no rebuild. Shows the image ref.
   - **In registry** (green) — a source-built app with a push registry assigned — the built image lives in that registry. Shows the registry name.
   - **Rebuild only** (orange ⚠) — a source-built app with no registry, or a compose child with `build:` — the image exists only in the local docker daemon.
   - Databases/Redis run standard public images and are omitted.

Header shows overall totals (X re-pullable / Y in registry / Z rebuild-only); collapsed project/env rows show a "⚠ N rebuild-only" rollup or a green check.

## How
- **One additive tRPC query** `backupPolicy.imageProvenance`, gated `registry:read` to match the Registry page (owner/admin) and service-ACL-scoped for members exactly like `backupPolicy.coverage`. Returns per-service provenance fields (sourceType/buildType/dockerImage/registryId+name/hasComposeFile) and a credential-free registry summary (name/url/username/type + pushCount) — **no passwords, no AWS secrets, no env vars**. `ShowRegistry` and the provenance table share this one query (React Query dedupes).
- **Pure classification** in `apps/dokploy/lib/image-provenance.ts` (`parseRegistryHost`, `classifyApplicationProvenance`, `classifyComposeChildImage`) with **10 new vitest tests**. Registry-host parsing handles bare names → docker.io, user/repo, host/repo, host:port/repo, tags and digests.
- Compose children reuse the existing lazy `backupPolicy.composeChildren` endpoint (image present → re-pullable, absent → rebuild-only).
- **No migration.**

## Scope / notes
- Rollup counts and header totals are over **applications** (known up-front). Compose services are expandable; their children's badges show on expand but don't feed the numeric rollups, because classifying them requires the lazy per-compose parse (the tree deliberately avoids eager-loading every compose). Noted as a limitation.
- Backup Center (Coverage/Policies/Instance/Activity) is unchanged; no Coverage column added.

## Verification
- `pnpm --filter=dokploy typecheck` clean
- `pnpm --filter=dokploy test __test__/backup-policy/` → 82/82 (10 new)
- biome clean