### PR TITLE
fix(security): org-scope serverId on destructive settings mutations

### DIFF
--- a/apps/dokploy/__test__/permissions/settings-server-org-scope.test.ts
+++ b/apps/dokploy/__test__/permissions/settings-server-org-scope.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `adminProcedure` only proves the caller is an owner/admin of their *active*
+ * organization -- it says nothing about the `serverId` they pass in. The
+ * destructive docker cleanup mutations in the settings router take that
+ * `serverId` straight to an SSH/docker exec, so they must additionally verify
+ * the target server belongs to the caller's organization.
+ */
+vi.mock("@/server/api/utils/audit", () => ({
+	audit: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@dokploy/server", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@dokploy/server")>();
+	return {
+		...actual,
+		findServerById: vi.fn(async () => ({
+			serverId: "srv-1",
+			organizationId: "org-1",
+			serverStatus: "active",
+		})),
+		cleanupImages: vi.fn(async () => {}),
+		cleanupVolumes: vi.fn(async () => {}),
+		cleanupContainers: vi.fn(async () => {}),
+		cleanupBuilders: vi.fn(async () => {}),
+		cleanupSystem: vi.fn(async () => {}),
+		cleanupAll: vi.fn(async () => {}),
+	};
+});
+
+const { appRouter } = await import("@/server/api/root");
+const { createCallerFactory } = await import("@/server/api/trpc");
+const {
+	cleanupAll,
+	cleanupBuilders,
+	cleanupContainers,
+	cleanupImages,
+	cleanupSystem,
+	cleanupVolumes,
+	findServerById,
+} = await import("@dokploy/server");
+
+const createCaller = createCallerFactory(appRouter);
+
+const ownerCtx = {
+	user: { id: "user-1", email: "owner@test.com", role: "owner" },
+	session: { activeOrganizationId: "org-1" },
+	req: {} as unknown,
+	res: {} as unknown,
+} as never;
+
+const inAnotherOrganization = () => {
+	vi.mocked(findServerById).mockResolvedValue({
+		serverId: "srv-1",
+		organizationId: "org-2",
+		serverStatus: "active",
+	} as Awaited<ReturnType<typeof findServerById>>);
+};
+
+const inSameOrganization = () => {
+	vi.mocked(findServerById).mockResolvedValue({
+		serverId: "srv-1",
+		organizationId: "org-1",
+		serverStatus: "active",
+	} as Awaited<ReturnType<typeof findServerById>>);
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	inSameOrganization();
+});
+
+describe("settings destructive mutations are organization-scoped", () => {
+	const cases = [
+		["cleanUnusedImages", cleanupImages],
+		["cleanUnusedVolumes", cleanupVolumes],
+		["cleanStoppedContainers", cleanupContainers],
+		["cleanDockerBuilder", cleanupBuilders],
+		["cleanDockerPrune", cleanupSystem],
+		["cleanAll", cleanupAll],
+	] as const;
+
+	for (const [procedure, cleanup] of cases) {
+		it(`${procedure} rejects a serverId from another organization`, async () => {
+			inAnotherOrganization();
+			const caller = createCaller(ownerCtx);
+
+			await expect(
+				caller.settings[procedure]({ serverId: "srv-1" }),
+			).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+			expect(cleanup).not.toHaveBeenCalled();
+		});
+
+		it(`${procedure} allows a serverId from the caller's organization`, async () => {
+			const caller = createCaller(ownerCtx);
+
+			await expect(
+				caller.settings[procedure]({ serverId: "srv-1" }),
+			).resolves.not.toThrow();
+			expect(cleanup).toHaveBeenCalledWith("srv-1");
+		});
+	}
+
+	it("still allows local (serverId-less) cleanups without a server lookup", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.settings.cleanUnusedImages({})).resolves.not.toThrow();
+		expect(cleanupImages).toHaveBeenCalledWith(undefined);
+		expect(findServerById).not.toHaveBeenCalled();
+	});
+
+	it("rejects when the caller has no active organization", async () => {
+		const caller = createCaller({
+			user: { id: "user-1", email: "owner@test.com", role: "owner" },
+			session: { activeOrganizationId: undefined },
+			req: {} as unknown,
+			res: {} as unknown,
+		} as never);
+
+		await expect(
+			caller.settings.cleanUnusedImages({ serverId: "srv-1" }),
+		).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+		expect(cleanupImages).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -84,6 +84,29 @@ import {
 	publicProcedure,
 } from "../trpc";
 
+/**
+ * Settings procedures take a caller-supplied `serverId` and then run docker /
+ * SSH commands against that server. `adminProcedure` (and `protectedProcedure`)
+ * only assert a role inside the caller's *active* organization, never that the
+ * target server belongs to it, so without this check an owner/admin of one
+ * organization could pass another organization's `serverId` and act on it.
+ *
+ * No-op when no `serverId` is supplied: those calls target the local Dokploy
+ * host, which is already covered by the procedure's role gate.
+ */
+const assertServerInOrganization = async (
+	serverId: string | undefined,
+	activeOrganizationId: string | null | undefined,
+) => {
+	if (!serverId) {
+		return;
+	}
+	const targetServer = await findServerById(serverId);
+	if (targetServer.organizationId !== activeOrganizationId) {
+		throw new TRPCError({ code: "UNAUTHORIZED" });
+	}
+};
+
 export const settingsRouter = createTRPCRouter({
 	getWebServerSettings: protectedProcedure.query(async () => {
 		if (IS_CLOUD) {
@@ -119,6 +142,10 @@ export const settingsRouter = createTRPCRouter({
 	reloadTraefik: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			// Run in background so the request returns immediately; avoids proxy timeouts.
 			void reloadDockerResource("dokploy-traefik", input?.serverId).catch(
 				(err) => {
@@ -135,6 +162,10 @@ export const settingsRouter = createTRPCRouter({
 	toggleDashboard: adminProcedure
 		.input(apiEnableDashboard)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			const ports = await readPorts("dokploy-traefik", input.serverId);
 			const env = await readEnvironmentVariables(
 				"dokploy-traefik",
@@ -183,6 +214,10 @@ export const settingsRouter = createTRPCRouter({
 	cleanUnusedImages: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await cleanupImages(input?.serverId);
 			await audit(ctx, {
 				action: "delete",
@@ -194,6 +229,10 @@ export const settingsRouter = createTRPCRouter({
 	cleanUnusedVolumes: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await cleanupVolumes(input?.serverId);
 			await audit(ctx, {
 				action: "delete",
@@ -205,6 +244,10 @@ export const settingsRouter = createTRPCRouter({
 	cleanStoppedContainers: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await cleanupContainers(input?.serverId);
 			await audit(ctx, {
 				action: "delete",
@@ -216,6 +259,10 @@ export const settingsRouter = createTRPCRouter({
 	cleanDockerBuilder: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await cleanupBuilders(input?.serverId);
 			await audit(ctx, {
 				action: "delete",
@@ -226,6 +273,10 @@ export const settingsRouter = createTRPCRouter({
 	cleanDockerPrune: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await cleanupSystem(input?.serverId);
 			await cleanupBuilders(input?.serverId);
 			await audit(ctx, {
@@ -238,6 +289,10 @@ export const settingsRouter = createTRPCRouter({
 	cleanAll: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			// Execute cleanup in background and return immediately to avoid gateway timeouts
 			void cleanupAll(input?.serverId);
 			await audit(ctx, {
@@ -269,12 +324,10 @@ export const settingsRouter = createTRPCRouter({
 			if (IS_CLOUD) {
 				return [];
 			}
-			if (input?.serverId) {
-				const server = await findServerById(input.serverId);
-				if (server.organizationId !== ctx.session?.activeOrganizationId) {
-					throw new TRPCError({ code: "UNAUTHORIZED" });
-				}
-			}
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			return getDockerDiskUsage(input?.serverId);
 		}),
 	saveSSHPrivateKey: adminProcedure
@@ -343,21 +396,21 @@ export const settingsRouter = createTRPCRouter({
 		.input(apiUpdateDockerCleanup)
 		.mutation(async ({ input, ctx }) => {
 			if (input.serverId) {
+				// Authorize before writing: the previous order persisted the
+				// `enableDockerCleanup` flag on the target server *before*
+				// checking that it belongs to the caller's organization.
+				await assertServerInOrganization(
+					input.serverId,
+					ctx.session?.activeOrganizationId,
+				);
+
 				await updateServerById(input.serverId, {
 					enableDockerCleanup: input.enableDockerCleanup,
 				});
 
 				const server = await findServerById(input.serverId);
 
-				if (server.organizationId !== ctx.session?.activeOrganizationId) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You are not authorized to access this server",
-					});
-				}
-
 				if (server.enableDockerCleanup) {
-					const server = await findServerById(input.serverId);
 					if (server.serverStatus === "inactive") {
 						throw new TRPCError({
 							code: "NOT_FOUND",
@@ -636,6 +689,10 @@ export const settingsRouter = createTRPCRouter({
 		.query(async ({ ctx, input }) => {
 			try {
 				await checkPermission(ctx, { traefikFiles: ["read"] });
+				await assertServerInOrganization(
+					input?.serverId,
+					ctx.session?.activeOrganizationId,
+				);
 				const { MAIN_TRAEFIK_PATH } = paths(!!input?.serverId);
 				const result = await readDirectory(MAIN_TRAEFIK_PATH, input?.serverId);
 				return result || [];
@@ -648,6 +705,10 @@ export const settingsRouter = createTRPCRouter({
 		.input(apiModifyTraefikConfig)
 		.mutation(async ({ input, ctx }) => {
 			await checkPermission(ctx, { traefikFiles: ["write"] });
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await writeTraefikConfigInPath(
 				input.path,
 				input.traefikConfig,
@@ -665,14 +726,10 @@ export const settingsRouter = createTRPCRouter({
 		.input(apiReadTraefikConfig)
 		.query(async ({ input, ctx }) => {
 			await checkPermission(ctx, { traefikFiles: ["read"] });
-
-			if (input.serverId) {
-				const server = await findServerById(input.serverId);
-
-				if (server.organizationId !== ctx.session?.activeOrganizationId) {
-					throw new TRPCError({ code: "UNAUTHORIZED" });
-				}
-			}
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 
 			return readConfigInPath(input.path, input.serverId);
 		}),
@@ -790,7 +847,11 @@ export const settingsRouter = createTRPCRouter({
 	),
 	readTraefikEnv: adminProcedure
 		.input(apiServerSchema)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			const envVars = await readEnvironmentVariables(
 				"dokploy-traefik",
 				input?.serverId,
@@ -801,6 +862,10 @@ export const settingsRouter = createTRPCRouter({
 	writeTraefikEnv: adminProcedure
 		.input(z.object({ env: z.string(), serverId: z.string().optional() }))
 		.mutation(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			const envs = prepareEnvironmentVariables(input.env);
 			const ports = await readPorts("dokploy-traefik", input?.serverId);
 
@@ -821,7 +886,11 @@ export const settingsRouter = createTRPCRouter({
 		}),
 	haveTraefikDashboardPortEnabled: adminProcedure
 		.input(apiServerSchema)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			const ports = await readPorts("dokploy-traefik", input?.serverId);
 			return ports.some((port) => port.targetPort === 8080);
 		}),
@@ -993,6 +1062,10 @@ export const settingsRouter = createTRPCRouter({
 			if (IS_CLOUD && !input.serverId) {
 				throw new Error("Select a server to enable the GPU Setup");
 			}
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 
 			try {
 				await setupGPUSupport(input.serverId);
@@ -1013,7 +1086,7 @@ export const settingsRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
 			if (IS_CLOUD && !input.serverId) {
 				return {
 					driverInstalled: false,
@@ -1029,6 +1102,11 @@ export const settingsRouter = createTRPCRouter({
 					gpuResources: 0,
 				};
 			}
+
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 
 			try {
 				return await checkGPUStatus(input.serverId || "");
@@ -1055,6 +1133,13 @@ export const settingsRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
+			// Kept outside the try/catch below, which rewrites every error into a
+			// BAD_REQUEST and would mask the authorization failure.
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
+
 			try {
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
@@ -1111,7 +1196,11 @@ export const settingsRouter = createTRPCRouter({
 		}),
 	getTraefikPorts: adminProcedure
 		.input(apiServerSchema)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await assertServerInOrganization(
+				input?.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			const ports = await readPorts("dokploy-traefik", input?.serverId);
 			return ports;
 		}),


### PR DESCRIPTION
## Context

While reviewing #187 (`settings.getDockerDiskUsage` was missing an organization check on `serverId`) we noticed the same gap on the rest of the settings router, including the destructive docker cleanup mutations. #187 fixed one procedure; this PR closes the remaining ones.

## The gap

`adminProcedure` (`apps/dokploy/server/api/trpc.ts`) only asserts that the caller has the `owner` or `admin` role **within their own active organization**. It never validates the `serverId` the caller supplies. Every settings procedure that accepts a `serverId` then hands it straight to a docker/SSH exec on that host.

Net effect: any authenticated owner/admin of *any* organization could pass another organization's `serverId` and run destructive docker prune/clean commands (or read/write Traefik config, env vars and ports) on that organization's server. This is an upstream-inherited gap, not something the fork introduced.

## The fix

A single `assertServerInOrganization(serverId, activeOrganizationId)` helper in the settings router, applying the exact guard shape #187 introduced (`findServerById` -> compare `organizationId` -> `TRPCError UNAUTHORIZED`). It is a no-op when no `serverId` is supplied, so local (Dokploy host) calls are unchanged.

**The six destructive mutations from the review** (the headline fix):

- `cleanUnusedImages`
- `cleanUnusedVolumes`
- `cleanStoppedContainers`
- `cleanDockerBuilder`
- `cleanDockerPrune`
- `cleanAll`

**Identical siblings in the same file** — same class of bug, same one-line guard, so they are fixed here rather than left as a known hole in a file we are already touching:

- `reloadTraefik`, `toggleDashboard`, `writeTraefikEnv`, `updateTraefikPorts`, `setupGPU`, `updateTraefikFile` (remote writes/exec)
- `readTraefikEnv`, `getTraefikPorts`, `haveTraefikDashboardPortEnabled`, `readDirectories`, `checkGPUStatus` (cross-org reads / existence oracles)

**Ordering bug in `updateDockerCleanup`**: it already had the org check, but it ran *after* `updateServerById` had already persisted `enableDockerCleanup` on the target server. The check now runs before the write. (The redundant shadowed `findServerById` re-fetch inside the branch was dropped in the process.)

**Refactors, no behavior change**: `getDockerDiskUsage` (from #187) and `readTraefikFile` had the guard inline; they now call the shared helper so all call sites stay in sync.

Two placement details worth a reviewer's eye:

- In `updateTraefikPorts` the guard sits **outside** the existing `try/catch`, which rewrites every error into `BAD_REQUEST` and would otherwise mask the authorization failure.
- In `setupGPU` / `checkGPUStatus` the guard runs after the existing `IS_CLOUD && !serverId` branches, so cloud behavior is untouched. `checkGPUStatus("")` (local) still skips the lookup.

## No legitimate flow is affected

The only UI entry points are `ShowStorageActions`, mounted from `web-server.tsx` (no `serverId` -> local, guard is a no-op) and from `ShowServerActions` inside `show-servers.tsx`. That server list comes from `server.all`, which is scoped by `getAccessibleServerIds(ctx.session)` — org servers intersected with the member's accessible servers. The UI can therefore only ever offer a `serverId` that passes the new check.

## Tests

New `apps/dokploy/__test__/permissions/settings-server-org-scope.test.ts` (14 cases), following the existing `cloudflare-domain-publish-authz.test.ts` pattern (`createCallerFactory` + mocked `@dokploy/server`). For each of the six destructive mutations: cross-org `serverId` -> `UNAUTHORIZED` and the cleanup helper is never invoked; same-org `serverId` -> passes authz and the helper is invoked with that id. Plus a local (`serverId`-less) case that must still work without a server lookup, and a caller with no active organization that must fail closed.

Verified as a real regression test: reverting just the `cleanUnusedImages` guard makes exactly the cross-org and no-active-organization cases fail, then pass again once restored.

- `pnpm --filter=dokploy typecheck` — clean
- `vitest run __test__/permissions/` — 66 passed
- `biome check` on both touched files — no issues

## Out of scope (reported, not changed)

A sweep of the other routers turned up the same pattern elsewhere; those are deliberately left out to keep this PR reviewable and will be handled separately. Highest-impact: `certificate.create`, `registry.testRegistry` / `testRegistryById`, `destination.testConnection`, `patch.cleanPatchRepos`, `network.create` / `import` / `networksToSync`, `domain.generateDomain`.

For the record, these routers were checked and are already correctly guarded: `docker.ts`, `docker-volume.ts`, `docker-image.ts`, `docker-disk-usage.ts`, `cluster.ts`, `swarm.ts`, `proprietary/forward-auth.ts`, `server.ts` (except `getDefaultCommand`), `schedule.ts`, `deployment.ts`, and the service `create` procedures gated by `getAccessibleServerIds`.
