### PR TITLE
fix(preview-deployment): refetch github provider before authenticating

### DIFF
--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -30,7 +30,7 @@ import {
 import { createDomain } from "./domain";
 import { getRemotePublicIp, isPrivateIp } from "../utils/ip";
 import { getPublicIpWithFallback } from "../wss/utils";
-import { type Github, getIssueComment } from "./github";
+import { type Github, findGithubById, getIssueComment } from "./github";
 import { getWebServerSettings } from "./web-server-settings";
 
 export type PreviewDeployment = typeof previewDeployments.$inferSelect;
@@ -295,7 +295,17 @@ export const createPreviewDeployment = async (
 	// handler instead.
 	if (application.sourceType === "github") {
 		try {
-			const octokit = authGithub(application?.github as Github);
+			if (!application.githubId) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Github Account not configured correctly",
+				});
+			}
+
+			// `findApplicationById` redacts `githubPrivateKey` from the `github`
+			// relation, so the provider must be refetched to authenticate.
+			const githubProvider = await findGithubById(application.githubId);
+			const octokit = authGithub(githubProvider);
 			const runningComment = getIssueComment(
 				application.name,
 				"initializing",


### PR DESCRIPTION
1:1 port of upstream Dokploy/dokploy#4933 by @CyrilBIENNE (open upstream at time of porting), which fixes upstream issue Dokploy/dokploy#4898.

### What

`findApplicationById` deliberately redacts `githubPrivateKey` (along with the client secret and webhook secret) from the `github` relation. `createPreviewDeployment` then handed that redacted object straight to `authGithub`. Because `haveGithubRequirements` requires the private key, it always returned false and `authGithub` threw `TRPCError NOT_FOUND: "Github Account not configured correctly"` — so the initial "initializing" pull request comment could never be posted for a GitHub preview deployment.

### Fix

Resolve the provider through `findGithubById(application.githubId)` before authenticating, which is how every other call site obtains GitHub credentials. The redaction on `findApplicationById` stays intact.

### Adaptation vs upstream

This fork guards the comment block with `if (application.sourceType === "github")` and a `try/catch` (GitLab previews have no GitHub provider and surface status via MR notes instead). The refetch and the `githubId` guard are therefore placed inside that existing GitHub-only block rather than at the top level of `createPreviewDeployment`, so GitLab previews are unaffected. Otherwise identical to upstream.

Checked while porting: the compose preview paths in the same file use `findComposeById`, which does not redact `githubPrivateKey`, so they are not affected by this bug.
