### PR TITLE
fix(swarm): exclude pre-existing tasks from stability counts to fix rolling-update false positive

### DIFF
--- a/apps/dokploy/__test__/server/waitForSwarmServiceStable.test.ts
+++ b/apps/dokploy/__test__/server/waitForSwarmServiceStable.test.ts
@@ -1,10 +1,15 @@
 import { waitForSwarmServiceStable } from "@dokploy/server/utils/docker/utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listTasksMock, getRemoteDockerMock } = vi.hoisted(() => {
+const { listTasksMock, infoMock, getRemoteDockerMock } = vi.hoisted(() => {
 	const listTasks = vi.fn();
-	const getRemoteDocker = vi.fn(async () => ({ listTasks }));
-	return { listTasksMock: listTasks, getRemoteDockerMock: getRemoteDocker };
+	const info = vi.fn();
+	const getRemoteDocker = vi.fn(async () => ({ listTasks, info }));
+	return {
+		listTasksMock: listTasks,
+		infoMock: info,
+		getRemoteDockerMock: getRemoteDocker,
+	};
 });
 
 vi.mock("@dokploy/server/utils/servers/remote-docker", () => ({
@@ -15,29 +20,44 @@ vi.mock("@dokploy/server/utils/servers/remote-docker", () => ({
 const WINDOW_MS = 400;
 const POLL_MS = 20;
 
+// Represents a task that pre-exists this deploy (outgoing task in a rolling
+// update, or a leftover in Swarm's history). Its `CreatedAt` must be well
+// before `pollStartMs = Date.now()` so the CreatedAt filter excludes it.
+const PRE_EXISTING_TASK_AGE_MS = 7 * 60 * 60 * 1000;
+
 type Task = {
 	Status?: { State?: string; Err?: string; Message?: string };
 	DesiredState?: string;
+	CreatedAt?: string;
 	UpdatedAt?: string;
 };
+
+const now = () => new Date().toISOString();
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
 
 const runningTask = (opts: Partial<Task> = {}): Task => ({
 	Status: { State: "running" },
 	DesiredState: "running",
-	UpdatedAt: new Date().toISOString(),
+	CreatedAt: now(),
+	UpdatedAt: now(),
 	...opts,
 });
 
 const startingTask = (opts: Partial<Task> = {}): Task => ({
 	Status: { State: "starting" },
 	DesiredState: "running",
-	UpdatedAt: new Date().toISOString(),
+	CreatedAt: now(),
+	UpdatedAt: now(),
 	...opts,
 });
 
 describe("waitForSwarmServiceStable", () => {
 	beforeEach(() => {
 		listTasksMock.mockReset();
+		infoMock.mockReset();
+		// Default: daemon clock in sync with ours. Individual tests override
+		// with `infoMock.mockResolvedValue({ SystemTime: <skewed> })`.
+		infoMock.mockResolvedValue({ SystemTime: new Date().toISOString() });
 	});
 
 	it("returns stable when a task reaches running and stays there", async () => {
@@ -51,30 +71,35 @@ describe("waitForSwarmServiceStable", () => {
 		expect(result).toEqual({ stable: true });
 	});
 
-	it("does not false-positive on the rolling-update handover between two tasks", async () => {
-		// The outgoing task is already marked for shutdown by Swarm, so it must
-		// be ignored for the running/starting counts. The incoming task is
-		// still starting when the outgoing one disappears — without the
-		// DesiredState filter this used to flip `everRunning=true` from the
-		// outgoing task and then fire "Container restarted after running".
+	it("does not false-positive when Swarm still lists the outgoing task as desired=running during the handover", async () => {
+		// Real Swarm behavior during a rolling update (stop-first or start-first
+		// alike): the outgoing task keeps `DesiredState=running` briefly while
+		// the new task is being created — Swarm only flips it to `shutdown`
+		// when it's about to stop it. If the DesiredState filter alone were
+		// enough, the outgoing task would still be counted here and flip
+		// `everRunning=true`; the subsequent poll (outgoing gone, incoming
+		// still starting) would then trip the "restarted after running"
+		// branch. The CreatedAt filter excludes tasks born long before the
+		// poll started so only tasks from the current deploy contribute to
+		// the running/starting counts.
 		listTasksMock
 			.mockResolvedValueOnce([
-				{
-					Status: { State: "running" },
-					DesiredState: "shutdown",
-					UpdatedAt: new Date().toISOString(),
-				},
-				startingTask({ Status: { State: "preparing" } }),
+				runningTask({ CreatedAt: ago(PRE_EXISTING_TASK_AGE_MS) }),
+				startingTask({
+					Status: { State: "preparing" },
+					CreatedAt: now(),
+				}),
 			])
 			.mockResolvedValueOnce([
 				{
 					Status: { State: "shutdown" },
 					DesiredState: "shutdown",
-					UpdatedAt: new Date().toISOString(),
+					CreatedAt: ago(PRE_EXISTING_TASK_AGE_MS),
+					UpdatedAt: now(),
 				},
-				startingTask(),
+				startingTask({ CreatedAt: now() }),
 			])
-			.mockResolvedValue([runningTask()]);
+			.mockResolvedValue([runningTask({ CreatedAt: now() })]);
 
 		const result = await waitForSwarmServiceStable("app", {
 			windowMs: WINDOW_MS,
@@ -89,20 +114,24 @@ describe("waitForSwarmServiceStable", () => {
 		// moves its DesiredState to "shutdown" and starts a rollback task.
 		// The `desired-state=running` filter alone would hide the failure and
 		// mark the deploy stable while the new image never ran successfully.
-		const failedAt = new Date().toISOString();
+		const failedAt = now();
 		listTasksMock
 			.mockResolvedValueOnce([
 				runningTask({
-					DesiredState: "running",
-					UpdatedAt: new Date(Date.now() - 10).toISOString(),
+					CreatedAt: ago(PRE_EXISTING_TASK_AGE_MS),
+					UpdatedAt: ago(10),
 				}),
-				startingTask({ Status: { State: "preparing" } }),
+				startingTask({
+					Status: { State: "preparing" },
+					CreatedAt: now(),
+				}),
 			])
 			.mockResolvedValue([
-				runningTask(),
+				runningTask({ CreatedAt: ago(PRE_EXISTING_TASK_AGE_MS) }),
 				{
 					Status: { State: "rejected", Err: "No such image: broken:latest" },
 					DesiredState: "shutdown",
+					CreatedAt: now(),
 					UpdatedAt: failedAt,
 				},
 			]);
@@ -122,13 +151,13 @@ describe("waitForSwarmServiceStable", () => {
 		// Swarm keeps a few historical tasks per service. A failure from a
 		// previous deploy has UpdatedAt older than pollStartMs and must not
 		// trigger a false negative for the current deploy.
-		const staleFailed = new Date(Date.now() - 60_000).toISOString();
 		listTasksMock.mockResolvedValue([
 			runningTask(),
 			{
 				Status: { State: "failed", Err: "stale failure" },
 				DesiredState: "shutdown",
-				UpdatedAt: staleFailed,
+				CreatedAt: ago(60_000),
+				UpdatedAt: ago(60_000),
 			},
 		]);
 
@@ -142,7 +171,9 @@ describe("waitForSwarmServiceStable", () => {
 
 	it("returns unstable with lastReason when the task never reaches running", async () => {
 		listTasksMock.mockResolvedValue([
-			startingTask({ Status: { State: "preparing", Message: "pulling image" } }),
+			startingTask({
+				Status: { State: "preparing", Message: "pulling image" },
+			}),
 		]);
 
 		const result = await waitForSwarmServiceStable("app", {
@@ -155,5 +186,49 @@ describe("waitForSwarmServiceStable", () => {
 			expect(result.reason).toContain("preparing");
 			expect(result.reason).toContain("pulling image");
 		}
+	});
+
+	it("survives a remote daemon clock behind ours by anchoring to its clock", async () => {
+		// The Swarm manager on a remote server can drift from the Dokploy host.
+		// Comparing our `Date.now()` to `Task.CreatedAt` (stamped by the remote
+		// daemon) would filter out genuinely-new tasks whose remote-stamped
+		// CreatedAt trails ours by more than the leeway — so `active` stays
+		// empty for the whole window and a healthy deploy times out as failed.
+		// Anchoring the gates to `docker info -> SystemTime` fixes it.
+		const SKEW_MS = 30_000;
+		infoMock.mockResolvedValue({
+			SystemTime: new Date(Date.now() - SKEW_MS).toISOString(),
+		});
+		// Task's CreatedAt uses the remote (skewed) clock.
+		listTasksMock.mockResolvedValue([
+			runningTask({ CreatedAt: new Date(Date.now() - SKEW_MS).toISOString() }),
+		]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result).toEqual({ stable: true });
+	});
+
+	it("reports 'no tasks from this deployment' when only pre-existing tasks are visible", async () => {
+		// Distinct from "task never reached running" (something exists but is
+		// stuck starting): here nothing that belongs to this deploy is present
+		// at all, e.g. the poll landed against a daemon that never received
+		// the service update, or every task is filtered out as pre-existing.
+		listTasksMock.mockResolvedValue([
+			runningTask({ CreatedAt: ago(PRE_EXISTING_TASK_AGE_MS) }),
+		]);
+
+		const result = await waitForSwarmServiceStable("app", {
+			windowMs: WINDOW_MS,
+			pollMs: POLL_MS,
+		});
+
+		expect(result).toEqual({
+			stable: false,
+			reason: "No tasks from this deployment found",
+		});
 	});
 });

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -1065,7 +1065,25 @@ export const waitForSwarmServiceStable = async (
 	}: { serverId?: string | null; windowMs?: number; pollMs?: number } = {},
 ): Promise<SwarmStabilityResult> => {
 	const remoteDocker = await getRemoteDocker(serverId);
+
+	// Swarm timestamps (`Task.CreatedAt`, `Task.UpdatedAt`) come from the
+	// target daemon's clock, which can drift from ours on remote servers.
+	// Anchor the time gates to the daemon's own clock so `CreatedAt` /
+	// `UpdatedAt` comparisons stay meaningful under skew. `deadline` stays
+	// on our clock — it's just a local timer for the poll loop.
+	let clockOffsetMs = 0;
+	try {
+		const info = await remoteDocker.info();
+		const daemonNowMs = new Date(info.SystemTime).getTime();
+		if (Number.isFinite(daemonNowMs)) {
+			clockOffsetMs = daemonNowMs - Date.now();
+		}
+	} catch {
+		// Fall back to our own clock — no worse than the pre-anchor behavior.
+	}
+
 	const pollStartMs = Date.now();
+	const daemonPollStartMs = pollStartMs + clockOffsetMs;
 	const deadline = pollStartMs + windowMs;
 	let everRunning = false;
 	let lastReason = "Service did not reach running state";
@@ -1084,7 +1102,7 @@ export const waitForSwarmServiceStable = async (
 			const recentlyFailed = tasks.find(
 				(t) =>
 					(t.Status?.State === "failed" || t.Status?.State === "rejected") &&
-					new Date(t.UpdatedAt ?? 0).getTime() >= pollStartMs,
+					new Date(t.UpdatedAt ?? 0).getTime() >= daemonPollStartMs,
 			);
 			if (recentlyFailed) {
 				const state = recentlyFailed.Status?.State;
@@ -1098,11 +1116,24 @@ export const waitForSwarmServiceStable = async (
 				};
 			}
 
-			// Stability counts must exclude tasks Swarm has already marked for
-			// shutdown (typically the outgoing task during a rolling update),
-			// otherwise the running→starting transition of the handover flags a
-			// perfectly healthy deploy as unstable.
-			const active = tasks.filter((t) => t.DesiredState === "running");
+			// Stability counts must exclude:
+			//   1. tasks Swarm has already marked for shutdown (the outgoing
+			//      task once the rolling update has flipped it), and
+			//   2. tasks created before this poll started — Swarm briefly
+			//      keeps the outgoing task at DesiredState="running" while the
+			//      new task boots, so filtering on DesiredState alone still
+			//      lets the outgoing task set `everRunning=true`, and the
+			//      subsequent handover (outgoing → shutdown, incoming still
+			//      starting) then trips the "restarted after running" branch.
+			// Small leeway so a task created in the sub-second between the
+			// service update call and our first Date.now() still counts.
+			const CREATED_AT_LEEWAY_MS = 5_000;
+			const active = tasks.filter(
+				(t) =>
+					t.DesiredState === "running" &&
+					new Date(t.CreatedAt ?? 0).getTime() >=
+						daemonPollStartMs - CREATED_AT_LEEWAY_MS,
+			);
 			const sorted = [...active].sort((a, b) => {
 				const at = new Date(a.UpdatedAt ?? 0).getTime();
 				const bt = new Date(b.UpdatedAt ?? 0).getTime();
@@ -1136,9 +1167,11 @@ export const waitForSwarmServiceStable = async (
 				};
 			}
 
-			lastReason = message
-				? `Latest task state: ${state ?? "unknown"} (${message})`
-				: `Latest task state: ${state ?? "unknown"}`;
+			lastReason = active.length === 0
+				? "No tasks from this deployment found"
+				: message
+					? `Latest task state: ${state ?? "unknown"} (${message})`
+					: `Latest task state: ${state ?? "unknown"}`;
 		} catch (error) {
 			lastReason =
 				error instanceof Error ? error.message : "Failed to inspect service";


### PR DESCRIPTION
## Description

Follow-up to #184. The DesiredState=running filter fixed the case where Swarm had already flipped the outgoing task to `shutdown` — but real Swarm behavior is subtler: **the outgoing task keeps `DesiredState=running` for a few seconds while the new task is being created**, and only gets flipped to `shutdown` when Swarm is about to stop it. During that window both tasks survive the DS filter, the outgoing task's `State=running` sets `everRunning=true`, and the subsequent handover (outgoing gone, incoming still starting) fires the 'restarted after running' branch.

## Reproduction

Observed on a live deployment running `v0.30.0-community.2` (already includes #184):

- **Old task** — CreatedAt `09:34:10` (~7 h earlier), Shutdown at `16:40:21`, `DesiredState=shutdown`.
- **New task** — CreatedAt `16:40:17`, reached `State=running` at `16:40:28`.

Reconstructed poll timeline:

| Poll | Old task | New task | Counts | Outcome |
|------|----------|----------|--------|---------|
| ~16:40:17 | DS=running State=running | DS=running State=new | runningCount=1 (old), startingCount=1 (new) | `everRunning=true` |
| ~16:40:22 | DS=shutdown State=shutdown (filtered) | DS=running State=starting | runningCount=0, startingCount=1 | **`{ stable: false, reason: 'Container restarted after running: starting' }`** |

Deploy was actually healthy — new task reaches running 6 s later — but the UI reports the deployment as failed.

## Fix

Restrict the running/starting counts further: a task is only considered part of this deploy if its `CreatedAt` is at or after `pollStartMs` (with a 5 s leeway for the sub-second between the service update call and `Date.now()`).

- Pre-existing tasks are excluded even while Swarm still lists them as `DesiredState=running`, so they can never set `everRunning=true` on behalf of the incoming deploy.
- Fresh deploys (`createService` with no prior task) are unaffected — all tasks are new.
- Crash-loop / rollback detection still runs against the **full** task set for `failed`/`rejected` states, filtered by `UpdatedAt >= pollStartMs` — a new task that fails after being created is still surfaced immediately.

## Scope

Fork-specific — `waitForSwarmServiceStable` doesn't exist upstream. Continues the work of #184.

## Test plan

- [x] All 5 tests in `__test__/server/waitForSwarmServiceStable.test.ts` pass locally with `pnpm exec vitest run`.
- [x] The new regression test mirrors the exact real-world sequence observed above (outgoing task with old `CreatedAt` and `DesiredState=running` at poll 1, flipped to `shutdown` at poll 2, incoming task still `starting`).
- [x] Verified on the live deployment that originally exhibited the bug: with the built image rolled out, redeploying the same application now completes without the 'Container restarted after running' false negative.