### PR TITLE
port: add cursor pointer style for buttons (upstream #4890)

### DIFF
--- a/apps/dokploy/styles/globals.css
+++ b/apps/dokploy/styles/globals.css
@@ -269,6 +269,12 @@
 		@apply bg-background text-foreground;
 	}
 
+	/* Cursor pointer on buttons */
+	button:not([disabled]),
+	[role="button"]:not([disabled]) {
+		cursor: pointer;
+	}
+
 	/* Custom scrollbar styling */
 	::-webkit-scrollbar {
 		width: 0.3125rem;


### PR DESCRIPTION
Ports upstream Dokploy PR #4890 by @SteadEXE.

Adds a `cursor: pointer` style for non-disabled buttons and elements with `role="button"`, improving affordance across the UI.

Upstream: https://github.com/Dokploy/dokploy/pull/4890