### PR TITLE
fix(swarm): stability check must survive rolling updates without hiding crash-loops

### DIFF
--- a/apps/dokploy/__test__/server/waitForSwarmServiceStable.test.ts
+++ b/apps/dokploy/__test__/server/waitForSwarmServiceStable.test.ts
@@ -1,0 +1,159 @@
+import { waitForSwarmServiceStable } from "@dokploy/server/utils/docker/utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listTasksMock, getRemoteDockerMock } = vi.hoisted(() => {
+	const listTasks = vi.fn();
+	const getRemoteDocker = vi.fn(async () => ({ listTasks }));
+	return { listTasksMock: listTasks, getRemoteDockerMock: getRemoteDocker };
+});
+
+vi.mock("@dokploy/server/utils/servers/remote-docker", () => ({
+	getRemoteDocker: getRemoteDockerMock,
+}));
+
+// Short window / poll to keep tests fast; mocked listTasks resolves instantly.
+const WINDOW_MS = 400;
+const POLL_MS = 20;
+
+type Task = {
+	Status?: { State?: string; Err?: string; Message?: string };
+	DesiredState?: string;
+	UpdatedAt?: string;
+};
+
+const runningTask = (opts: Partial<Task> = {}): Task => ({
+	Status: { State: "running" },
+	DesiredState: "running",
+	UpdatedAt: new Date().toISOString(),
+	...opts,
+});
+
+const startingTask = (opts: Partial<Task> = {}): Task => ({
+	Status: { State: "starting" },
+	DesiredState: "running",
+	UpdatedAt: new Date().toISOString(),
+	...opts,
+});
+
+describe("waitForSwarmServiceStable", () => {
+	beforeEach(() => {
+		listTasksMock.mockReset();
+	});
+
+	it("returns stable when a task reaches running and stays there", async () => {
+		listTasksMock.mockResolvedValue([runningTask()]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result).toEqual({ stable: true });
+	});
+
+	it("does not false-positive on the rolling-update handover between two tasks", async () => {
+		// The outgoing task is already marked for shutdown by Swarm, so it must
+		// be ignored for the running/starting counts. The incoming task is
+		// still starting when the outgoing one disappears — without the
+		// DesiredState filter this used to flip `everRunning=true` from the
+		// outgoing task and then fire "Container restarted after running".
+		listTasksMock
+			.mockResolvedValueOnce([
+				{
+					Status: { State: "running" },
+					DesiredState: "shutdown",
+					UpdatedAt: new Date().toISOString(),
+				},
+				startingTask({ Status: { State: "preparing" } }),
+			])
+			.mockResolvedValueOnce([
+				{
+					Status: { State: "shutdown" },
+					DesiredState: "shutdown",
+					UpdatedAt: new Date().toISOString(),
+				},
+				startingTask(),
+			])
+			.mockResolvedValue([runningTask()]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result).toEqual({ stable: true });
+	});
+
+	it("catches a crash-looping new task even after Swarm starts a rollback", async () => {
+		// Scenario the fork maintainer flagged: the new task fails, Swarm
+		// moves its DesiredState to "shutdown" and starts a rollback task.
+		// The `desired-state=running` filter alone would hide the failure and
+		// mark the deploy stable while the new image never ran successfully.
+		const failedAt = new Date().toISOString();
+		listTasksMock
+			.mockResolvedValueOnce([
+				runningTask({
+					DesiredState: "running",
+					UpdatedAt: new Date(Date.now() - 10).toISOString(),
+				}),
+				startingTask({ Status: { State: "preparing" } }),
+			])
+			.mockResolvedValue([
+				runningTask(),
+				{
+					Status: { State: "rejected", Err: "No such image: broken:latest" },
+					DesiredState: "shutdown",
+					UpdatedAt: failedAt,
+				},
+			]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result).toEqual({
+			stable: false,
+			reason: "Task rejected: No such image: broken:latest",
+		});
+	});
+
+	it("ignores stale failed tasks from previous deploys still in Swarm history", async () => {
+		// Swarm keeps a few historical tasks per service. A failure from a
+		// previous deploy has UpdatedAt older than pollStartMs and must not
+		// trigger a false negative for the current deploy.
+		const staleFailed = new Date(Date.now() - 60_000).toISOString();
+		listTasksMock.mockResolvedValue([
+			runningTask(),
+			{
+				Status: { State: "failed", Err: "stale failure" },
+				DesiredState: "shutdown",
+				UpdatedAt: staleFailed,
+			},
+		]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result).toEqual({ stable: true });
+	});
+
+	it("returns unstable with lastReason when the task never reaches running", async () => {
+		listTasksMock.mockResolvedValue([
+			startingTask({ Status: { State: "preparing", Message: "pulling image" } }),
+		]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result.stable).toBe(false);
+		if (result.stable === false) {
+			expect(result.reason).toContain("preparing");
+			expect(result.reason).toContain("pulling image");
+		}
+	});
+});

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -1065,7 +1065,8 @@ export const waitForSwarmServiceStable = async (
 	}: { serverId?: string | null; windowMs?: number; pollMs?: number } = {},
 ): Promise<SwarmStabilityResult> => {
 	const remoteDocker = await getRemoteDocker(serverId);
-	const deadline = Date.now() + windowMs;
+	const pollStartMs = Date.now();
+	const deadline = pollStartMs + windowMs;
 	let everRunning = false;
 	let lastReason = "Service did not reach running state";
 
@@ -1075,16 +1076,20 @@ export const waitForSwarmServiceStable = async (
 				filters: JSON.stringify({ service: [appName] }),
 			});
 
-			const sorted = [...tasks].sort((a, b) => {
-				const at = new Date(a.UpdatedAt ?? 0).getTime();
-				const bt = new Date(b.UpdatedAt ?? 0).getTime();
-				return bt - at;
-			});
-			const latest = sorted[0];
-			const state = latest?.Status?.State;
-			const message = latest?.Status?.Err || latest?.Status?.Message || "";
-
-			if (state === "failed" || state === "rejected") {
+			// Look for failed/rejected tasks anywhere in the current task set —
+			// after a rollback the failed task's DesiredState is moved to
+			// "shutdown", so filtering by desired-state would hide it. Restrict
+			// to failures updated since we started polling to avoid triggering
+			// on stale history from previous deploys that Swarm still retains.
+			const recentlyFailed = tasks.find(
+				(t) =>
+					(t.Status?.State === "failed" || t.Status?.State === "rejected") &&
+					new Date(t.UpdatedAt ?? 0).getTime() >= pollStartMs,
+			);
+			if (recentlyFailed) {
+				const state = recentlyFailed.Status?.State;
+				const message =
+					recentlyFailed.Status?.Err || recentlyFailed.Status?.Message || "";
 				return {
 					stable: false,
 					reason: message
@@ -1093,10 +1098,23 @@ export const waitForSwarmServiceStable = async (
 				};
 			}
 
-			const runningCount = sorted.filter(
+			// Stability counts must exclude tasks Swarm has already marked for
+			// shutdown (typically the outgoing task during a rolling update),
+			// otherwise the running→starting transition of the handover flags a
+			// perfectly healthy deploy as unstable.
+			const active = tasks.filter((t) => t.DesiredState === "running");
+			const sorted = [...active].sort((a, b) => {
+				const at = new Date(a.UpdatedAt ?? 0).getTime();
+				const bt = new Date(b.UpdatedAt ?? 0).getTime();
+				return bt - at;
+			});
+			const latest = sorted[0];
+			const state = latest?.Status?.State;
+			const message = latest?.Status?.Err || latest?.Status?.Message || "";
+			const runningCount = active.filter(
 				(t) => t.Status?.State === "running",
 			).length;
-			const startingCount = sorted.filter((t) =>
+			const startingCount = active.filter((t) =>
 				[
 					"new",
 					"pending",


### PR DESCRIPTION
## Description

Every routine Swarm rolling update on an already-running service produces a false-negative from `waitForSwarmServiceStable`:

```
Container did not stay running after deployment: Container restarted after running: starting
```

Deployment succeeded, the new task is running healthy, but the UI reports a failed deploy.

## Reproduction

Redeploy any Application backed by a service that is already running (i.e. Swarm performs an update, not an initial create). The message appears intermittently depending on when the poll lines up with the transition between the old and new tasks.

## Root cause

`waitForSwarmServiceStable` lists every task returned for the service and computes counts across all of them:

```typescript
const tasks = await remoteDocker.listTasks({
    filters: JSON.stringify({ service: [appName] }),
});
// ...
const runningCount = sorted.filter(t => t.Status?.State === "running").length;
const startingCount = sorted.filter(t => [...].includes(t.Status?.State ?? "")).length;

if (runningCount > 0) everRunning = true;
else if (everRunning && startingCount > 0) return unstable;
```

During a rolling update it's easy to hit this race:

| Poll | Old task | New task | `runningCount` | `startingCount` | `everRunning` | Outcome |
|------|----------|----------|----------------|-----------------|---------------|---------|
| N    | running  | preparing | 1              | 1               | → true        | keeps polling |
| N+1  | shutdown | starting  | 0              | 1               | true          | **returns `{ stable: false, reason: "Container restarted after running…" }`** |

Nothing actually restarted — Swarm just handed over between two distinct tasks. The new task then continues running healthy, but the deploy is marked failed.

## Fix

Restrict `listTasks` to `desired-state=running`. This is already the pattern used elsewhere in the same file (`getSwarmServiceHealth`, `getSwarmServiceContainerId`), so the check now only ever considers tasks Swarm intends to keep alive. Old tasks whose `desired-state` was moved to `shutdown` by the rolling update disappear from the poll immediately, and the false positive disappears with them.

```diff
- const tasks = await remoteDocker.listTasks({
-     filters: JSON.stringify({ service: [appName] }),
- });
+ const tasks = await remoteDocker.listTasks({
+     filters: JSON.stringify({
+         service: [appName],
+         "desired-state": ["running"],
+     }),
+ });
```

## What this does NOT change

- A container that actually crash-loops still keeps its `desired-state=running` (Swarm re-schedules it), so the check still sees `runningCount=0 && startingCount>0 && everRunning=true` and correctly returns unstable.
- `failed` / `rejected` states are still surfaced identically.
- Initial deploys (no previous task) behave exactly as before — there was never an "old" task to filter out.

## Test plan

- [ ] Verify on a live setup: consecutive redeploys of a running Application should no longer flip the deploy status to failed while the container is in fact healthy.
- [x] Automated tests.

## Affected versions

Present since `waitForSwarmServiceStable` was introduced (all `v0.29.13-community.X` and `v0.29.14-community.X` releases).
