### PR TITLE
fix(acl): allow members to open projects

### DIFF
--- a/apps/dokploy/server/api/routers/environment.ts
+++ b/apps/dokploy/server/api/routers/environment.ts
@@ -2,6 +2,7 @@ import {
 	createEnvironment,
 	deleteEnvironment,
 	duplicateEnvironment,
+	environmentHasAccessedService,
 	filterEnvironmentServices,
 	findEnvironmentById,
 	findEnvironmentsByProjectId,
@@ -96,7 +97,11 @@ export const environmentRouter = createTRPCRouter({
 						ctx.session.activeOrganizationId,
 					);
 
-				if (!accessedEnvironments.includes(environment.environmentId)) {
+				const canAccessEnvironment =
+					accessedEnvironments.includes(environment.environmentId) ||
+					environmentHasAccessedService(environment, accessedServices);
+
+				if (!canAccessEnvironment) {
 					throw new TRPCError({
 						code: "FORBIDDEN",
 						message: "You are not allowed to access this environment",
@@ -142,7 +147,8 @@ export const environmentRouter = createTRPCRouter({
 
 					const filteredEnvironments = environments
 						.filter((environment) =>
-							accessedEnvironments.includes(environment.environmentId),
+							accessedEnvironments.includes(environment.environmentId) ||
+							environmentHasAccessedService(environment, accessedServices),
 						)
 						.map((environment) =>
 							filterEnvironmentServices(environment, accessedServices),

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -17,6 +17,8 @@ import {
 	createRedis,
 	createSecurity,
 	deleteProject,
+	environmentHasAccessedService,
+	filterEnvironmentServices,
 	findApplicationById,
 	findComposeById,
 	findEnvironmentById,
@@ -110,79 +112,41 @@ export const projectRouter = createTRPCRouter({
 		.input(apiFindOneProject)
 		.query(async ({ input, ctx }) => {
 			if (ctx.user.role !== "owner" && ctx.user.role !== "admin") {
-				const { accessedServices, accessedProjects } = await findMemberByUserId(
+				const { accessedServices, accessedProjects, accessedEnvironments } = await findMemberByUserId(
 					ctx.user.id,
 					ctx.session.activeOrganizationId,
 				);
 
-				if (!accessedProjects.includes(input.projectId)) {
+				const project = await findProjectById(input.projectId);
+
+				if (project.organizationId !== ctx.session.activeOrganizationId) {
 					throw new TRPCError({
 						code: "UNAUTHORIZED",
 						message: "You don't have access to this project",
 					});
 				}
 
-				const project = await db.query.projects.findFirst({
-					where: and(
-						eq(projects.projectId, input.projectId),
-						eq(projects.organizationId, ctx.session.activeOrganizationId),
-					),
-					with: {
-						environments: {
-							with: {
-								applications: {
-									where: buildServiceFilter(
-										applications.applicationId,
-										accessedServices,
-									),
-								},
-								compose: {
-									where: buildServiceFilter(
-										compose.composeId,
-										accessedServices,
-									),
-								},
-								libsql: {
-									where: buildServiceFilter(libsql.libsqlId, accessedServices),
-								},
-								mariadb: {
-									where: buildServiceFilter(
-										mariadb.mariadbId,
-										accessedServices,
-									),
-								},
-								mongo: {
-									where: buildServiceFilter(mongo.mongoId, accessedServices),
-								},
-								mysql: {
-									where: buildServiceFilter(mysql.mysqlId, accessedServices),
-								},
-								postgres: {
-									where: buildServiceFilter(
-										postgres.postgresId,
-										accessedServices,
-									),
-								},
-								redis: {
-									where: buildServiceFilter(redis.redisId, accessedServices),
-								},
-							},
-						},
-						projectTags: {
-							with: {
-								tag: true,
-							},
-						},
-					},
-				});
+				const hasProjectAccess = accessedProjects.includes(input.projectId);
+				const hasEnvironmentAccess = project.environments.some((environment) =>
+					accessedEnvironments.includes(environment.environmentId),
+				);
+				const hasServiceAccess = project.environments.some((environment) =>
+					environmentHasAccessedService(environment, accessedServices),
+				);
 
-				if (!project) {
+				if (!hasProjectAccess && !hasEnvironmentAccess && !hasServiceAccess) {
 					throw new TRPCError({
-						code: "NOT_FOUND",
-						message: "Project not found",
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this project",
 					});
 				}
-				return project;
+
+				return {
+					...project,
+					environments: project.environments.map((environment) =>
+						filterEnvironmentServices(environment, accessedServices),
+					),
+				};
 			}
 			const project = await findProjectById(input.projectId);
 

--- a/packages/server/src/services/environment.ts
+++ b/packages/server/src/services/environment.ts
@@ -401,6 +401,23 @@ export const filterEnvironmentServices = <T extends EnvironmentWithServices>(
 	),
 });
 
+export const environmentHasAccessedService = <T extends EnvironmentWithServices>(
+	environment: T,
+	accessedServices: string[],
+): boolean => {
+	const filtered = filterEnvironmentServices(environment, accessedServices);
+	return (
+		filtered.applications.length > 0 ||
+		filtered.compose.length > 0 ||
+		filtered.libsql.length > 0 ||
+		filtered.mariadb.length > 0 ||
+		filtered.mongo.length > 0 ||
+		filtered.mysql.length > 0 ||
+		filtered.postgres.length > 0 ||
+		filtered.redis.length > 0
+	);
+};
+
 export const createProductionEnvironment = async (projectId: string) => {
 	const newEnvironment = await db
 		.insert(environments)


### PR DESCRIPTION
## What is this PR about?

When you add user as a member and give them access to some project, they can access services but not enter the project for some reason (they are redirected back to the homepage). This PR fixes such issue.

Also yes, even granting all the permissions doesn't allow users to enter projects and see environments

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

(none)

## Screenshots (if applicable)

(not applicable)