### PR TITLE
fix(security): scrub credentials from error reports and ExecError messages

### DIFF
--- a/apps/dokploy/__test__/process/exec-error-redaction.test.ts
+++ b/apps/dokploy/__test__/process/exec-error-redaction.test.ts
@@ -1,0 +1,54 @@
+import { ExecError } from "@dokploy/server/utils/process/ExecError";
+import { describe, expect, it } from "vitest";
+
+// Reproduces the leak path behind the scheduled-backup failure reports: a
+// generated backup command fails, Node embeds the ENTIRE command (with live
+// rclone/S3 flags) in the child_process error message, and that message is
+// wrapped into an ExecError which then reaches logs and Sentry. ExecError must
+// scrub every field it carries. All credentials below are obviously fake.
+
+describe("ExecError credential scrubbing", () => {
+	const command =
+		`RCLONE_CRYPT_PASSWORD='cryptFAKE' rclone rcat ` +
+		`--s3-access-key-id="AKIAFAKEFAKEFAKE" ` +
+		`--s3-secret-access-key="secret123" :s3:bucket/db.sql.gz`;
+
+	const originalError = new Error(`Command failed: ${command}`);
+
+	const error = new ExecError(`Command execution failed: ${command}`, {
+		command,
+		stdout: "",
+		stderr: `rclone: failed to upload with ${command}`,
+		exitCode: 1,
+		originalError,
+	});
+
+	const leaks = ["cryptFAKE", "AKIAFAKEFAKEFAKE", "secret123"];
+
+	it("scrubs the message", () => {
+		for (const leak of leaks) {
+			expect(error.message).not.toContain(leak);
+		}
+		expect(error.message).toContain("[REDACTED]");
+	});
+
+	it("scrubs the stored command and stderr", () => {
+		for (const leak of leaks) {
+			expect(error.command).not.toContain(leak);
+			expect(error.stderr ?? "").not.toContain(leak);
+		}
+	});
+
+	it("scrubs the wrapped original error message", () => {
+		for (const leak of leaks) {
+			expect(error.originalError?.message ?? "").not.toContain(leak);
+		}
+	});
+
+	it("scrubs getDetailedMessage() output", () => {
+		const detailed = error.getDetailedMessage();
+		for (const leak of leaks) {
+			expect(detailed).not.toContain(leak);
+		}
+	});
+});

--- a/apps/dokploy/__test__/process/redact-secrets.test.ts
+++ b/apps/dokploy/__test__/process/redact-secrets.test.ts
@@ -35,4 +35,95 @@ describe("redactSecrets", () => {
 
 		expect(redactSecrets(command)).toBe(command);
 	});
+
+	// All credentials below are obviously fake.
+	it("redacts rclone S3 credential flags in every quoting form", () => {
+		const doubleQuoted = redactSecrets(
+			'rclone rcat --s3-access-key-id="AKIAFAKEFAKEFAKE" :s3:b/f',
+		);
+		expect(doubleQuoted).not.toContain("AKIAFAKEFAKEFAKE");
+		expect(doubleQuoted).toContain('--s3-access-key-id="[REDACTED]"');
+
+		// Flag values are always rewritten to a double-quoted placeholder,
+		// regardless of the original quoting, which stays valid shell.
+		const singleQuoted = redactSecrets(
+			"rclone rcat --s3-secret-access-key='secret123' :s3:b/f",
+		);
+		expect(singleQuoted).not.toContain("secret123");
+		expect(singleQuoted).toContain('--s3-secret-access-key="[REDACTED]"');
+
+		const bare = redactSecrets("rclone rcat --s3-session-token=sessFAKE :s3:b/f");
+		expect(bare).not.toContain("sessFAKE");
+		expect(bare).toContain('--s3-session-token="[REDACTED]"');
+	});
+
+	it("keeps non-credential S3 flags intact", () => {
+		const command =
+			'rclone rcat --s3-region="eu-west-1" --s3-endpoint="https://s3.example.com" :s3:b/f';
+		expect(redactSecrets(command)).toBe(command);
+	});
+
+	it("redacts SFTP/FTP passwords (space and equals forms)", () => {
+		const redacted = redactSecrets(
+			"rclone --sftp-pass 'sftpFAKE' --ftp-pass=\"ftpFAKE\" remote:",
+		);
+		expect(redacted).not.toContain("sftpFAKE");
+		expect(redacted).not.toContain("ftpFAKE");
+	});
+
+	it("redacts database password env assignments", () => {
+		expect(redactSecrets("PGPASSWORD='pgFAKE' pg_dump db")).toContain(
+			"PGPASSWORD='[REDACTED]'",
+		);
+		expect(redactSecrets("MYSQL_PWD=mysqlFAKE mysqldump db")).toContain(
+			"MYSQL_PWD=[REDACTED]",
+		);
+		expect(
+			redactSecrets("MONGO_INITDB_ROOT_PASSWORD='mongoFAKE' mongodump"),
+		).not.toContain("mongoFAKE");
+	});
+
+	it("redacts rclone crypt and config password env vars", () => {
+		const redacted = redactSecrets(
+			"RCLONE_CRYPT_PASSWORD='cryptFAKE1' RCLONE_CRYPT_PASSWORD2='cryptFAKE2' RCLONE_CONFIG_MYS3_PASS='cfgFAKE' rclone lsf MYS3:",
+		);
+		expect(redacted).not.toContain("cryptFAKE1");
+		expect(redacted).not.toContain("cryptFAKE2");
+		expect(redacted).not.toContain("cfgFAKE");
+		expect(redacted).toContain("RCLONE_CRYPT_PASSWORD='[REDACTED]'");
+		expect(redacted).toContain("RCLONE_CRYPT_PASSWORD2='[REDACTED]'");
+	});
+
+	it("redacts Authorization headers", () => {
+		const redacted = redactSecrets(
+			'curl -H "Authorization: Bearer tokenFAKE" https://example.com',
+		);
+		expect(redacted).not.toContain("tokenFAKE");
+		expect(redacted).toContain("Authorization: [REDACTED]");
+	});
+
+	it("scrubs a full generated backup command end to end", () => {
+		const command =
+			`PGPASSWORD='pgFAKEpass' pg_dump -U dokploy mydb | ` +
+			`RCLONE_CRYPT_PASSWORD='cryptFAKE1' RCLONE_CRYPT_PASSWORD2='cryptFAKE2' ` +
+			`rclone rcat --s3-access-key-id="AKIAFAKEFAKEFAKE" ` +
+			`--s3-secret-access-key="secret123" --s3-session-token="sessFAKE" ` +
+			`--s3-region="us-east-1" :s3:my-bucket/daily/db.sql.gz`;
+
+		const redacted = redactSecrets(command);
+
+		for (const secret of [
+			"pgFAKEpass",
+			"cryptFAKE1",
+			"cryptFAKE2",
+			"AKIAFAKEFAKEFAKE",
+			"secret123",
+			"sessFAKE",
+		]) {
+			expect(redacted).not.toContain(secret);
+		}
+		// Non-secret context is preserved for diagnosability.
+		expect(redacted).toContain('--s3-region="us-east-1"');
+		expect(redacted).toContain("pg_dump -U dokploy mydb");
+	});
 });

--- a/apps/dokploy/server/sentry.ts
+++ b/apps/dokploy/server/sentry.ts
@@ -1,5 +1,28 @@
+import { redactSecrets } from "@dokploy/server/utils/process/redactSecrets";
 import * as Sentry from "@sentry/node";
+import type { ErrorEvent } from "@sentry/node";
 import packageInfo from "../package.json";
+
+// Defense in depth: even though ExecError scrubs its own fields, strip
+// credentials from every event field an embedded command could reach (exception
+// values, the top-level message, and breadcrumb messages) before it leaves the
+// process. This catches any future code path that puts a raw command in an error.
+const scrubEvent = (event: ErrorEvent): ErrorEvent => {
+	if (typeof event.message === "string") {
+		event.message = redactSecrets(event.message);
+	}
+	for (const exception of event.exception?.values ?? []) {
+		if (typeof exception.value === "string") {
+			exception.value = redactSecrets(exception.value);
+		}
+	}
+	for (const breadcrumb of event.breadcrumbs ?? []) {
+		if (typeof breadcrumb.message === "string") {
+			breadcrumb.message = redactSecrets(breadcrumb.message);
+		}
+	}
+	return event;
+};
 
 // Public ingest-only DSN for the fork's error tracker. A DSN can only submit
 // events — it grants no read access to the project — so it is safe in source.
@@ -35,7 +58,7 @@ if (isSentryEnabled) {
 		beforeSend(event) {
 			// The reporting instance's hostname identifies a user's server — drop it.
 			event.server_name = undefined;
-			return event;
+			return scrubEvent(event);
 		},
 	});
 }

--- a/packages/server/src/utils/backups/redact.ts
+++ b/packages/server/src/utils/backups/redact.ts
@@ -1,22 +1,16 @@
+import { redactSecrets } from "../process/redactSecrets";
+
 /**
- * Redacts S3 credentials and rclone crypt passwords from rclone command strings.
+ * Redacts credentials from rclone command strings before they reach structured
+ * logs or error output.
  *
- * Used to prevent credential leakage in structured logs and error output.
- * The flag value may be double-quoted, single-quoted, or an unquoted token,
- * because `getS3Credentials()` escapes values with shell-quote (which leaves
- * simple values bare and single-quotes/backslash-escapes the rest):
- *   --s3-access-key-id=VALUE  /  ="VALUE"  /  ='VALUE'
- * and the crypt password env vars produced by `getRclonePathAndFlags()` /
- * `buildRcloneCommand()`:
- *   RCLONE_CRYPT_PASSWORD='VALUE'  and  RCLONE_CRYPT_PASSWORD2='VALUE'
+ * This is a thin alias over the shared {@link redactSecrets} redactor so the
+ * logger path and the thrown-error path (ExecError, Sentry) share ONE source of
+ * truth. `redactSecrets` covers S3 access/secret/session keys, SFTP/FTP
+ * passwords, database passwords (PGPASSWORD/MYSQL_PWD/MONGO*),
+ * RCLONE_CONFIG_*_PASS and RCLONE_CRYPT_PASSWORD* env vars, and Authorization
+ * headers, in bare, single-quoted and double-quoted forms — the shapes
+ * `getS3Credentials()` (shell-quote) and `buildRcloneCommand()` produce.
  */
-export const redactRcloneCredentials = (command: string): string => {
-	const value = `("[^"]*"|'[^']*'|\\S+)`;
-	return command
-		.replace(new RegExp(`(--s3-access-key-id=)${value}`, "g"), '$1"[REDACTED]"')
-		.replace(
-			new RegExp(`(--s3-secret-access-key=)${value}`, "g"),
-			'$1"[REDACTED]"',
-		)
-		.replace(/(RCLONE_CRYPT_PASSWORD2?=)'[^']*'/g, "$1'[REDACTED]'");
-};
+export const redactRcloneCredentials = (command: string): string =>
+	redactSecrets(command);

--- a/packages/server/src/utils/process/redactSecrets.ts
+++ b/packages/server/src/utils/process/redactSecrets.ts
@@ -1,19 +1,87 @@
-// Dokploy embeds some secrets directly into the shell commands it runs: the
-// SSH key written to /tmp/id_rsa when cloning over SSH, and the base64 TLS key
-// piped to `base64 -d` when provisioning certificates on a remote server. When
-// such a command fails, its ExecError (command/stdout/stderr) is logged, which
-// would otherwise persist the secret in plain text. These helpers strip that
-// material before it can reach the logs.
+// Dokploy embeds secrets directly into the shell commands it runs and into the
+// generated backup scripts it streams: the SSH key written to /tmp/id_rsa when
+// cloning over SSH, the base64 TLS key piped to `base64 -d` when provisioning
+// certificates, and — for scheduled backups — rclone S3 access keys, SFTP/FTP
+// passwords, database passwords (PGPASSWORD/MYSQL_PWD/MONGO*), rclone crypt
+// passwords and Authorization headers. When such a command fails, Node embeds
+// the entire command in the child_process error `message`, which is wrapped in
+// an ExecError and can reach both logs AND crash reports (Sentry). These
+// helpers strip that material before it can be persisted.
+//
+// Redaction here intentionally errs toward over-redaction: an error report that
+// loses a benign token is preferable to one that leaks a live credential. The
+// UNREDACTED stderr is still written to the per-backup local log file on the
+// server (that path does not go through here) so operators keep full detail.
 
 const PRIVATE_KEY_BLOCK =
 	/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
 
 const BASE64_DECODE_PIPE = /echo "[A-Za-z0-9+/=]+"\s*\|\s*base64 -d/g;
 
+// A flag/assignment value may be double-quoted, single-quoted, or a bare token —
+// shell-quote leaves simple values bare and quotes the rest.
+const QUOTED_OR_BARE = `("[^"]*"|'[^']*'|\\S+)`;
+
+// Long-option flags whose value is a credential (rclone S3 / SFTP / FTP, plus a
+// generic --password). Matched as `--flag=VALUE` or `--flag VALUE`.
+const SECRET_FLAGS = [
+	"s3-access-key-id",
+	"s3-secret-access-key",
+	"s3-session-token",
+	"sftp-pass",
+	"ftp-pass",
+	"password",
+];
+
+// Env / inline assignment names (NAME=VALUE) whose value is a credential.
+// Uppercase-anchored so it never matches lowercase rclone flags like
+// `--s3-region`. Covers the explicit DB/rclone vars plus any *PASSWORD /
+// *PASSWD / *SECRET / *TOKEN name.
+const SECRET_ASSIGNMENT =
+	"(?:PGPASSWORD|MYSQL_PWD|RCLONE_CONFIG_[A-Z0-9_]*_PASS|MONGO[A-Z0-9_]*(?:PASSWORD|PASS|PWD)|[A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN)[0-9]*)";
+
+/** Preserve the value's original quoting so the surrounding command stays valid. */
+const quoteLike = (value: string): string => {
+	if (value.startsWith('"')) return '"[REDACTED]"';
+	if (value.startsWith("'")) return "'[REDACTED]'";
+	return "[REDACTED]";
+};
+
+// Flag values are always rewritten to a double-quoted placeholder (valid shell
+// regardless of the original form), matching the redactor's long-standing
+// output for --s3-* flags.
+const redactFlags = (value: string): string => {
+	let out = value;
+	for (const flag of SECRET_FLAGS) {
+		out = out
+			.replace(new RegExp(`(--${flag}=)${QUOTED_OR_BARE}`, "gi"), '$1"[REDACTED]"')
+			.replace(
+				new RegExp(`(--${flag}\\s+)${QUOTED_OR_BARE}`, "gi"),
+				'$1"[REDACTED]"',
+			);
+	}
+	return out;
+};
+
+const redactAssignments = (value: string): string =>
+	value.replace(
+		new RegExp(`\\b(${SECRET_ASSIGNMENT}=)${QUOTED_OR_BARE}`, "g"),
+		(_m, name, v) => name + quoteLike(v),
+	);
+
+const redactAuthHeaders = (value: string): string =>
+	value.replace(/(Authorization:\s*)([^"'\r\n]+)/gi, "$1[REDACTED]");
+
 export const redactSecrets = (value: string): string =>
-	value
-		.replace(PRIVATE_KEY_BLOCK, "[REDACTED PRIVATE KEY]")
-		.replace(BASE64_DECODE_PIPE, 'echo "[REDACTED]" | base64 -d');
+	redactAuthHeaders(
+		redactAssignments(
+			redactFlags(
+				value
+					.replace(PRIVATE_KEY_BLOCK, "[REDACTED PRIVATE KEY]")
+					.replace(BASE64_DECODE_PIPE, 'echo "[REDACTED]" | base64 -d'),
+			),
+		),
+	);
 
 // Node's child_process errors repeat the failed command on `message`, `stack`
 // and `cmd`, so redact those too when wrapping an original error.


### PR DESCRIPTION
## Problem

Scheduled-backup failure reports could embed destination credentials (DOKPLOY-COMMUNITY-Q/S — backup failure reports embedded destination credentials).

When a generated backup script fails, Node's `child_process` error repeats the **entire command** on `error.message`, including the live rclone `--s3-access-key-id` / `--s3-secret-access-key` flags and crypt/DB passwords. `execAsync` wraps that into an `ExecError`, an `unhandledRejection` fires, and the raw event ships to Sentry.

`ExecError` already funnels every field (`message`, `command`, `stdout`, `stderr`, `originalError`) through `redactSecrets` — but that redactor only stripped PEM private-key blocks and `base64 -d` pipes, **not** the rclone/S3/DB credentials. So they leaked.

## Changes

1. **Generalize `redactSecrets`** (`packages/server/src/utils/process/redactSecrets.ts`) — the single ExecError funnel — to also redact, in **bare, single-quoted and double-quoted** forms:
   - flags: `--s3-access-key-id`, `--s3-secret-access-key`, `--s3-session-token`, `--sftp-pass`, `--ftp-pass`, `--password`
   - env assignments: `PGPASSWORD`, `MYSQL_PWD`, `MONGO*…PASSWORD/PASS/PWD`, `RCLONE_CONFIG_*_PASS`, `RCLONE_CRYPT_PASSWORD*`, and any `*PASSWORD/*PASSWD/*SECRET/*TOKEN`
   - `Authorization:` headers

   Because `ExecError` scrubs all its fields through this one function, `execAsync`, `execAsyncStream` and `execAsyncRemote` are all covered **at the boundary** — no per-call-site edits needed.

2. **`redactRcloneCredentials`** (the backup logger path) now delegates to `redactSecrets`, so the log path and the error path share **one source of truth**.

3. **Sentry `beforeSend` scrubber** (`apps/dokploy/server/sentry.ts`) applies the same redaction to exception values, the event message, and breadcrumb messages — defense in depth for any future path that embeds a command in an error.

4. **Local per-backup log files keep the original unredacted stderr** (that path does not go through the redactor); only error objects / crash reports are scrubbed.

5. **Tests**: `redactSecrets` against a realistic generated backup command (fake credentials) across all quoting forms and env assignments; `ExecError` message/command/stderr/originalError scrubbing. Existing `redactRcloneCredentials` and `encryption-config` assertions stay green (S3 flags still render as `"[REDACTED]"`, crypt env as `'[REDACTED]'`).

No real credentials appear anywhere; test fixtures use obviously fake values.
