### PR TITLE
fix: avoid postgres 100-argument limit in schedule, volume backup and port queries

### DIFF
--- a/apps/schedules/src/utils.ts
+++ b/apps/schedules/src/utils.ts
@@ -180,6 +180,9 @@ export const initializeJobs = async () => {
 		where: eq(schedules.enabled, true),
 		with: {
 			application: {
+				columns: {
+					applicationId: true,
+				},
 				with: {
 					server: true,
 				},
@@ -227,6 +230,9 @@ export const initializeJobs = async () => {
 		where: eq(volumeBackups.enabled, true),
 		with: {
 			application: {
+				columns: {
+					applicationId: true,
+				},
 				with: {
 					server: true,
 				},

--- a/packages/server/src/services/schedule.ts
+++ b/packages/server/src/services/schedule.ts
@@ -88,7 +88,7 @@ export const findScheduleById = async (scheduleId: string) => {
 			// project it down to only the fields consumers read. `compose`/`server`
 			// are far narrower and left intact. See services/mount.ts for the same fix.
 			application: {
-				columns: { appName: true, serverId: true },
+				columns: { applicationId: true, appName: true, serverId: true },
 				with: {
 					environment: {
 						columns: {},

--- a/packages/server/src/services/volume-backups.ts
+++ b/packages/server/src/services/volume-backups.ts
@@ -20,7 +20,7 @@ export const findVolumeBackupById = async (volumeBackupId: string) => {
 			// project it down to only the fields consumers read. The other joined
 			// resources are far narrower and left intact. See services/mount.ts.
 			application: {
-				columns: { appName: true, serverId: true },
+				columns: { applicationId: true, appName: true, serverId: true },
 				with: {
 					environment: {
 						columns: {},


### PR DESCRIPTION
1:1 port of upstream Dokploy/dokploy#4931 by @Siumauricio.

Fixes `PostgresError: cannot pass more than 100 arguments to a function (54023)` when drizzle hydrates the joined `application` relation: every selected column of a joined resource plus one entry per nested relation is packed into a single `json_build_array(...)`, and the `application` table sits at/over the `FUNC_MAX_ARGS = 100` limit. Projecting `application` down to its identifying columns keeps the query under the limit.

Scope notes (this fork already carried part of the same fix):
- `apps/schedules/src/utils.ts` — ported verbatim from upstream (schedule + volume-backup job initialization queries; this was the one site still unfixed here).
- `packages/server/src/services/schedule.ts` and `services/volume-backups.ts` — already projected in this fork; only `applicationId` is added so the selected column set matches upstream's.
- `packages/server/src/services/port.ts` — already fixed here by `fix(server): avoid Postgres 100-arg limit in port and rollback relational queries`, so upstream's hunk for that file is a no-op and was not re-applied.
