### PR TITLE
fix(security): org-scope serverId in certificate/registry/destination/patch routers + quote rclone additionalFlags

### DIFF
--- a/apps/dokploy/__test__/backups/rclone-additional-flags.test.ts
+++ b/apps/dokploy/__test__/backups/rclone-additional-flags.test.ts
@@ -71,10 +71,16 @@ describe("quoteAdditionalFlags", () => {
 		]);
 	});
 
-	it("is a no-op for flags that need no escaping", () => {
-		expect(
-			quoteAdditionalFlags(["--s3-no-check-bucket", "--checksum"]),
-		).toEqual(["--s3-no-check-bucket", "--checksum"]);
+	it("leaves schema-valid flags byte-identical", () => {
+		const flags = [
+			"--s3-no-check-bucket",
+			"--checksum",
+			"--transfers=4",
+			"--drive-root-folder-id=abc123",
+			"--bwlimit=10M",
+		];
+
+		expect(quoteAdditionalFlags(flags)).toEqual(flags);
 	});
 
 	// Negative control: without quoting, the very same payloads split the

--- a/apps/dokploy/__test__/backups/rclone-additional-flags.test.ts
+++ b/apps/dokploy/__test__/backups/rclone-additional-flags.test.ts
@@ -192,9 +192,12 @@ describe.skipIf(process.platform === "win32")(
 		});
 
 		it("negative control: the unquoted payload does execute", () => {
-			const argv = runShell([`--foo; echo ${PWNED}`]);
+			const output = runShell([`--foo; echo ${PWNED}`]);
 
-			expect(argv).toContain(PWNED);
+			// The payload ran as a second command, so `printf` only ever saw
+			// `ls --foo` and the injected `echo` produced the rest of the output.
+			expect(output).not.toContain(`--foo; echo ${PWNED}`);
+			expect(output.join("\n")).toContain(PWNED);
 		});
 	},
 );

--- a/apps/dokploy/__test__/backups/rclone-additional-flags.test.ts
+++ b/apps/dokploy/__test__/backups/rclone-additional-flags.test.ts
@@ -1,0 +1,194 @@
+import { execSync } from "node:child_process";
+import {
+	getRcloneCredentials,
+	quoteAdditionalFlags,
+} from "@dokploy/server/utils/backups/utils";
+import { parse } from "shell-quote";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Destination `additionalFlags` are user-supplied strings that end up
+ * interpolated into the rclone shell command line (test connection, database
+ * backups, volume backups, restores). They must reach rclone as inert argv
+ * tokens, never as shell syntax.
+ *
+ * `parse()` is shell-quote's POSIX word splitter: it returns plain strings for
+ * literal words and `{ op: ";" }`-style objects for shell operators, so it
+ * models exactly what /bin/sh would do with the command line we build.
+ */
+const MARK = "/tmp/dokploy_rclone_pwned";
+
+const buildCommand = (flags: string[]) =>
+	`rclone ls ${flags.join(" ")} ':s3:bucket/'`;
+
+// Tokenize the assembled command line the way a POSIX shell would.
+const tokenize = (flags: string[]) => parse(buildCommand(flags));
+
+const payloads = [
+	`--foo; touch ${MARK}`,
+	`$(touch ${MARK})`,
+	`\`touch ${MARK}\``,
+	`--foo && touch ${MARK}`,
+	`--foo | touch ${MARK}`,
+	`--foo' ; touch ${MARK} ; '`,
+	`--foo" ; touch ${MARK} ; "`,
+	`--foo$(touch ${MARK})`,
+	`--foo\`touch ${MARK}\``,
+	`--foo > ${MARK}`,
+];
+
+const s3Destination = {
+	provider: "s3",
+	bucket: "bucket",
+	accessKey: "ak",
+	secretAccessKey: "sk",
+	region: "us-east-1",
+	endpoint: "https://s3.example.com",
+	additionalFlags: null as string[] | null,
+};
+
+describe("quoteAdditionalFlags", () => {
+	it("returns an empty list when there are no flags", () => {
+		expect(quoteAdditionalFlags(null)).toEqual([]);
+		expect(quoteAdditionalFlags(undefined)).toEqual([]);
+		expect(quoteAdditionalFlags([])).toEqual([]);
+	});
+
+	it("keeps legitimate flags working as separate argv words", () => {
+		const flags = [
+			"--s3-no-check-bucket",
+			"--transfers=4",
+			"--s3-force-path-style",
+			"--checksum",
+			"--bwlimit=10M",
+		];
+
+		expect(tokenize(quoteAdditionalFlags(flags))).toEqual([
+			"rclone",
+			"ls",
+			...flags,
+			":s3:bucket/",
+		]);
+	});
+
+	it("is a no-op for flags that need no escaping", () => {
+		expect(
+			quoteAdditionalFlags(["--s3-no-check-bucket", "--checksum"]),
+		).toEqual(["--s3-no-check-bucket", "--checksum"]);
+	});
+
+	// Negative control: without quoting, the very same payloads split the
+	// command line into extra words and shell operators.
+	it("negative control: unquoted flags do inject shell operators", () => {
+		const tokens = parse(buildCommand([`--foo; touch ${MARK}`]));
+
+		expect(tokens).toContainEqual({ op: ";" });
+		expect(tokens).toContain("touch");
+	});
+
+	for (const payload of payloads) {
+		it(`neutralizes ${JSON.stringify(payload)}`, () => {
+			const tokens = tokenize(quoteAdditionalFlags([payload]));
+
+			// One inert literal argument, no operators, nothing added.
+			expect(tokens).toEqual(["rclone", "ls", payload, ":s3:bucket/"]);
+			expect(tokens.every((token) => typeof token === "string")).toBe(true);
+		});
+	}
+});
+
+describe("getRcloneCredentials quotes destination additionalFlags", () => {
+	it("neutralizes an injected flag on an S3 destination", () => {
+		const tokens = tokenize(
+			getRcloneCredentials({
+				...s3Destination,
+				additionalFlags: [`--foo; touch ${MARK}`],
+			}),
+		);
+
+		expect(tokens).toContain(`--foo; touch ${MARK}`);
+		expect(tokens.every((token) => typeof token === "string")).toBe(true);
+	});
+
+	it("neutralizes an injected flag on a generic rclone destination", () => {
+		const tokens = tokenize(
+			getRcloneCredentials({
+				...s3Destination,
+				provider: "GenericRclone",
+				additionalFlags: [`--foo; touch ${MARK}`],
+			}),
+		);
+
+		expect(tokens).toEqual([
+			"rclone",
+			"ls",
+			`--foo; touch ${MARK}`,
+			":s3:bucket/",
+		]);
+	});
+
+	it("keeps the S3 credential flags intact alongside a legitimate flag", () => {
+		const tokens = tokenize(
+			getRcloneCredentials({
+				...s3Destination,
+				additionalFlags: ["--transfers=4"],
+			}),
+		);
+
+		expect(tokens).toContain("--s3-access-key-id=ak");
+		expect(tokens).toContain("--s3-region=us-east-1");
+		expect(tokens).toContain("--s3-no-check-bucket");
+		expect(tokens).toContain("--transfers=4");
+	});
+});
+
+// The tokenizer above models a POSIX shell; this suite proves it against a real
+// one. `printf '%s\n'` stands in for the rclone binary and echoes back the argv
+// it actually received, so no temporary files or path assumptions are involved.
+// Skipped on Windows, which has no /bin/bash for execSync.
+describe.skipIf(process.platform === "win32")(
+	"additionalFlags against a real shell",
+	() => {
+		const PWNED = "PWNED";
+
+		const runShell = (flags: string[]) => {
+			const stdout = execSync(
+				`printf '%s\\n' ls ${flags.join(" ")} ':s3:bucket/'`,
+				{ shell: "/bin/bash", encoding: "utf8" },
+			);
+			return stdout.split("\n").filter(Boolean);
+		};
+
+		it("passes legitimate flags through as separate argv words", () => {
+			const argv = runShell(
+				quoteAdditionalFlags(["--s3-no-check-bucket", "--transfers=4"]),
+			);
+
+			expect(argv).toEqual([
+				"ls",
+				"--s3-no-check-bucket",
+				"--transfers=4",
+				":s3:bucket/",
+			]);
+		});
+
+		it("does not execute an injected command", () => {
+			const argv = runShell(quoteAdditionalFlags([`--foo; echo ${PWNED}`]));
+
+			expect(argv).toEqual(["ls", `--foo; echo ${PWNED}`, ":s3:bucket/"]);
+			expect(argv).not.toContain(PWNED);
+		});
+
+		it("does not execute an injected command substitution", () => {
+			const argv = runShell(quoteAdditionalFlags([`--foo$(echo ${PWNED})`]));
+
+			expect(argv).toEqual(["ls", `--foo$(echo ${PWNED})`, ":s3:bucket/"]);
+		});
+
+		it("negative control: the unquoted payload does execute", () => {
+			const argv = runShell([`--foo; echo ${PWNED}`]);
+
+			expect(argv).toContain(PWNED);
+		});
+	},
+);

--- a/apps/dokploy/__test__/permissions/routers-server-org-scope.test.ts
+++ b/apps/dokploy/__test__/permissions/routers-server-org-scope.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Wave 2 of the cross-organization `serverId` sweep.
+ *
+ * `withPermission(...)` / `adminProcedure` only prove the caller holds a
+ * role/permission inside their *active* organization -- they say nothing about
+ * the `serverId` the caller passes in. These procedures take that `serverId`
+ * straight to an SSH exec (docker login, rclone, rm -rf) or write files onto
+ * it, so they must additionally verify the target server belongs to the
+ * caller's organization.
+ */
+vi.mock("@/server/api/utils/audit", () => ({
+	audit: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@dokploy/server/services/permission", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("@dokploy/server/services/permission")
+		>();
+	return {
+		...actual,
+		checkPermission: vi.fn(async () => {}),
+	};
+});
+
+vi.mock("@dokploy/server", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@dokploy/server")>();
+	return {
+		...actual,
+		findServerById: vi.fn(async () => ({
+			serverId: "srv-1",
+			organizationId: "org-1",
+			serverStatus: "active",
+		})),
+		createCertificate: vi.fn(async () => ({
+			certificateId: "cert-1",
+			name: "cert",
+		})),
+		cleanPatchRepos: vi.fn(async () => {}),
+		execAsync: vi.fn(async () => ({ stdout: "", stderr: "" })),
+		execAsyncRemote: vi.fn(async () => ({ stdout: "", stderr: "" })),
+		execFileAsync: vi.fn(async () => ({ stdout: "", stderr: "" })),
+		getRclonePathAndFlags: vi.fn(async () => ({
+			flags: [] as string[],
+			path: ":s3:bucket/",
+			envVars: "",
+		})),
+	};
+});
+
+const { appRouter } = await import("@/server/api/root");
+const { createCallerFactory } = await import("@/server/api/trpc");
+const { db } = await import("@dokploy/server/db");
+const {
+	cleanPatchRepos,
+	createCertificate,
+	execAsync,
+	execAsyncRemote,
+	execFileAsync,
+	findServerById,
+} = await import("@dokploy/server");
+
+const createCaller = createCallerFactory(appRouter);
+
+const ownerCtx = {
+	user: { id: "user-1", email: "owner@test.com", role: "owner" },
+	session: { activeOrganizationId: "org-1" },
+	req: {} as unknown,
+	res: {} as unknown,
+} as never;
+
+const noOrganizationCtx = {
+	user: { id: "user-1", email: "owner@test.com", role: "owner" },
+	session: { activeOrganizationId: undefined },
+	req: {} as unknown,
+	res: {} as unknown,
+} as never;
+
+const serverInOrganization = (organizationId: string) => {
+	vi.mocked(findServerById).mockResolvedValue({
+		serverId: "srv-1",
+		organizationId,
+		serverStatus: "active",
+	} as Awaited<ReturnType<typeof findServerById>>);
+};
+
+const registryRow = (organizationId: string) => ({
+	registryId: "reg-1",
+	registryName: "reg",
+	registryType: "cloud",
+	registryUrl: "registry.example.com",
+	username: "user",
+	password: "pass",
+	imagePrefix: null,
+	organizationId,
+});
+
+const certificateInput = {
+	name: "cert",
+	certificateData: "data",
+	privateKey: "key",
+	organizationId: "",
+	serverId: "srv-1",
+};
+
+const destinationInput = {
+	name: "dest",
+	provider: "s3",
+	accessKey: "ak",
+	secretAccessKey: "sk",
+	bucket: "bucket",
+	region: "us-east-1",
+	endpoint: "https://s3.example.com",
+	additionalFlags: [] as string[],
+	serverId: "srv-1",
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	serverInOrganization("org-1");
+	vi.mocked(db.query.registry.findFirst).mockResolvedValue(
+		registryRow("org-1") as never,
+	);
+});
+
+describe("certificate.create is organization-scoped", () => {
+	it("rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.certificates.create(certificateInput),
+		).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+		expect(createCertificate).not.toHaveBeenCalled();
+	});
+
+	it("allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.certificates.create(certificateInput),
+		).resolves.toMatchObject({ certificateId: "cert-1" });
+		expect(createCertificate).toHaveBeenCalled();
+	});
+
+	it("rejects when the caller has no active organization", async () => {
+		const caller = createCaller(noOrganizationCtx);
+
+		await expect(
+			caller.certificates.create(certificateInput),
+		).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+		expect(createCertificate).not.toHaveBeenCalled();
+	});
+
+	it("still allows a local (serverId-less) certificate", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.certificates.create({ ...certificateInput, serverId: undefined }),
+		).resolves.toMatchObject({ certificateId: "cert-1" });
+		expect(findServerById).not.toHaveBeenCalled();
+	});
+});
+
+describe("registry.testRegistry is organization-scoped", () => {
+	const input = {
+		registryUrl: "registry.example.com",
+		registryType: "cloud" as const,
+		username: "user",
+		password: "pass",
+		serverId: "srv-1",
+	};
+
+	it("rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.registry.testRegistry(input)).rejects.toMatchObject({
+			code: "UNAUTHORIZED",
+		});
+		expect(execAsyncRemote).not.toHaveBeenCalled();
+	});
+
+	it("allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.registry.testRegistry(input)).resolves.toBe(true);
+		expect(execAsyncRemote).toHaveBeenCalledWith(
+			"srv-1",
+			expect.stringContaining("docker login"),
+		);
+	});
+
+	it("runs locally without a server lookup when no serverId is given", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.registry.testRegistry({ ...input, serverId: undefined }),
+		).resolves.toBe(true);
+		expect(findServerById).not.toHaveBeenCalled();
+		expect(execFileAsync).toHaveBeenCalled();
+	});
+});
+
+describe("registry.testRegistryById is organization-scoped", () => {
+	const input = { registryId: "reg-1", serverId: "srv-1" };
+
+	it("rejects a registry from another organization", async () => {
+		vi.mocked(db.query.registry.findFirst).mockResolvedValue(
+			registryRow("org-2") as never,
+		);
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.registry.testRegistryById(input)).rejects.toMatchObject(
+			{ code: "UNAUTHORIZED" },
+		);
+		expect(execAsyncRemote).not.toHaveBeenCalled();
+	});
+
+	it("rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.registry.testRegistryById(input)).rejects.toMatchObject(
+			{ code: "UNAUTHORIZED" },
+		);
+		expect(execAsyncRemote).not.toHaveBeenCalled();
+	});
+
+	it("allows a registry and serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.registry.testRegistryById(input)).resolves.toBe(true);
+		expect(execAsyncRemote).toHaveBeenCalledWith(
+			"srv-1",
+			expect.stringContaining("docker login"),
+		);
+	});
+});
+
+describe("destination.testConnection is organization-scoped", () => {
+	it("rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.destination.testConnection(destinationInput),
+		).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+		expect(execAsync).not.toHaveBeenCalled();
+		expect(execAsyncRemote).not.toHaveBeenCalled();
+	});
+
+	it("allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.destination.testConnection(destinationInput),
+		).resolves.not.toThrow();
+		expect(execAsync).toHaveBeenCalledWith(
+			expect.stringContaining("rclone ls"),
+		);
+	});
+});
+
+describe("patch.cleanPatchRepos is organization-scoped", () => {
+	it("rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.patch.cleanPatchRepos({ serverId: "srv-1" }),
+		).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+		expect(cleanPatchRepos).not.toHaveBeenCalled();
+	});
+
+	it("allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.patch.cleanPatchRepos({ serverId: "srv-1" }),
+		).resolves.toBe(true);
+		expect(cleanPatchRepos).toHaveBeenCalledWith("srv-1");
+	});
+
+	it("still allows the local cleanup without a server lookup", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.patch.cleanPatchRepos({})).resolves.toBe(true);
+		expect(cleanPatchRepos).toHaveBeenCalledWith(undefined);
+		expect(findServerById).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/server/api/routers/certificate.ts
+++ b/apps/dokploy/server/api/routers/certificate.ts
@@ -10,6 +10,7 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { createTRPCRouter, withPermission } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiCreateCertificate,
 	apiFindCertificate,
@@ -27,6 +28,13 @@ export const certificateRouter = createTRPCRouter({
 					message: "Please set a server to create a certificate",
 				});
 			}
+			// Creating a certificate writes the cert/key and a traefik dynamic
+			// config onto `input.serverId` over SSH, so the target server must
+			// belong to the caller's organization.
+			await assertServerInOrganization(
+				input.serverId ?? undefined,
+				ctx.session?.activeOrganizationId,
+			);
 			const cert = await createCertificate(
 				input,
 				ctx.session.activeOrganizationId,

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -3,10 +3,11 @@ import {
 	execAsync,
 	execAsyncRemote,
 	findDestinationById,
+	getRclonePathAndFlags,
 	IS_CLOUD,
+	quoteAdditionalFlags,
 	removeDestinationById,
 	updateDestinationById,
-	getRclonePathAndFlags,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
 import { TRPCError } from "@trpc/server";
@@ -14,6 +15,7 @@ import { desc, eq } from "drizzle-orm";
 import { quote } from "shell-quote";
 import { createTRPCRouter, withPermission } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiCreateDestination,
 	apiFindOneDestination,
@@ -48,7 +50,7 @@ export const destinationRouter = createTRPCRouter({
 		}),
 	testConnection: withPermission("destination", "create")
 		.input(apiCreateDestination)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			const {
 				secretAccessKey,
 				bucket,
@@ -58,6 +60,12 @@ export const destinationRouter = createTRPCRouter({
 				provider,
 				additionalFlags,
 			} = input;
+			// The rclone probe runs over SSH on `input.serverId`; guard it before
+			// the try/catch below, which rewrites every error to BAD_REQUEST.
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			try {
 				const { flags: rcloneFlags, path: rcloneDestination } =
 					await getRclonePathAndFlags(
@@ -79,9 +87,7 @@ export const destinationRouter = createTRPCRouter({
 					"--contimeout 5s",
 				);
 
-				if (additionalFlags?.length) {
-					rcloneFlags.push(...additionalFlags);
-				}
+				rcloneFlags.push(...quoteAdditionalFlags(additionalFlags));
 				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} ${quote([rcloneDestination])}`;
 
 				if (IS_CLOUD && !input.serverId) {

--- a/apps/dokploy/server/api/routers/patch.ts
+++ b/apps/dokploy/server/api/routers/patch.ts
@@ -22,6 +22,7 @@ import {
 	protectedProcedure,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiCreatePatch,
 	apiDeletePatch,
@@ -320,6 +321,13 @@ export const patchRouter = createTRPCRouter({
 	cleanPatchRepos: adminProcedure
 		.input(z.object({ serverId: z.string().optional() }))
 		.mutation(async ({ input, ctx }) => {
+			// Removes the patch repositories directory on `input.serverId` over
+			// SSH; `adminProcedure` only proves a role in the caller's active
+			// organization, not ownership of the target server.
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session?.activeOrganizationId,
+			);
 			await cleanPatchRepos(input.serverId);
 			await audit(ctx, {
 				action: "delete",

--- a/apps/dokploy/server/api/routers/registry.ts
+++ b/apps/dokploy/server/api/routers/registry.ts
@@ -17,6 +17,7 @@ import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiCreateRegistry,
 	apiFindOneRegistry,
@@ -108,7 +109,15 @@ export const registryRouter = createTRPCRouter({
 		}),
 	testRegistry: withPermission("registry", "read")
 		.input(apiTestRegistry)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
+			// `docker login` runs over SSH on `input.serverId`; the guard stays
+			// outside the try/catch below so it is not rewritten to BAD_REQUEST.
+			await assertServerInOrganization(
+				input.serverId && input.serverId !== "none"
+					? input.serverId
+					: undefined,
+				ctx.session?.activeOrganizationId,
+			);
 			try {
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
@@ -170,25 +179,36 @@ export const registryRouter = createTRPCRouter({
 	testRegistryById: withPermission("registry", "read")
 		.input(apiTestRegistryById)
 		.mutation(async ({ input, ctx }) => {
-			try {
-				const registryData = await db.query.registry.findFirst({
-					where: eq(registry.registryId, input.registryId ?? ""),
+			// Both the registry row and the target server are caller-supplied and
+			// end up in a `docker login` over SSH, so authorize them before the
+			// try/catch below, which would otherwise rewrite UNAUTHORIZED into
+			// BAD_REQUEST.
+			const registryData = await db.query.registry.findFirst({
+				where: eq(registry.registryId, input.registryId ?? ""),
+			});
+
+			if (!registryData) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Registry not found",
 				});
+			}
 
-				if (!registryData) {
-					throw new TRPCError({
-						code: "NOT_FOUND",
-						message: "Registry not found",
-					});
-				}
+			if (registryData.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to test this registry",
+				});
+			}
 
-				if (registryData.organizationId !== ctx.session.activeOrganizationId) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You are not allowed to test this registry",
-					});
-				}
+			await assertServerInOrganization(
+				input.serverId && input.serverId !== "none"
+					? input.serverId
+					: undefined,
+				ctx.session?.activeOrganizationId,
+			);
 
+			try {
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
 						code: "NOT_FOUND",

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -57,6 +57,7 @@ import { scheduledJobs, scheduleJob } from "node-schedule";
 import { parse, stringify } from "yaml";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiAssignDomain,
 	apiEnableDashboard,
@@ -83,29 +84,6 @@ import {
 	protectedProcedure,
 	publicProcedure,
 } from "../trpc";
-
-/**
- * Settings procedures take a caller-supplied `serverId` and then run docker /
- * SSH commands against that server. `adminProcedure` (and `protectedProcedure`)
- * only assert a role inside the caller's *active* organization, never that the
- * target server belongs to it, so without this check an owner/admin of one
- * organization could pass another organization's `serverId` and act on it.
- *
- * No-op when no `serverId` is supplied: those calls target the local Dokploy
- * host, which is already covered by the procedure's role gate.
- */
-const assertServerInOrganization = async (
-	serverId: string | undefined,
-	activeOrganizationId: string | null | undefined,
-) => {
-	if (!serverId) {
-		return;
-	}
-	const targetServer = await findServerById(serverId);
-	if (targetServer.organizationId !== activeOrganizationId) {
-		throw new TRPCError({ code: "UNAUTHORIZED" });
-	}
-};
 
 export const settingsRouter = createTRPCRouter({
 	getWebServerSettings: protectedProcedure.query(async () => {

--- a/apps/dokploy/server/api/utils/server-org-scope.ts
+++ b/apps/dokploy/server/api/utils/server-org-scope.ts
@@ -1,0 +1,29 @@
+import { findServerById } from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
+
+/**
+ * Several routers take a caller-supplied `serverId` and then run docker / SSH
+ * commands (or write files) against that server. `adminProcedure`,
+ * `protectedProcedure` and `withPermission` only assert a role/permission
+ * inside the caller's *active* organization, never that the target server
+ * belongs to it, so without this check an owner/admin of one organization could
+ * pass another organization's `serverId` and act on it.
+ *
+ * No-op when no `serverId` is supplied: those calls target the local Dokploy
+ * host, which is already covered by the procedure's role gate.
+ *
+ * Must be called BEFORE any remote exec or database write, and outside any
+ * try/catch that rewrites errors, so the UNAUTHORIZED code reaches the client.
+ */
+export const assertServerInOrganization = async (
+	serverId: string | undefined,
+	activeOrganizationId: string | null | undefined,
+) => {
+	if (!serverId) {
+		return;
+	}
+	const targetServer = await findServerById(serverId);
+	if (targetServer.organizationId !== activeOrganizationId) {
+		throw new TRPCError({ code: "UNAUTHORIZED" });
+	}
+};

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -103,6 +103,26 @@ type RcloneDestination = Pick<
 	| "additionalFlags"
 >;
 
+/**
+ * `additionalFlags` are user-supplied strings that get interpolated into the
+ * rclone shell command line. The destination API schema validates them against
+ * ADDITIONAL_FLAG_REGEX, but that only covers values written through the API
+ * after the validation landed — rows created before it, or by any other writer,
+ * are not covered, and every rclone call site (test connection, database
+ * backups, volume backups, restores) shares these builders.
+ *
+ * Quoting here is the single choke point: shell-quote only escapes what the
+ * shell would otherwise interpret, so ordinary flags still reach rclone as the
+ * same argv words (`--s3-no-check-bucket` unchanged, `--transfers=4` escaped to
+ * `--transfers\=4`, which the shell unescapes back), while an injection payload
+ * (`--foo; touch /tmp/pwned`, `$(id)`, backticks) collapses into one inert
+ * literal argument.
+ */
+export const quoteAdditionalFlags = (
+	additionalFlags: string[] | null | undefined,
+) =>
+	additionalFlags?.length ? additionalFlags.map((flag) => quote([flag])) : [];
+
 export const isGenericRcloneDestination = (destination: RcloneDestination) =>
 	destination.provider === GENERIC_RCLONE_PROVIDER;
 
@@ -116,9 +136,7 @@ export const getRcloneCredentials = (destination: RcloneDestination) => {
 		destination;
 
 	if (isGenericRcloneDestination(destination)) {
-		return destination.additionalFlags?.length
-			? [...destination.additionalFlags]
-			: [];
+		return quoteAdditionalFlags(destination.additionalFlags);
 	}
 
 	const rcloneFlags = [
@@ -134,9 +152,7 @@ export const getRcloneCredentials = (destination: RcloneDestination) => {
 		rcloneFlags.unshift(`--s3-provider=${quote([provider])}`);
 	}
 
-	if (destination.additionalFlags?.length) {
-		rcloneFlags.push(...destination.additionalFlags);
-	}
+	rcloneFlags.push(...quoteAdditionalFlags(destination.additionalFlags));
 
 	return rcloneFlags;
 };
@@ -491,9 +507,10 @@ export const getRclonePathAndFlags = async (
 	subPath: string,
 ) => {
 	// Generic rclone remote: the user supplies a full remote spec (in `bucket`)
-	// plus their own rclone flags (additionalFlags, already validated against
-	// ADDITIONAL_FLAG_REGEX at the schema layer). We don't build an S3/SFTP
-	// connection string for it, but the remote spec and subPath are still
+	// plus their own rclone flags (additionalFlags, validated against
+	// ADDITIONAL_FLAG_REGEX at the schema layer and shell-quoted here via
+	// quoteAdditionalFlags). We don't build an S3/SFTP connection string for
+	// it, but the remote spec and subPath are still
 	// interpolated into a shell command, so validate them the same way the
 	// SFTP/FTP branch validates its path segments to prevent shell injection.
 	if (isGenericRcloneDestination(destination)) {
@@ -509,9 +526,7 @@ export const getRclonePathAndFlags = async (
 				"Invalid rclone backup path: contains forbidden characters",
 			);
 		}
-		const flags = destination.additionalFlags?.length
-			? [...destination.additionalFlags]
-			: [];
+		const flags = quoteAdditionalFlags(destination.additionalFlags);
 		if (isDestinationEncrypted(destination)) {
 			return {
 				flags,

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -1,4 +1,7 @@
-import { GENERIC_RCLONE_PROVIDER } from "@dokploy/server/db/validations/destination";
+import {
+	ADDITIONAL_FLAG_REGEX,
+	GENERIC_RCLONE_PROVIDER,
+} from "@dokploy/server/db/validations/destination";
 import { logger } from "@dokploy/server/lib/logger";
 
 export { GENERIC_RCLONE_PROVIDER };
@@ -111,17 +114,21 @@ type RcloneDestination = Pick<
  * are not covered, and every rclone call site (test connection, database
  * backups, volume backups, restores) shares these builders.
  *
- * Quoting here is the single choke point: shell-quote only escapes what the
- * shell would otherwise interpret, so ordinary flags still reach rclone as the
- * same argv words (`--s3-no-check-bucket` unchanged, `--transfers=4` escaped to
- * `--transfers\=4`, which the shell unescapes back), while an injection payload
- * (`--foo; touch /tmp/pwned`, `$(id)`, backticks) collapses into one inert
- * literal argument.
+ * This is the single choke point. A flag that satisfies the same
+ * ADDITIONAL_FLAG_REGEX allowlist is already free of shell metacharacters and
+ * passes through byte-identical (`--s3-no-check-bucket`, `--transfers=4`);
+ * anything else is shell-quoted, which collapses an injection payload
+ * (`--foo; touch /tmp/pwned`, `$(id)`, backticks) into one inert literal
+ * argument instead of extra shell words.
  */
 export const quoteAdditionalFlags = (
 	additionalFlags: string[] | null | undefined,
 ) =>
-	additionalFlags?.length ? additionalFlags.map((flag) => quote([flag])) : [];
+	additionalFlags?.length
+		? additionalFlags.map((flag) =>
+				ADDITIONAL_FLAG_REGEX.test(flag) ? flag : quote([flag]),
+			)
+		: [];
 
 export const isGenericRcloneDestination = (destination: RcloneDestination) =>
 	destination.provider === GENERIC_RCLONE_PROVIDER;


### PR DESCRIPTION
Wave 2 of the cross-organization `serverId` sweep started in #191.

`withPermission(...)` and `adminProcedure` only prove the caller holds a role/permission inside their **active** organization — they say nothing about the `serverId` the caller passes in. #191 fixed `settings.ts`; this PR fixes the four remaining routers that sweep flagged.

## Findings

| Router / procedure | Hole (verified against the code) | Fix |
| --- | --- | --- |
| `certificates.create` | Takes `serverId` and calls `createCertificate` → `createCertificateFiles`, which base64-writes the cert + private key **and a traefik dynamic config** onto that server via `execAsyncRemote`. No org check. A member of org A could plant attacker-controlled TLS material and traefik config on org B's server. | `assertServerInOrganization(input.serverId, …)` before `createCertificate`. |
| `registry.testRegistry` | Runs `docker login` (or ECR login) on an arbitrary `serverId` via `execAsyncRemote`, with caller-supplied credentials. No org check, and the whole body sits in a try/catch that rewrites errors to `BAD_REQUEST`. | Guard added **before** the try/catch. `serverId === "none"` is normalized to “local”, matching `loginDockerToECR`/the exec branch. |
| `registry.testRegistryById` | Same remote `docker login`, no server org check. **Additionally**: the pre-existing registry-*row* org check was *inside* the try/catch, so its `UNAUTHORIZED` was rewritten to `BAD_REQUEST` before reaching the client. | Row lookup + row org check + new server guard all moved **above** the try. Fail-closed behavior unchanged; the error code is now correct. |
| `destination.testConnection` | Runs an rclone probe on an arbitrary `serverId` (cloud path) via `execAsyncRemote`. No org check, inside an error-rewriting try/catch. | Guard added before the try/catch. |
| `patch.cleanPatchRepos` | `adminProcedure`, optional `serverId`, calls `cleanPatchRepos` → `rm -rf "$PATCH_REPOS_PATH"/*` over SSH. No org check. | Guard added before `cleanPatchRepos`. |

### Already guarded (no redundant check added)

- `certificates.one` / `remove` / `update` — all load the row and compare `certificate.organizationId` to the session's active org before acting. `certificates.all` is org-scoped in its `where`.
- `registry.one` / `remove` / `update` / `listECRImageTags` / `listECRRepositories` — all compare `registry.organizationId`. `registry.all` uses `findAllRegistryByOrganizationId`.
- `destination.one` / `remove` / `update` — all compare `destination.organizationId`. `destination.all` is org-scoped.
- `patch.readRepoDirectories` / `readRepoFile` and every other patch procedure — they derive `serverId` from the application/compose **after** `checkServicePermissionAndAccess`, which already scopes to the caller's org. Only `cleanPatchRepos` takes a raw caller-supplied `serverId`.
- `registry.create` / `apiUpdateRegistry` accept a `serverId` in their input schema but never use it, so there is nothing to guard.

## Shared helper

`assertServerInOrganization` moved out of `settings.ts` into `apps/dokploy/server/api/utils/server-org-scope.ts` (alongside the existing `audit.ts` / `plan-limits.ts` router helpers) and is imported by `settings.ts` plus the four routers. The implementation is unchanged, so `settings.ts` behavior is byte-identical:

- no-op when no `serverId` (local Dokploy host, already covered by the role gate);
- otherwise `findServerById` + `server.organizationId === ctx.session?.activeOrganizationId`, else `TRPCError({ code: "UNAUTHORIZED" })`;
- fail-closed when the session has no active organization (`undefined !== "org-1"`).

In every router the guard runs **before** any remote exec / DB write and **outside** any try/catch that rewrites errors.

## Shell injection: rclone `additionalFlags`

Destination `additionalFlags` are user-supplied strings that were spread into the rclone flag list and then `join(" ")`-ed into a command string passed to `execAsync` / `execAsyncRemote` — i.e. straight into `/bin/sh`. A value like `--foo; touch /tmp/pwned` or `$(id)` executed as a separate command on the target host.

The destination API schema does validate flags against `ADDITIONAL_FLAG_REGEX` (`/^--[a-zA-Z0-9-]+(=[a-zA-Z0-9._:/@-]+)?$/`), which blocks these payloads *at the API boundary*. That is not sufficient: it only covers rows written through the API **after** that validation landed (it was added in `feat(destinations): enhance validation for additionalFlags`), and the builders are shared by backup jobs, volume backups and restores that read straight from the DB row.

So the fix is at the builder level, where every call site converges:

```ts
export const quoteAdditionalFlags = (additionalFlags: string[] | null | undefined) =>
	additionalFlags?.length
		? additionalFlags.map((flag) =>
				ADDITIONAL_FLAG_REGEX.test(flag) ? flag : quote([flag]),
			)
		: [];
```

Applied in `getRcloneCredentials` (S3 + generic branches), `getRclonePathAndFlags` (generic branch) and `destination.testConnection`.

A flag that satisfies the same allowlist the schema uses is already free of shell metacharacters, so it passes through **byte-identical** — `--s3-no-check-bucket`, `--transfers=4`, `--drive-root-folder-id=abc123` are unchanged, and there is zero behavior change for legitimate users. Anything outside the allowlist (legacy rows, direct DB writes) is shell-quoted, collapsing an injection payload into a single inert literal argument. Note this matters: plain `quote()` escapes `=` (`--transfers\=4`), which is shell-*equivalent* but changes the built string and broke the existing generic-rclone expectation in `__test__/utils/backups.test.ts` — the allowlist-first form avoids that entirely.

## Tests

`apps/dokploy/__test__/permissions/routers-server-org-scope.test.ts` (extends the pattern of `settings-server-org-scope.test.ts`, mocking `@dokploy/server` the same way) — for each newly guarded procedure: cross-org `serverId` rejected with `UNAUTHORIZED` **and** the side-effecting function asserted not called; same-org `serverId` passes through to the exec/write. Plus:

- `certificates.create` with no active organization → rejected;
- `certificates.create` / `registry.testRegistry` / `patch.cleanPatchRepos` with no `serverId` → still allowed, and `findServerById` asserted *not* called (local path preserved);
- `registry.testRegistryById` → separate cases for a cross-org **registry row** and a cross-org **server**, both now surfacing `UNAUTHORIZED` rather than `BAD_REQUEST`.

Because each rejection case also asserts the downstream mock was never invoked, removing a guard turns the paired assertions red — the tests exercise the guard path, not just the error type.

`apps/dokploy/__test__/backups/rclone-additional-flags.test.ts`:

- schema-valid flags (`--s3-no-check-bucket`, `--checksum`, `--transfers=4`, `--drive-root-folder-id=abc123`, `--bwlimit=10M`) come back byte-identical, and survive as the exact same argv words after shell tokenization;
- 10 injection payloads (`--foo; touch …`, `$(touch …)`, backticks, `&&`, `|`, quote-breakouts, `>`) each collapse to one literal argument with no shell operators;
- the same via `getRcloneCredentials` for both S3 and generic-rclone destinations, with the S3 credential flags asserted intact;
- **negative controls**: the unquoted payload is shown to produce a real `{ op: ";" }` operator, and (on POSIX) to actually execute;
- a real-`/bin/bash` suite that feeds the built command line to `printf '%s\n'` and asserts the argv it received (skipped on Windows, which has no `/bin/bash` for `execSync` — the same constraint as the existing `restore-use-statement.test.ts`).

## Validation

- `biome check --write` on the touched files (the repo-wide run rewrites ~100 unrelated files; those were reverted so this diff stays scoped)
- `pnpm --filter=dokploy typecheck` — clean
- `pnpm --filter=@dokploy/server build` — clean (`packages/server/package.json` restored after `switch:prod`)
- full `vitest run` — 1483 pass / 11 fail, and every failure is in a pre-existing Windows-only suite that shells out (`backups/restore-use-statement`, `compose/env-file-literals`, `deploy/application.real`, `server/server-setup`, `wss/readValidDirectory`); none touch the routers or rclone builders changed here. The targeted suites (`registry`, `backup*`, `volume-backups`, `restore`, `permissions`, `utils`) are 331/331 apart from that same `/bin/bash ENOENT` case.

## Note

`registry.ts` has a pre-existing unused import (`safeDockerLoginCommand`) that biome flags; it is unrelated to this change and was left alone to avoid a drive-by edit.

Out of scope by design (later wave): network / domain / ai / metrics routers.


- CI on `f773831b2`: typecheck / build / test all green (1498 passed, 1 skipped on Linux).
