### PR TITLE
fix(application): post-deploy stability check must target runtime server, not build server

### DIFF
--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -253,7 +253,7 @@ export const deployApplication = async ({
 		await mechanizeDockerContainer(application);
 
 		const stability = await waitForSwarmServiceStable(application.appName, {
-			serverId,
+			serverId: application.serverId,
 		});
 		if (!stability.stable) {
 			throw new Error(
@@ -383,7 +383,7 @@ export const rebuildApplication = async ({
 		await mechanizeDockerContainer(application);
 
 		const stability = await waitForSwarmServiceStable(application.appName, {
-			serverId,
+			serverId: application.serverId,
 		});
 		if (!stability.stable) {
 			throw new Error(


### PR DESCRIPTION
## Description

When an application has a **separate build server** configured (`buildServerId` set to a different server than `serverId`), the `waitForSwarmServiceStable` post-deployment check runs against the **build server** instead of the **runtime server** where the service was actually deployed. The deployment succeeds and the container runs correctly on the runtime server, but the UI marks the deployment as failed with a misleading error:

```
Container did not stay running after deployment: (HTTP code 404) unexpected - service <appName> not found
```

## Reproduction

1. Configure an Application with `buildServerId` = server A and `serverId` = server B.
2. Deploy the application.
3. The service is successfully created on server B (`docker service ls` on B shows the running replicas), but Dokploy reports the deployment as failed with the error above.

## Root cause

In `packages/server/src/services/application.ts`:

```typescript
export const deployApplication = async ({ ... }) => {
    const application = await findApplicationById(applicationId);
    const serverId = application.buildServerId || application.serverId;  // ← build server
    // ...

    await mechanizeDockerContainer(application);
    // ↑ internally uses application.serverId — deploys to the correct (runtime) server

    const stability = await waitForSwarmServiceStable(application.appName, {
        serverId,
        // ↑ passes buildServerId — queries the wrong Docker socket
    });
```

The local `serverId` variable holds the build server ID (correctly used for the build/exec phases) but is incorrectly reused for the post-deploy check, which needs the runtime server. Same pattern in `rebuildApplication`.

## Change

Pass `application.serverId` explicitly to `waitForSwarmServiceStable` in both `deployApplication` and `rebuildApplication`, so the check consistently targets the same server where `mechanizeDockerContainer` created the service.

## Test plan

- [x] Verified on a live setup where `buildServerId` and `serverId` differ: deployment now completes successfully in the UI, matching the actual runtime state.
- [ ] Automated tests — none added; happy to add if the maintainers prefer.

## Affected versions

- `v0.29.13-community.1`, `.2`, `.3` (all versions since the check was introduced).
- Not present in upstream Dokploy.
