### PR TITLE
fix(db): make fork-delta migrations idempotent and surface migration failures

### DIFF
--- a/apps/dokploy/__test__/db/migration-idempotency.test.ts
+++ b/apps/dokploy/__test__/db/migration-idempotency.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Fork-delta migrations (idx >= 174) must be idempotent.
+ *
+ * A user switching from OFFICIAL Dokploy to this fork can have upstream's own
+ * migrations already applied at an EARLIER `when` timestamp than the fork's
+ * journal records. Drizzle's migrator replays every journal entry whose `when`
+ * is greater than the last-applied `created_at`, so any fork-delta migration
+ * that re-runs unguarded DDL (e.g. a plain `ADD COLUMN`) throws (duplicate
+ * column/type/constraint), which rolls back the WHOLE pending batch and leaves
+ * the install missing every later fork table/column.
+ *
+ * This guards against a regression: every CREATE TABLE / CREATE TYPE /
+ * CREATE INDEX / ADD COLUMN / ADD CONSTRAINT in a fork-delta migration must be
+ * idempotent — either `IF NOT EXISTS`, or wrapped in a
+ * `DO $$ BEGIN ... EXCEPTION WHEN ... THEN null; END $$;` block (the style
+ * drizzle emits for types/constraints, which have no `IF NOT EXISTS` form).
+ *
+ * The linter is intentionally pragmatic (statement-split + regex). It must pass
+ * on the current fixed set and fail if someone adds an unguarded fork migration.
+ * Upstream-owned migrations (idx < 174) are out of scope.
+ */
+
+const FORK_DELTA_START = 174;
+const drizzleDir = path.resolve(__dirname, "../../drizzle");
+
+interface JournalEntry {
+	idx: number;
+	tag: string;
+}
+
+const journal = JSON.parse(
+	fs.readFileSync(path.join(drizzleDir, "meta/_journal.json"), "utf8"),
+) as { entries: JournalEntry[] };
+
+const forkEntries = journal.entries.filter((e) => e.idx >= FORK_DELTA_START);
+
+/** Drizzle separates statements with a `--> statement-breakpoint` marker. */
+const splitStatements = (sql: string): string[] =>
+	sql
+		.split("--> statement-breakpoint")
+		.map((s) => s.trim())
+		.filter(Boolean);
+
+/**
+ * A statement is idempotent when it is a `DO $$ ... EXCEPTION WHEN ...` block
+ * (which swallows duplicate_object/duplicate_column), or when the bare DDL
+ * carries an `IF NOT EXISTS` clause.
+ */
+const isGuarded = (stmt: string): boolean => {
+	if (/^DO\s+\$\$/i.test(stmt)) {
+		return /EXCEPTION\s+WHEN/i.test(stmt);
+	}
+	return /IF\s+NOT\s+EXISTS/i.test(stmt);
+};
+
+/** DDL that fails on re-apply unless guarded. */
+const NON_IDEMPOTENT_DDL: { label: string; pattern: RegExp }[] = [
+	{ label: "CREATE TABLE", pattern: /CREATE\s+TABLE/i },
+	{ label: "CREATE TYPE", pattern: /CREATE\s+TYPE/i },
+	{ label: "CREATE INDEX", pattern: /CREATE\s+(UNIQUE\s+)?INDEX/i },
+	{ label: "ADD COLUMN", pattern: /ADD\s+COLUMN/i },
+	{ label: "ADD CONSTRAINT", pattern: /ADD\s+CONSTRAINT/i },
+];
+
+describe("fork-delta migration idempotency (idx >= 174)", () => {
+	it("has fork-delta migrations to check", () => {
+		expect(forkEntries.length).toBeGreaterThan(0);
+	});
+
+	it.each(forkEntries.map((e) => [e.tag] as const))(
+		"%s only contains idempotent DDL",
+		(tag) => {
+			const file = path.join(drizzleDir, `${tag}.sql`);
+			expect(fs.existsSync(file)).toBe(true);
+			const sql = fs.readFileSync(file, "utf8");
+
+			const offenders: string[] = [];
+			for (const stmt of splitStatements(sql)) {
+				const kinds = NON_IDEMPOTENT_DDL.filter((d) =>
+					d.pattern.test(stmt),
+				).map((d) => d.label);
+				if (kinds.length === 0) continue;
+				if (isGuarded(stmt)) continue;
+				offenders.push(
+					`[${kinds.join(", ")}] ${stmt.replace(/\s+/g, " ").slice(0, 100)}`,
+				);
+			}
+
+			expect(
+				offenders,
+				`Unguarded DDL in ${tag}.sql — wrap in DO $$ ... EXCEPTION or add IF NOT EXISTS:\n${offenders.join("\n")}`,
+			).toEqual([]);
+		},
+	);
+});

--- a/apps/dokploy/drizzle/0174_great_naoko.sql
+++ b/apps/dokploy/drizzle/0174_great_naoko.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "backup" ADD COLUMN "includeEncryptionKey" boolean DEFAULT true NOT NULL;
+ALTER TABLE "backup" ADD COLUMN IF NOT EXISTS "includeEncryptionKey" boolean DEFAULT true NOT NULL;

--- a/apps/dokploy/server/db/migration.ts
+++ b/apps/dokploy/server/db/migration.ts
@@ -2,19 +2,34 @@ import { dbUrl } from "@dokploy/server/db";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import { captureError } from "../sentry";
 
 const sql = postgres(dbUrl, { max: 1 });
 const db = drizzle(sql);
 
-export const migration = async () =>
-	await migrate(db, { migrationsFolder: "drizzle" })
-		.then(() => {
-			console.log("Migration complete");
-			sql.end();
-		})
-		.catch((error) => {
-			console.log("Migration failed", error);
-		})
-		.finally(() => {
-			sql.end();
-		});
+export const migration = async () => {
+	try {
+		await migrate(db, { migrationsFolder: "drizzle" });
+		console.log("Migration complete");
+	} catch (error) {
+		// A swallowed migration failure is how an install ends up "half-migrated":
+		// the pending batch rolls back, later fork tables/columns never land, and
+		// the only visible symptom is downstream "column X does not exist" errors.
+		// Boot anyway (never brick a running install), but make the root cause
+		// LOUD in logs and report it to Sentry so broken switchers are diagnosable.
+		const message =
+			error instanceof Error ? error.message : String(error);
+		console.error(
+			"\n============================================================\n" +
+				"DATABASE MIGRATION FAILED — the app is starting WITHOUT the\n" +
+				"pending migrations applied. Schema-dependent features WILL break\n" +
+				"until this is resolved. Failing migration error:\n" +
+				`  ${message}\n` +
+				"============================================================\n",
+		);
+		console.error(error);
+		captureError(error, { subsystem: "db-migration" });
+	} finally {
+		await sql.end();
+	}
+};


### PR DESCRIPTION
## Problem

A user switching from **official Dokploy v0.29.13** to this fork with the documented one-command switch ends up with a half-migrated database.

Fork migration `apps/dokploy/drizzle/0174_great_naoko.sql` is upstream's own v0.29.13 migration:

```sql
ALTER TABLE "backup" ADD COLUMN "includeEncryptionKey" boolean DEFAULT true NOT NULL;
```

But the fork's journal entry for idx 174 carries `when=1783795384581`, while upstream ships `when=1783674181297`. Drizzle's migrator applies every journal entry whose `when` is greater than the last-applied `created_at`. So a switcher who already ran official 0174 (at the earlier timestamp) has the fork **re-execute** 0174 → `duplicate_column` → the entire pending batch (0174–0192) rolls back → every fork table/column is missing. Startup then continues silently, and the only errors surfaced are downstream symptoms.

Observed on a third-party install: `column projects.logo does not exist`, missing `cloudflare` table, etc. (Sentry issues DOKPLOY-COMMUNITY-3/4/5/6/7/9/A/B/C/D/E/F/G/K).

## Changes

1. **`0174_great_naoko.sql`** → `ADD COLUMN IF NOT EXISTS` so a re-apply is a no-op. The journal `when`/tag are untouched; drizzle gates application by timestamp, not content hash, so the hash change is safe.
2. **Audit of all fork-delta migrations (idx ≥ 174).** The rest already guard their DDL (`IF NOT EXISTS` for tables/columns/indexes, `DO $$ … EXCEPTION WHEN … THEN null; END $$;` for types/constraints). **Only 0174 was unguarded.**
3. **Regression test** `apps/dokploy/__test__/db/migration-idempotency.test.ts` — parses `_journal.json`, and for every fork-delta `.sql` asserts each `CREATE TABLE/TYPE/INDEX` and `ADD COLUMN/CONSTRAINT` is guarded. Fails if someone adds an unguarded fork migration.
4. **Migration-failure visibility** in `server/db/migration.ts` — on failure we now log a loud structured banner naming the failing error and stating the app is booting **without** the pending migrations, and report to Sentry when enabled (via the existing `captureError`). Boot-anyway behavior is preserved so we never brick a running install.

Restores the README "switch with one command" guarantee for v0.29.13 switchers.
