### PR TITLE
fix(monitoring): pass selected serverId through to the Docker Disk Usage widget

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_SERVER_ID } from "@dokploy/server/monitoring/constants";
 import { Loader2, RefreshCw } from "lucide-react";
 import { useMemo } from "react";
 import { Cell, Label, Pie, PieChart } from "recharts";
@@ -48,11 +49,18 @@ const formatSize = (bytes: number): string => {
 	return `${bytes} B`;
 };
 
-export const DockerDiskUsageChart = () => {
+interface Props {
+	serverId?: string;
+}
+
+export const DockerDiskUsageChart = ({ serverId }: Props) => {
+	const remoteServerId =
+		serverId && serverId !== LOCAL_SERVER_ID ? serverId : undefined;
 	const { data, isLoading, refetch, isRefetching } =
-		api.settings.getDockerDiskUsage.useQuery(undefined, {
-			refetchOnWindowFocus: false,
-		});
+		api.settings.getDockerDiskUsage.useQuery(
+			{ serverId: remoteServerId },
+			{ refetchOnWindowFocus: false },
+		);
 
 	const { chartData, totalBytes } = useMemo(() => {
 		const items =

--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -356,7 +356,7 @@ export const ContainerFreeMonitoring = ({
 							</CardTitle>
 						</CardHeader>
 						<CardContent>
-							<DockerDiskUsageChart />
+							<DockerDiskUsageChart serverId={serverId} />
 						</CardContent>
 					</Card>
 				)}

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -263,12 +263,20 @@ export const settingsRouter = createTRPCRouter({
 		});
 		return true;
 	}),
-	getDockerDiskUsage: adminProcedure.query(async () => {
-		if (IS_CLOUD) {
-			return [];
-		}
-		return getDockerDiskUsage();
-	}),
+	getDockerDiskUsage: adminProcedure
+		.input(z.object({ serverId: z.string().optional() }).optional())
+		.query(async ({ input, ctx }) => {
+			if (IS_CLOUD) {
+				return [];
+			}
+			if (input?.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			return getDockerDiskUsage(input?.serverId);
+		}),
 	saveSSHPrivateKey: adminProcedure
 		.input(apiSaveSSHKey)
 		.mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
## Description

On the multi-server monitoring page, changing the server in the selector never changed what the **Docker Disk Usage** card showed — it always reported the Dokploy host's own docker socket. Two pieces had to line up for that:

- `DockerDiskUsageChart` accepted no props and always called `settings.getDockerDiskUsage` with `undefined`.
- The `settings.getDockerDiskUsage` tRPC procedure accepted no input either, so `getDockerDiskUsage()` fell through to the local docker socket regardless of the caller.

Result: selecting any remote server on the monitoring page and looking at Docker Disk Usage showed the local (Dokploy host) numbers, not the remote's.

## Reproduction

1. On a Dokploy instance with at least one remote server configured
2. Go to `/dashboard/monitoring`
3. Switch the server selector from "Dokploy Server" (local) to a remote server
4. Observe: the **Docker Disk Usage** card keeps showing the local server's docker disk usage.

## Change

Thread the currently selected `serverId` down to the same underlying `getDockerDiskUsage(serverId)` call the dedicated Docker → Disk Usage page already uses:

- `DockerDiskUsageChart` now accepts a `serverId?: string` prop. When it receives the sentinel `LOCAL_SERVER_ID` from the monitoring page's selector, it forwards `undefined` (matching the pattern used in `show-free-container-monitoring.tsx` and `docker-stats.ts`); any other value is forwarded as-is.
- `ContainerFreeMonitoring` passes the page-level `serverId` when rendering the widget.
- `settings.getDockerDiskUsage` gets an optional `serverId` input and forwards it to `getDockerDiskUsage(serverId)`. Input is optional so existing callers that omit it keep the local-socket behavior — nothing else on the settings/monitoring pages needs to change.

## Scope

Fork-specific — the multi-server selector on the monitoring page was added in this fork; upstream Dokploy's monitoring page has no server switcher, so this widget only ever showed the local docker socket there.

## Test plan

- [x] Verified on a live setup: selecting the local Dokploy server shows the host's own docker disk usage, and selecting a remote server shows that server's docker disk usage, matching `docker system df` on the remote.