### PR TITLE
port: fix(ui): constrain organization menu width when sidebar is collapsed (upstream #4845)

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -689,7 +689,7 @@ function SidebarLogo() {
 								</SidebarMenuButton>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent
-								className="rounded-lg max-h-[min(70vh,28rem)] flex flex-col"
+								className="w-(--radix-dropdown-menu-trigger-width) min-w-64 rounded-lg max-h-[min(70vh,28rem)] flex flex-col"
 								align="start"
 								side={isMobile ? "bottom" : "right"}
 								sideOffset={4}


### PR DESCRIPTION
1:1 port of upstream [Dokploy/dokploy#4845](https://github.com/Dokploy/dokploy/pull/4845) by @hbilal9.

When the sidebar is collapsed, the organization dropdown menu rendered at an unconstrained width. This pins the menu to the trigger width with a sensible minimum (`w-(--radix-dropdown-menu-trigger-width) min-w-64`).

Applied verbatim — the target line was identical in this fork. Original authorship preserved on the commit.