### PR TITLE
feat(backups): delete partial uploads on failed backups and split failure diagnostics

### DIFF
--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -228,10 +228,47 @@ describe("getBackupCommand", () => {
 		expect(occurrences).toBe(1);
 	});
 
-	test("pipes the single dump straight into the rclone upload", () => {
+	test("streams the single dump directly into the rclone upload", () => {
 		const dumpCommand = generateBackupCommand(backup) as string;
 		const script = getBackupCommand(backup, rcloneCommand, logPath);
 
-		expect(script).toContain(`${dumpCommand} | ${rcloneCommand}`);
+		// The dump is piped straight into rclone (its stderr is teed to a temp
+		// file in between so dump vs upload failures stay distinguishable).
+		expect(script).toContain(`${dumpCommand} 2> "$DUMP_ERROR_FILE"`);
+		expect(script).toContain(`| ${rcloneCommand}`);
+	});
+
+	// #4896: split the combined error so operators can tell a dump failure from
+	// an upload failure.
+	test("keeps dump and upload failures distinguishable", () => {
+		const script = getBackupCommand(backup, rcloneCommand, logPath);
+
+		expect(script).toContain("❌ Error: Backup failed");
+		expect(script).toContain("❌ Error: Upload to S3 failed");
+	});
+
+	// #4896: a failed stream can leave a truncated object that would count toward
+	// keepLatestNBackups retention; delete it on the failure paths.
+	test("derives a deletefile cleanup command from the upload path", () => {
+		const script = getBackupCommand(backup, rcloneCommand, logPath);
+
+		expect(script).toContain(
+			'rclone deletefile --s3-provider="AWS" ":s3:bucket/key.sql.gz"',
+		);
+		// The dump command itself still appears exactly once (no second dump).
+		const dumpCommand = generateBackupCommand(backup) as string;
+		expect(script.split(dumpCommand).length - 1).toBe(1);
+	});
+
+	// The cleanup must inherit the crypt env prefix so encrypted remotes work —
+	// only the rcat verb is swapped, the RCLONE_CRYPT_* prefix is preserved.
+	test("preserves the crypt env prefix in the cleanup command", () => {
+		const cryptRcloneCommand =
+			"RCLONE_CRYPT_PASSWORD='obscured_pass' rclone rcat --s3-provider=\"AWS\" \":crypt:bucket/key.sql.gz\"";
+		const script = getBackupCommand(backup, cryptRcloneCommand, logPath);
+
+		expect(script).toContain(
+			"RCLONE_CRYPT_PASSWORD='obscured_pass' rclone deletefile --s3-provider=\"AWS\" \":crypt:bucket/key.sql.gz\"",
+		);
 	});
 });

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -398,6 +398,24 @@ export const getBackupCommand = (
 		? backup.destination?.provider?.toUpperCase() || "remote"
 		: "S3";
 
+	// A failed streamed upload can leave a TRUNCATED object at the destination.
+	// That partial object then counts toward keepLatestNBackups retention and can
+	// evict a good backup, so remove it best-effort on any failure. The delete
+	// reuses the SAME remote path, flags and env as the rcat upload (rcloneCommand
+	// is built by buildRcloneCommand, so a crypt env prefix is preserved) — we only
+	// swap the `rcat` verb for `deletefile`. rcloneCommand may start with that env
+	// prefix rather than `rclone`, so match the verb anywhere in the string.
+	const rcloneCleanupCommand = rcloneCommand.includes("rclone rcat ")
+		? `${rcloneCommand.replace(
+				"rclone rcat ",
+				"rclone deletefile ",
+			)} >/dev/null 2>&1 || true;`
+		: "";
+	const cleanupPartialUpload = rcloneCleanupCommand
+		? `echo "[$(date)] Cleaning up partial upload from ${destinationType}..." >> ${logPath};
+		${rcloneCleanupCommand}`
+		: "";
+
 	logger.info(
 		{
 			containerSearch,
@@ -422,15 +440,36 @@ export const getBackupCommand = (
 	echo "[$(date)] Container Up: $CONTAINER_ID" >> ${logPath};
 	echo "[$(date)] Streaming backup to ${destinationType}..." >> ${logPath};
 
-	# Stream the dump straight to the destination. The dump runs ONCE; "set -o pipefail"
-	# makes the pipeline fail if the dump (not just rclone) fails, so a broken
-	# backup never reports success. Running the dump a second time to "validate"
-	# it would double the load on the database and risk an inconsistent copy.
-	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Backup/upload to ${destinationType} failed" >> ${logPath};
-		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
+	# Stream the dump straight to the destination. The dump runs ONCE; "set -o
+	# pipefail" makes the pipeline fail if the dump (not just rclone) fails, so a
+	# broken backup never reports success. Running the dump a second time to
+	# "validate" it would double the load on the database and risk an inconsistent
+	# copy. The dump's exit code and stderr are captured through temp files so a
+	# dump failure ("Backup failed") stays distinguishable from an upload failure
+	# ("Upload to ... failed"). Because the pipeline is on the left of "||", set -e
+	# is ignored inside it, so "echo $? > status" always records the dump's code.
+	DUMP_STATUS_FILE=$(mktemp);
+	DUMP_ERROR_FILE=$(mktemp);
+	trap 'rm -f "$DUMP_STATUS_FILE" "$DUMP_ERROR_FILE"' EXIT;
+
+	UPLOAD_FAILED=0;
+	UPLOAD_OUTPUT=$({ ${backupCommand} 2> "$DUMP_ERROR_FILE"; echo $? > "$DUMP_STATUS_FILE"; } | ${rcloneCommand} 2>&1 >/dev/null) || UPLOAD_FAILED=1;
+	DUMP_STATUS=$(cat "$DUMP_STATUS_FILE");
+
+	if [ "$DUMP_STATUS" != "0" ]; then
+		# Dump failure takes precedence: a failed dump also fails the upload stage.
+		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
+		echo "Error: $(cat "$DUMP_ERROR_FILE")" >> ${logPath};
+		${cleanupPartialUpload}
 		exit 1;
-	}
+	fi
+
+	if [ "$UPLOAD_FAILED" != "0" ]; then
+		echo "[$(date)] ❌ Error: Upload to ${destinationType} failed" >> ${logPath};
+		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
+		${cleanupPartialUpload}
+		exit 1;
+	fi
 
 	echo "[$(date)] ✅ Upload to ${destinationType} completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};


### PR DESCRIPTION
## What & why

Adapts the useful half of upstream [Dokploy/dokploy#4896](https://github.com/Dokploy/dokploy/pull/4896) to this fork's backup pipeline. This is **not a 1:1 port**: upstream #4896 primarily fixed a double-dump bug that this fork does not have — the fork already streams the dump **once** through `backupCommand | rcloneCommand` with `set -eo pipefail`, and already wraps rclone crypt-aware via `buildRcloneCommand`/`getRclonePathAndFlags`. We took the two things worth keeping:

1. **Partial-object cleanup.** A failed streamed upload can leave a **truncated object** at the destination. That partial then counts toward `keepLatestNBackups` retention and can evict a good backup. On any failure path we now delete it best-effort.
2. **Split failure diagnostics.** One combined message made a dump failure indistinguishable from an upload failure. The log now distinguishes `❌ Error: Backup failed` (dump side, takes precedence) from `❌ Error: Upload to <S3/SFTP/FTP> failed` (rclone side).

## Changes

`packages/server/src/utils/backups/utils.ts` — `getBackupCommand`:

- **Cleanup command** is derived from the *same* already-built `rcloneCommand` (which callers construct through `buildRcloneCommand(rclone rcat …, envVars)`), swapping only the `rcat` verb for `deletefile`. Because the swap matches `rclone rcat ` anywhere in the string, any `RCLONE_CRYPT_*` env prefix is preserved, so crypt remotes delete the correct underlying object. The rcat target is a full file path (`…/<timestamp>.sql.gz`), so `deletefile` targets exactly that one object. Runs best-effort (`>/dev/null 2>&1 || true`) and logs that cleanup was attempted.
- **Split diagnostics** via temp files + an `EXIT` trap (adapting upstream's pattern): the dump's stderr goes to `$DUMP_ERROR_FILE` and its exit code to `$DUMP_STATUS_FILE`. Since the pipeline sits on the left of `|| UPLOAD_FAILED=1`, `set -e` is inert inside it and `echo $? > status` always records the dump's real code — pipefail semantics are preserved and nothing masks the pipeline's exit status. Dump wording kept generic (`Backup failed`); upload wording keeps the fork's `destinationType` (S3/SFTP/FTP).

`apps/dokploy/__test__/utils/backups.test.ts` — extended: dump runs exactly once; dump streamed into rclone; both failure messages present; `deletefile` derived from the upload path; crypt env prefix preserved in the cleanup command.

## Four-path trace

Let `set -eo pipefail`; the pipeline is `{ DUMP 2>err; echo $? >status; } | RCLONE 2>&1 >/dev/null`, whose left group always exits 0, so the pipeline's status reflects **rclone only** (`UPLOAD_FAILED`). `DUMP_STATUS` is read from the status file.

1. **Success** — DUMP=0, rclone=0 → `UPLOAD_FAILED=0`, `DUMP_STATUS=0`. Neither `if` fires → `✅ Upload … completed` / `Backup done ✅`. No cleanup.
2. **Dump fails** — DUMP≠0, rclone typically 0 (rclone streams whatever it got and may exit 0) → `DUMP_STATUS≠0`. First branch fires (takes precedence): `❌ Error: Backup failed` + dump stderr, best-effort `deletefile` of the partial, `exit 1`.
3. **Upload fails** — DUMP=0, rclone≠0 → `DUMP_STATUS=0`, `UPLOAD_FAILED=1`. First branch skipped, second fires: `❌ Error: Upload to <dest> failed` + rclone stderr, best-effort `deletefile`, `exit 1`.
4. **Both fail** — DUMP≠0, rclone≠0 → `DUMP_STATUS≠0`. First branch fires (dump precedence): `❌ Error: Backup failed`, cleanup, `exit 1`. Upload branch never reached, so the operator sees the root cause (the dump) not the downstream symptom.

## Testing

- `apps/dokploy/__test__/utils/backups.test.ts` + `__test__/utils/encryption.test.ts`: **33 passed, 0 failed** locally (`vitest run --config __test__/vitest.config.ts`).
- `@dokploy/server` typecheck: clean.
- Local env caveat: `apps/dokploy` typecheck reports `Cannot find module '@dokploy/server'` in two unrelated files (`sso.ts`, `schedule.ts`) — a pre-existing local build-artifact/module-resolution issue in this workspace, not introduced here (this change adds no imports and only edits a shell template string). Relying on CI for the app typecheck.
