### PR TITLE
port: fix: rename compose "Reload" action to "Rebuild" (upstream #4847)

### DIFF
--- a/apps/dokploy/components/dashboard/compose/general/actions.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/actions.tsx
@@ -153,19 +153,19 @@ export const ComposeActions = ({ composeId }: Props) => {
 					)}
 				{canDeploy && (
 					<DialogAction
-						title="Reload Compose"
-						description="Are you sure you want to reload this compose?"
+						title="Rebuild Compose"
+						description="Are you sure you want to rebuild this compose?"
 						type="default"
 						onClick={async () => {
 							await redeploy({
 								composeId: composeId,
 							})
 								.then(() => {
-									toast.success("Compose reloaded successfully");
+									toast.success("Compose rebuilt successfully");
 									refetch();
 								})
 								.catch(() => {
-									toast.error("Error reloading compose");
+									toast.error("Error rebuilding compose");
 								});
 						}}
 					>
@@ -178,12 +178,14 @@ export const ComposeActions = ({ composeId }: Props) => {
 								<TooltipTrigger asChild>
 									<div className="flex items-center">
 										<RefreshCcw className="size-4 mr-1" />
-										Reload
+										Rebuild
 									</div>
 								</TooltipTrigger>
 								<TooltipPrimitive.Portal>
 									<TooltipContent sideOffset={5} className="z-60">
-										<p>Reload the compose without rebuilding it</p>
+										<p>
+												Rebuilds the compose without downloading the source code
+											</p>
 									</TooltipContent>
 								</TooltipPrimitive.Portal>
 							</Tooltip>


### PR DESCRIPTION
1:1 port of upstream [Dokploy/dokploy#4847](https://github.com/Dokploy/dokploy/pull/4847) by @ANSUJKMEHER.

The compose "Reload" button actually calls `redeploy` (a rebuild), so the label and its tooltip ("without rebuilding it") were misleading. Renamed to **Rebuild** with an accurate tooltip and matching toasts.

Applied to the fork's diverged line positions; original authorship preserved on the commit.