### PR TITLE
fix(ui): persist trigger type selection in GitHub provider forms

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -439,8 +439,12 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 										</TooltipProvider>
 									</div>
 									<Select
-										onValueChange={field.onChange}
-										defaultValue={field.value}
+										onValueChange={(value) => {
+											if (!value) {
+												return;
+											}
+											field.onChange(value);
+										}}
 										value={field.value}
 									>
 										<FormControl>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -432,8 +432,12 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 										</TooltipProvider>
 									</div>
 									<Select
-										onValueChange={field.onChange}
-										defaultValue={field.value}
+										onValueChange={(value) => {
+											if (!value) {
+												return;
+											}
+											field.onChange(value);
+										}}
 										value={field.value}
 									>
 										<FormControl>


### PR DESCRIPTION
1:1 port of upstream Dokploy/dokploy#4937 by @narcisonunez.

The Trigger Type `Select` in the GitHub provider forms (application and compose) passed both `defaultValue` and a controlled `value`, and forwarded `field.onChange` directly. Radix emits an empty-string change when the select closes/resets, which wiped the selection. The handler now ignores empty values, and the redundant `defaultValue` is dropped so the field stays controlled.

Applied verbatim to both `save-github-provider.tsx` and `save-github-provider-compose.tsx`; no fork adaptations were needed.
