### PR TITLE
port: fix(monitoring): dedupe container metrics by task suffix, not name prefix (upstream #4843)

### DIFF
--- a/apps/monitoring/containers/config.go
+++ b/apps/monitoring/containers/config.go
@@ -51,11 +51,18 @@ func ShouldMonitorContainer(containerName string) bool {
 	return true
 }
 
+// GetServiceName returns the deduplication key of a container: its name
+// without the swarm task suffix (myapp.1.abc123 → myapp), so replicas of the
+// same swarm service are stored once per tick. Names without a task suffix
+// (docker compose containers) are already unique per container and are kept
+// as-is. Splitting on "-" here used to conflate distinct services sharing a
+// name prefix (app-x-mysql and app-x-redis both mapped to "app-x"), so only
+// the first of them in `docker stats` output was stored each tick — even
+// though metrics are stored and queried by full container_name.
 func GetServiceName(containerName string) string {
 	name := strings.TrimPrefix(containerName, "/")
-	parts := strings.Split(name, "-")
-	if len(parts) > 1 {
-		return strings.Join(parts[:len(parts)-1], "-")
+	if dot := strings.Index(name, "."); dot != -1 {
+		return name[:dot]
 	}
 	return name
 }

--- a/apps/monitoring/containers/config_test.go
+++ b/apps/monitoring/containers/config_test.go
@@ -1,0 +1,27 @@
+package containers
+
+import "testing"
+
+func TestGetServiceName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"swarm replica 1", "myapp-3fa2bc.1.zxc4vplq8m0e", "myapp-3fa2bc"},
+		{"swarm replica 2 collapses to the same service", "myapp-3fa2bc.2.a1b2c3d4e5f6", "myapp-3fa2bc"},
+		{"leading slash is stripped", "/myapp-3fa2bc.1.zxc4vplq8m0e", "myapp-3fa2bc"},
+		{"compose container_name stays distinct", "app-1425-mysql", "app-1425-mysql"},
+		{"sibling compose service must not collapse with the previous one", "app-1425-redis", "app-1425-redis"},
+		{"compose default naming stays distinct", "project-web-1", "project-web-1"},
+		{"name without separators", "single", "single"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GetServiceName(tc.in); got != tc.want {
+				t.Errorf("GetServiceName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ports upstream **[Dokploy/dokploy#4843](https://github.com/Dokploy/dokploy/pull/4843)** by @sensorialsn 1:1 into the fork.

## Problem
`GetServiceName` (apps/monitoring/containers/config.go) deduplicated `docker stats` output by stripping the last `-`-separated segment of the container name. That conflated distinct compose services sharing a dash prefix — `app-x-mysql` and `app-x-redis` both mapped to `app-x` — so only the first sibling in each `docker stats` tick was stored, even though metrics are stored and queried by full `container_name`.

## Fix
Dedupe on the swarm **task suffix** (`myapp.1.abc → myapp`) via `strings.Index(name, ".")` instead. Swarm replicas of one service still collapse to a single stored series per tick, while distinct compose containers (which have no `.`-task suffix) each keep their full name and get stored.

## Adaptations
None — the fork's `config.go` was byte-identical to the upstream base at `GetServiceName`, so the patch applied cleanly. Adds a standalone `config_test.go` (`TestGetServiceName`, 7 cases).

## Verification
Go is not installed in the porting environment, so the test was not executed locally; the change is a self-contained logic swap plus a table-driven unit test. CI (Go build/test) is the ground truth.

Credit: @sensorialsn (upstream #4843).