### PR TITLE
fix(domains): don't render CDN info message as an error in DNS tooltip

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/columns.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/columns.tsx
@@ -209,7 +209,9 @@ export const createColumns = ({
 									</Badge>
 								</TooltipTrigger>
 								<TooltipContent className="max-w-xs">
-									{validationState?.error ? (
+									{validationState?.isValid && validationState?.message ? (
+										<p>{validationState.message}</p>
+									) : validationState?.error ? (
 										<div className="flex flex-col gap-1">
 											<p className="font-medium text-red-500">Error:</p>
 											<p>{validationState.error}</p>

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -690,7 +690,10 @@ export const ShowDomains = ({ id, type }: Props) => {
 																</Badge>
 															</TooltipTrigger>
 															<TooltipContent className="max-w-xs">
-																{validationState?.error ? (
+																{validationState?.isValid &&
+																validationState?.message ? (
+																	<p>{validationState.message}</p>
+																) : validationState?.error ? (
 																	<div className="flex flex-col gap-1">
 																		<p className="font-medium text-red-500">
 																			Error:


### PR DESCRIPTION
1:1 port of upstream Dokploy/dokploy#4911 by @AbiRaditya (fixes upstream issue Dokploy/dokploy#4910).

`validateDomain` returns `isValid: true` for CDN-fronted domains but reuses the `error` field to carry the provider's informational message. Both DNS tooltips branched on `error` alone, so that message rendered under a red "Error:" heading even though the badge already showed a green "Behind Cloudflare" state. The tooltips now check the valid + message case first, matching the badge's own branching.

Applied verbatim to the table view (`domains/columns.tsx`) and the card view (`domains/show-domains.tsx`); no fork adaptations were needed.
