### PR TITLE
port: fix(wss): terminate disconnected container log streams (upstream #4836)

### DIFF
--- a/apps/dokploy/__test__/wss/utils.test.ts
+++ b/apps/dokploy/__test__/wss/utils.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	buildDockerLogsArguments,
+	createDockerLogsDataHandler,
 	isValidContainerId,
 	isValidSearch,
 	isValidSince,
 	isValidTail,
+	terminateDockerLogsProcess,
 } from "../../server/wss/utils";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("isValidTail (docker-container-logs)", () => {
 	it("accepts valid numeric tail values", () => {
@@ -92,16 +99,13 @@ describe("isValidSearch (docker-container-logs)", () => {
 		expect(isValidSearch("a\x19b")).toBe(false);
 	});
 
-	it("rejects command injection vectors in search (search is concatenated into shell)", () => {
-		// Double-quoted context (SSH line 99): $ and ` execute
+	it("rejects shell metacharacters and unsupported punctuation", () => {
 		expect(isValidSearch("$(whoami)")).toBe(false);
 		expect(isValidSearch("`id`")).toBe(false);
 		expect(isValidSearch("$(id)")).toBe(false);
-		// Single-quoted context (local line 153): ' breaks out
 		expect(isValidSearch("'$(whoami)'")).toBe(false);
 		expect(isValidSearch("error'")).toBe(false);
 		expect(isValidSearch("'; whoami; #")).toBe(false);
-		// Other shell-metacharacters
 		expect(isValidSearch("error; id")).toBe(false);
 		expect(isValidSearch("a|b")).toBe(false);
 		expect(isValidSearch('error"')).toBe(false);
@@ -128,5 +132,100 @@ describe("isValidContainerId (docker-container-logs)", () => {
 		expect(isValidContainerId("`id`")).toBe(false);
 		expect(isValidContainerId("container|cat /etc/passwd")).toBe(false);
 		expect(isValidContainerId("x; env | grep DATABASE")).toBe(false);
+	});
+});
+
+describe("buildDockerLogsArguments", () => {
+	it("builds native container log arguments", () => {
+		expect(
+			buildDockerLogsArguments({
+				containerId: "abc123def456",
+				runType: "native",
+				since: "all",
+				tail: "100",
+			}),
+		).toEqual([
+			"container",
+			"logs",
+			"--timestamps",
+			"--tail",
+			"100",
+			"--follow",
+			"abc123def456",
+		]);
+	});
+
+	it("includes swarm and since flags when requested", () => {
+		expect(
+			buildDockerLogsArguments({
+				containerId: "scorely-backend",
+				runType: "swarm",
+				since: "10m",
+				tail: "300",
+			}),
+		).toEqual([
+			"service",
+			"logs",
+			"--timestamps",
+			"--raw",
+			"--tail",
+			"300",
+			"--since",
+			"10m",
+			"--follow",
+			"scorely-backend",
+		]);
+	});
+});
+
+describe("createDockerLogsDataHandler", () => {
+	it("forwards unfiltered chunks without buffering", () => {
+		const onData = vi.fn();
+		const handler = createDockerLogsDataHandler("", onData);
+
+		handler.write("first chunk");
+		handler.write(Buffer.from(" second chunk"));
+		handler.flush();
+
+		expect(onData.mock.calls).toEqual([["first chunk"], [" second chunk"]]);
+	});
+
+	it("filters case-insensitively across chunk boundaries", () => {
+		const onData = vi.fn();
+		const handler = createDockerLogsDataHandler("error", onData);
+
+		handler.write("info: started\nER");
+		handler.write("ROR: failed\ninfo: done\npartial error");
+		handler.flush();
+
+		expect(onData.mock.calls).toEqual([["ERROR: failed\n"], ["partial error"]]);
+	});
+});
+
+describe("terminateDockerLogsProcess", () => {
+	it("escalates from SIGTERM to SIGKILL while the process is running", () => {
+		vi.useFakeTimers();
+		const childProcess = {
+			exitCode: null,
+			signalCode: null,
+			kill: vi.fn(() => true),
+		};
+
+		terminateDockerLogsProcess(childProcess);
+		expect(childProcess.kill).toHaveBeenCalledWith("SIGTERM");
+
+		vi.advanceTimersByTime(1000);
+		expect(childProcess.kill).toHaveBeenLastCalledWith("SIGKILL");
+	});
+
+	it("does not signal a process that has already exited", () => {
+		const childProcess = {
+			exitCode: 0,
+			signalCode: null,
+			kill: vi.fn(() => true),
+		};
+
+		expect(terminateDockerLogsProcess(childProcess)).toBeUndefined();
+		expect(childProcess.kill).not.toHaveBeenCalled();
 	});
 });

--- a/apps/dokploy/components/dashboard/docker/logs/docker-logs-id.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/docker-logs-id.tsx
@@ -222,7 +222,10 @@ export const DockerLogsId: React.FC<Props> = ({
 		return () => {
 			isCurrentConnection = false;
 			if (noDataTimeout) clearTimeout(noDataTimeout);
-			if (ws.readyState === WebSocket.OPEN) {
+			if (
+				ws.readyState === WebSocket.OPEN ||
+				ws.readyState === WebSocket.CONNECTING
+			) {
 				ws.close();
 			}
 		};

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -1,14 +1,17 @@
+import { spawn } from "node:child_process";
 import type http from "node:http";
 import { findServerById, IS_CLOUD, validateRequest } from "@dokploy/server";
-import { spawn } from "node-pty";
-import { Client } from "ssh2";
+import { spawn as spawnPty } from "node-pty";
+import { Client, type ClientChannel } from "ssh2";
 import { WebSocketServer } from "ws";
 import {
-	getShell,
+	buildDockerLogsArguments,
+	createDockerLogsDataHandler,
 	isValidContainerId,
 	isValidSearch,
 	isValidSince,
 	isValidTail,
+	terminateDockerLogsProcess,
 } from "./utils";
 
 export const setupDockerContainerLogsWebSocketServer = (
@@ -41,7 +44,43 @@ export const setupDockerContainerLogsWebSocketServer = (
 		const since = url.searchParams.get("since") ?? "all";
 		const serverId = url.searchParams.get("serverId");
 		const runType = url.searchParams.get("runType");
+		const timers: {
+			forceKill?: NodeJS.Timeout;
+			ping?: NodeJS.Timeout;
+		} = {};
+		let localProcess: ReturnType<typeof spawn> | undefined;
+		let localAttach: ReturnType<typeof spawnPty> | undefined;
+		let sshClient: Client | undefined;
+		let sshStream: ClientChannel | undefined;
+		let isClosed = false;
+
+		const cleanup = () => {
+			if (isClosed) return;
+			isClosed = true;
+
+			if (timers.ping) clearInterval(timers.ping);
+
+			if (sshStream) {
+				try {
+					sshStream.signal("KILL");
+				} catch {}
+				sshStream.close();
+			}
+			sshClient?.end();
+
+			if (localProcess) {
+				timers.forceKill = terminateDockerLogsProcess(localProcess);
+			}
+			if (localAttach) {
+				try {
+					localAttach.kill();
+				} catch {}
+			}
+		};
+
+		ws.once("close", cleanup);
 		const { user, session } = await validateRequest(req);
+		if (isClosed) return;
 
 		if (!containerId) {
 			ws.close(4000, "containerId no provided");
@@ -76,61 +115,82 @@ export const setupDockerContainerLogsWebSocketServer = (
 
 		// Set up keep-alive ping mechanism to prevent timeout
 		// Send ping every 45 seconds to keep connection alive
-		const pingInterval = setInterval(() => {
+		timers.ping = setInterval(() => {
 			if (ws.readyState === ws.OPEN) {
 				ws.ping();
 			}
 		}, 45000); // 45 seconds
+		timers.ping.unref();
+
+		const send = (data: Buffer | string) => {
+			if (ws.readyState === ws.OPEN) {
+				ws.send(data.toString());
+			}
+		};
+		const dockerLogsArguments = buildDockerLogsArguments({
+			containerId,
+			runType,
+			since,
+			tail,
+		});
 		try {
 			if (serverId) {
 				const server = await findServerById(serverId);
+				if (isClosed) return;
 
 				if (server.organizationId !== session.activeOrganizationId) {
 					ws.close();
 					return;
 				}
 
-				if (!server.sshKeyId) return;
-				const client = new Client();
-				client
+				if (!server.sshKeyId) {
+					ws.close(4000, "No SSH key available for this server");
+					return;
+				}
+				sshClient = new Client();
+				sshClient
 					.once("ready", () => {
-						const baseCommand = `docker ${runType === "swarm" ? "service" : "container"} logs --timestamps ${
-							runType === "swarm" ? "--raw" : ""
-						} --tail ${tail} ${
-							since === "all" ? "" : `--since ${since}`
-						} --follow ${containerId}`;
-						const escapedSearch = search ? search.replace(/'/g, "'\\''") : "";
-						const command = search
-							? `${baseCommand} 2>&1 | grep --line-buffered -iF "${escapedSearch}"`
-							: baseCommand;
+						if (isClosed) {
+							sshClient?.end();
+							return;
+						}
+						const command = `docker ${dockerLogsArguments.join(" ")}`;
 						// Use pty: true to ensure the remote process receives SIGHUP when SSH connection closes
 						// This is crucial for terminating docker logs processes when the connection is closed
-						client.exec(command, { pty: true }, (err, stream) => {
+						sshClient?.exec(command, { pty: true }, (err, stream) => {
 							if (err) {
 								console.error("Execution error:", err);
 								ws.close();
-								client.end();
+								sshClient?.end();
 								return;
 							}
+							sshStream = stream;
+							if (isClosed) {
+								try {
+									stream.signal("KILL");
+								} catch {}
+								stream.close();
+								sshClient?.end();
+								return;
+							}
+							const stdout = createDockerLogsDataHandler(search, send);
+							const stderr = createDockerLogsDataHandler(search, send);
 							stream
 								.on("close", () => {
-									client.end();
+									stdout.flush();
+									stderr.flush();
+									sshClient?.end();
 									ws.close();
 								})
-								.on("data", (data: string) => {
-									ws.send(data.toString());
-								})
-								.stderr.on("data", (data) => {
-									ws.send(data.toString());
-								});
+								.on("data", stdout.write)
+								.stderr.on("data", stderr.write);
 						});
 					})
 					.on("error", (err) => {
 						console.error("SSH connection error:", err);
-						ws.send(`SSH error: ${err.message}`);
-						clearInterval(pingInterval);
+						send(`SSH error: ${err.message}`);
 						ws.close(); // Cierra el WebSocket si hay un error con SSH
-						client.end();
+						sshClient?.end();
 					})
 					.connect({
 						host: server.ipAddress,
@@ -138,26 +198,26 @@ export const setupDockerContainerLogsWebSocketServer = (
 						username: server.username,
 						privateKey: server.sshKey?.privateKey,
 					});
-				ws.on("close", () => {
-					clearInterval(pingInterval);
-					client.end();
-				});
 			} else {
 				if (IS_CLOUD) {
-					ws.send("This feature is not available in the cloud version.");
+					send("This feature is not available in the cloud version.");
 					ws.close();
 					return;
 				}
-				const shell = getShell();
-				const baseCommand = `docker ${runType === "swarm" ? "service" : "container"} logs --timestamps ${
-					runType === "swarm" ? "--raw" : ""
-				} --tail ${tail} ${
-					since === "all" ? "" : `--since ${since}`
-				} --follow ${containerId}`;
-				const command = search
-					? `${baseCommand} 2>&1 | grep -iF '${search}'`
-					: baseCommand;
-				const ptyProcess = spawn(shell, ["-c", command], {
+				const stdout = createDockerLogsDataHandler(search, send);
+				const stderr = createDockerLogsDataHandler(search, send);
+				const childProcess = spawn("docker", dockerLogsArguments, {
+					cwd: process.env.HOME,
+					env: process.env,
+					stdio: ["ignore", "pipe", "pipe"],
+				});
+				localProcess = childProcess;
+
+				// Separate interactive process so the "Send a command" input in the
+				// logs view can forward keystrokes to the container's stdin. The logs
+				// stream above is output-only (stdio stdin is ignored), so attaching
+				// keeps interactivity while the child_process handles clean teardown.
+				const attachPty = spawnPty("docker", ["attach", containerId], {
 					name: "xterm-256color",
 					cwd: process.env.HOME,
 					env: process.env,
@@ -165,23 +225,19 @@ export const setupDockerContainerLogsWebSocketServer = (
 					cols: 80,
 					rows: 30,
 				});
+				localAttach = attachPty;
 
-				const attachPty = spawn("docker", ["attach", containerId], {
-					name: "xterm-256color",
-					cwd: process.env.HOME,
-					env: process.env,
-					encoding: "utf8",
-					cols: 80,
-					rows: 30,
+				childProcess.stdout.on("data", stdout.write);
+				childProcess.stderr.on("data", stderr.write);
+				childProcess.once("close", () => {
+					stdout.flush();
+					stderr.flush();
+					if (timers.forceKill) clearTimeout(timers.forceKill);
+					ws.close();
 				});
-
-				ptyProcess.onData((data) => {
-					ws.send(data);
-				});
-				ws.on("close", () => {
-					clearInterval(pingInterval);
-					ptyProcess.kill();
-					attachPty.kill();
+				childProcess.once("error", (error) => {
+					send(error.message);
+					ws.close();
 				});
 				ws.on("message", (message) => {
 					try {
@@ -195,7 +251,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 					} catch (error) {
 						// @ts-ignore
 						const errorMessage = error?.message as unknown as string;
-						ws.send(errorMessage);
+						send(errorMessage);
 					}
 				});
 			}
@@ -203,7 +259,8 @@ export const setupDockerContainerLogsWebSocketServer = (
 			// @ts-ignore
 			const errorMessage = error?.message as unknown as string;
 
-			ws.send(errorMessage);
+			send(errorMessage);
+			ws.close();
 		}
 	});
 };

--- a/apps/dokploy/server/wss/utils.ts
+++ b/apps/dokploy/server/wss/utils.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -37,13 +38,98 @@ export const isValidSince = (since: string): boolean => {
 
 /**
  * Validates the `search` parameter for log filtering.
- * Search is concatenated into shell commands (SSH path: double quotes; local path: single quotes).
- * Only allow alphanumeric, space, dot, underscore, hyphen to prevent $, `, ', " from enabling command injection.
+ * Only allow alphanumeric, space, dot, underscore, and hyphen.
  * Max length 500.
  */
 export const isValidSearch = (search: string): boolean => {
 	// Space only (not \s) to reject \n, \r, \t and other control chars
 	return /^[a-zA-Z0-9 ._-]{0,500}$/.test(search);
+};
+
+interface DockerLogsArguments {
+	containerId: string;
+	runType: string | null;
+	since: string;
+	tail: string;
+}
+
+export const buildDockerLogsArguments = ({
+	containerId,
+	runType,
+	since,
+	tail,
+}: DockerLogsArguments): string[] => {
+	const args = [
+		runType === "swarm" ? "service" : "container",
+		"logs",
+		"--timestamps",
+	];
+
+	if (runType === "swarm") {
+		args.push("--raw");
+	}
+
+	args.push("--tail", tail);
+	if (since !== "all") {
+		args.push("--since", since);
+	}
+	args.push("--follow", containerId);
+
+	return args;
+};
+
+export const createDockerLogsDataHandler = (
+	search: string,
+	onData: (data: string) => void,
+) => {
+	if (!search) {
+		return {
+			write: (data: Buffer | string) => onData(data.toString()),
+			flush: () => {},
+		};
+	}
+
+	const normalizedSearch = search.toLowerCase();
+	let remainder = "";
+
+	return {
+		write: (data: Buffer | string) => {
+			const lines = `${remainder}${data.toString()}`.split("\n");
+			remainder = lines.pop() ?? "";
+			const matches = lines.filter((line) =>
+				line.toLowerCase().includes(normalizedSearch),
+			);
+			if (matches.length > 0) {
+				onData(`${matches.join("\n")}\n`);
+			}
+		},
+		flush: () => {
+			if (remainder.toLowerCase().includes(normalizedSearch)) {
+				onData(remainder);
+			}
+			remainder = "";
+		},
+	};
+};
+
+type KillableProcess = Pick<ChildProcess, "exitCode" | "kill" | "signalCode">;
+
+export const terminateDockerLogsProcess = (
+	childProcess: KillableProcess,
+): NodeJS.Timeout | undefined => {
+	if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+		return;
+	}
+
+	childProcess.kill("SIGTERM");
+	const forceKillTimeout = setTimeout(() => {
+		if (childProcess.exitCode === null && childProcess.signalCode === null) {
+			childProcess.kill("SIGKILL");
+		}
+	}, 1000);
+	forceKillTimeout.unref();
+
+	return forceKillTimeout;
 };
 
 /**


### PR DESCRIPTION
Ports upstream **[Dokploy/dokploy#4836](https://github.com/Dokploy/dokploy/pull/4836)** by @gilangh 1:1 into the fork (upstream closes Dokploy/dokploy#4835).

## Problem
The runtime Logs tab streams through `/docker-container-logs`. Disconnect cleanup was registered **after** the async `validateRequest`, so a client that disconnected mid-auth left the stream running. Local cleanup only killed the pty wrapper, and remote cleanup only ended the SSH client without signalling the remote `docker logs` process.

## Fix (from upstream)
- Registers `ws.once("close", cleanup)` **before** `validateRequest`, with an `isClosed` guard checked after each await.
- Local log process moves to `child_process.spawn` (stdout/stderr piped) with `terminateDockerLogsProcess` escalating `SIGTERM` → `SIGKILL` after 1s.
- SSH path explicitly `signal("KILL")`s and closes the remote channel on teardown.
- Frontend closes the WebSocket even when it unmounts while still `CONNECTING`.
- Server-side search filtering is chunk-safe and case-insensitive via `createDockerLogsDataHandler`.
- New pure helpers `buildDockerLogsArguments` / `createDockerLogsDataHandler` / `terminateDockerLogsProcess` with unit tests.

## Fork adaptation
The fork diverges from upstream in the local branch: it runs a **separate `docker attach` process** so the logs view's "Send a command" input (SendIcon form in `docker-logs-id.tsx`) forwards keystrokes to the container's stdin. Upstream removes the input path entirely when it switches to `child_process.spawn`.

To avoid regressing that feature, `docker-container-logs.ts` was hand-adapted rather than blind-applied:
- The **log stream** uses `child_process.spawn` with `stdio: ["ignore","pipe","pipe"]` (upstream's clean-teardown model).
- A **separate `node-pty` `docker attach` process** is kept for the interactive `ws.on("message")` input path.
- `cleanup()` kills **both** the log process (SIGTERM→SIGKILL escalation) and the attach process on disconnect.

`utils.ts`, `__test__/wss/utils.test.ts`, and the `docker-logs-id.tsx` CONNECTING fix were applied verbatim from upstream.

## Verification
- `pnpm --filter=dokploy typecheck` — clean.
- `pnpm exec vitest __test__/wss/utils.test.ts --run` — **22 passed**.

Credit: @gilangh (upstream #4836).