### PR TITLE
fix(backups): skip stopped databases on schedule, mariadb/mysql dump-binary fallback, capture tar stderr

### DIFF
--- a/apps/dokploy/__test__/backups/backup-error-details.test.ts
+++ b/apps/dokploy/__test__/backups/backup-error-details.test.ts
@@ -1,0 +1,94 @@
+import {
+	buildBackupErrorMessage,
+	MAX_BACKUP_LOG_TAIL,
+} from "@dokploy/server/utils/backups/log-tail";
+import {
+	ExecError,
+	truncateOutputTail,
+} from "@dokploy/server/utils/process/ExecError";
+import { describe, expect, it } from "vitest";
+
+// Volume backups redirect stdout AND stderr into the deployment log, so the
+// thrown ExecError carries no output at all — tar failures reached Sentry and
+// the notification with an empty message. buildBackupErrorMessage folds the
+// recovered output back into the message.
+
+describe("truncateOutputTail", () => {
+	it("keeps short output untouched", () => {
+		expect(truncateOutputTail("  tar: permission denied \n")).toBe(
+			"tar: permission denied",
+		);
+	});
+
+	it("keeps the END of long output", () => {
+		const long = `${"a".repeat(5000)}THE-ACTUAL-ERROR`;
+		const tail = truncateOutputTail(long, 100);
+		expect(tail).toContain("THE-ACTUAL-ERROR");
+		expect(tail.startsWith("...(truncated)...")).toBe(true);
+		expect(tail.length).toBe("...(truncated)...".length + 100);
+	});
+
+	it("defaults to a 2000 character budget", () => {
+		expect(MAX_BACKUP_LOG_TAIL).toBe(2000);
+		expect(truncateOutputTail("b".repeat(3000)).length).toBe(
+			"...(truncated)...".length + 2000,
+		);
+	});
+});
+
+describe("buildBackupErrorMessage", () => {
+	const execError = (stderr?: string) =>
+		new ExecError("Remote command failed with exit code 2", {
+			command: "tar cvf /backup/x.tar .",
+			stderr,
+		});
+
+	it("appends the log tail when the error carries no output", () => {
+		const message = buildBackupErrorMessage(
+			execError(),
+			"tar: /volume_data: Cannot open: No such file or directory",
+		);
+		expect(message).toContain("Remote command failed with exit code 2");
+		expect(message).toContain("Cannot open: No such file or directory");
+	});
+
+	it("prefers the error's own stderr over the log tail", () => {
+		const message = buildBackupErrorMessage(
+			execError("tar: unexpected EOF"),
+			"some older log content",
+		);
+		expect(message).toContain("tar: unexpected EOF");
+		expect(message).not.toContain("some older log content");
+	});
+
+	it("never returns an empty message", () => {
+		expect(buildBackupErrorMessage(new Error(""), "")).toBe(
+			"Backup failed without an error message",
+		);
+	});
+
+	it("does not duplicate output already present in the message", () => {
+		const error = new Error("Command failed: tar\ntar: unexpected EOF");
+		expect(buildBackupErrorMessage(error, "tar: unexpected EOF")).toBe(
+			"Command failed: tar\ntar: unexpected EOF",
+		);
+	});
+
+	it("redacts credentials recovered from the log", () => {
+		const message = buildBackupErrorMessage(
+			execError(),
+			"rclone: --s3-secret-access-key=supersecret failed",
+		);
+		expect(message).not.toContain("supersecret");
+	});
+
+	it("truncates a huge log tail", () => {
+		const message = buildBackupErrorMessage(execError(), "z".repeat(10000));
+		expect(message.length).toBeLessThan(2200);
+		expect(message).toContain("...(truncated)...");
+	});
+
+	it("handles non-Error throwables", () => {
+		expect(buildBackupErrorMessage("boom", "")).toBe("boom");
+	});
+});

--- a/apps/dokploy/__test__/backups/dump-binary-fallback.test.ts
+++ b/apps/dokploy/__test__/backups/dump-binary-fallback.test.ts
@@ -1,0 +1,123 @@
+import { execFileSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	getDumpBinarySelection,
+	getMariadbBackupCommand,
+	getMysqlBackupCommand,
+} from "@dokploy/server/utils/backups/utils";
+import {
+	getClientBinarySelection,
+	getMariadbRestoreCommand,
+	getMysqlRestoreCommand,
+} from "@dokploy/server/utils/restore/utils";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// MariaDB 11+ renamed mysqldump -> mariadb-dump; older MariaDB and MySQL images
+// only ship mysqldump. Users also register MariaDB containers as "mysql"
+// services, so both runners must resolve the binary at run time.
+
+const binDir = path.join(tmpdir(), `dokploy_dumpbin_${process.pid}`);
+
+const fakeBinary = (name: string) => {
+	const file = path.join(binDir, name);
+	writeFileSync(file, "#!/bin/sh\nexit 0\n");
+	chmodSync(file, 0o755);
+};
+
+// Evaluate a selection snippet with ONLY `available` on PATH and report which
+// binary it picked.
+const resolveBinary = (
+	snippet: string,
+	variable: string,
+	available: string,
+) => {
+	rmSync(binDir, { recursive: true, force: true });
+	mkdirSync(binDir, { recursive: true });
+	fakeBinary(available);
+	// A minimal PATH is essential: the CI image ships a real mysqldump, which
+	// would mask the fallback branch.
+	return execFileSync("/bin/sh", ["-c", `${snippet} echo "$${variable}"`], {
+		env: { PATH: binDir, NODE_ENV: "test" } as NodeJS.ProcessEnv,
+		encoding: "utf-8",
+	}).trim();
+};
+
+beforeAll(() => {
+	mkdirSync(binDir, { recursive: true });
+});
+
+afterAll(() => {
+	rmSync(binDir, { recursive: true, force: true });
+});
+
+// The selection snippet is POSIX sh; only run it where a POSIX shell exists
+// (CI is Linux, developer machines may be Windows).
+describe.skipIf(!existsSync("/bin/sh"))("dump binary selection", () => {
+	it("prefers mariadb-dump but falls back to mysqldump", () => {
+		const snippet = getDumpBinarySelection("mariadb-dump");
+		expect(resolveBinary(snippet, "DUMP_BIN", "mariadb-dump")).toBe(
+			"mariadb-dump",
+		);
+		expect(resolveBinary(snippet, "DUMP_BIN", "mysqldump")).toBe("mysqldump");
+	});
+
+	it("prefers mysqldump but falls back to mariadb-dump", () => {
+		const snippet = getDumpBinarySelection("mysqldump");
+		expect(resolveBinary(snippet, "DUMP_BIN", "mysqldump")).toBe("mysqldump");
+		expect(resolveBinary(snippet, "DUMP_BIN", "mariadb-dump")).toBe(
+			"mariadb-dump",
+		);
+	});
+
+	it("prefers the mariadb client but falls back to mysql", () => {
+		const snippet = getClientBinarySelection("mariadb");
+		expect(resolveBinary(snippet, "CLIENT_BIN", "mariadb")).toBe("mariadb");
+		expect(resolveBinary(snippet, "CLIENT_BIN", "mysql")).toBe("mysql");
+	});
+
+	it("prefers the mysql client but falls back to mariadb", () => {
+		const snippet = getClientBinarySelection("mysql");
+		expect(resolveBinary(snippet, "CLIENT_BIN", "mysql")).toBe("mysql");
+		expect(resolveBinary(snippet, "CLIENT_BIN", "mariadb")).toBe("mariadb");
+	});
+});
+
+describe("backup commands use the resolved binary", () => {
+	it("mariadb backup keeps its flags and pipes through gzip", () => {
+		const command = getMariadbBackupCommand("db", "user", "pw");
+		expect(command).toContain("command -v mariadb-dump");
+		expect(command).toContain("DUMP_BIN=mysqldump");
+		expect(command).toContain(
+			'"$DUMP_BIN" --user="$DB_USER" --password="$DB_PASS" --single-transaction --quick --databases "$DB_NAME" | gzip',
+		);
+		// Credentials still travel as env vars, never inline.
+		expect(command).toContain("-e DB_PASS=pw");
+	});
+
+	it("mysql backup keeps its flags and pipes through gzip", () => {
+		const command = getMysqlBackupCommand("db", "pw");
+		expect(command).toContain("command -v mysqldump");
+		expect(command).toContain("DUMP_BIN=mariadb-dump");
+		expect(command).toContain(
+			'"$DUMP_BIN" --default-character-set=utf8mb4 -u root --password="$DB_PASS" --single-transaction --no-tablespaces --quick "$DB_NAME" | gzip',
+		);
+		expect(command).toContain("set -o pipefail");
+	});
+
+	it("restore commands resolve their client binary too", () => {
+		expect(getMariadbRestoreCommand("db", "user", "pw")).toContain(
+			'"$CLIENT_BIN" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME"',
+		);
+		expect(getMysqlRestoreCommand("db", "pw")).toContain(
+			'"$CLIENT_BIN" -u root -p"$DB_PASS" "$DB_NAME"',
+		);
+	});
+});

--- a/apps/dokploy/__test__/backups/skip-stopped-backup.test.ts
+++ b/apps/dokploy/__test__/backups/skip-stopped-backup.test.ts
@@ -1,0 +1,103 @@
+import type { BackupSchedule } from "@dokploy/server/services/backup";
+import {
+	getBackupServerId,
+	shouldSkipStoppedBackup,
+} from "@dokploy/server/utils/backups/utils";
+import { describe, expect, it } from "vitest";
+
+// A "backup everything" policy materializes a schedule for every database,
+// including intentionally stopped ones. Those scheduled runs must skip instead
+// of erroring on every tick; manual ("run now") runs must still report the
+// failure the user asked for.
+
+const decide = (
+	overrides: Partial<Parameters<typeof shouldSkipStoppedBackup>[0]> = {},
+) =>
+	shouldSkipStoppedBackup({
+		trigger: "schedule",
+		backupType: "database",
+		databaseType: "postgres",
+		targetState: "stopped",
+		...overrides,
+	});
+
+describe("shouldSkipStoppedBackup", () => {
+	it("skips a scheduled run when the database container is stopped", () => {
+		expect(decide()).toBe(true);
+	});
+
+	it("runs a scheduled backup when the container is running", () => {
+		expect(decide({ targetState: "running" })).toBe(false);
+	});
+
+	it("never skips when the state could not be determined", () => {
+		// docker/SSH unreachable must surface as a real error, not a silent skip.
+		expect(decide({ targetState: "unknown" })).toBe(false);
+	});
+
+	it("never skips a manual run, even when stopped", () => {
+		expect(decide({ trigger: "manual" })).toBe(false);
+		expect(decide({ trigger: "manual", targetState: "running" })).toBe(false);
+	});
+
+	it("applies to every dump-capable database type", () => {
+		for (const databaseType of [
+			"postgres",
+			"mysql",
+			"mariadb",
+			"mongo",
+			"libsql",
+		] as const) {
+			expect(decide({ databaseType })).toBe(true);
+		}
+	});
+
+	it("applies to compose backups", () => {
+		expect(decide({ backupType: "compose", databaseType: "mysql" })).toBe(true);
+	});
+
+	it("never skips web-server backups", () => {
+		expect(decide({ databaseType: "web-server" })).toBe(false);
+	});
+});
+
+describe("getBackupServerId", () => {
+	const base = {
+		backupType: "database",
+		postgres: null,
+		mysql: null,
+		mariadb: null,
+		mongo: null,
+		libsql: null,
+		compose: null,
+	} as unknown as BackupSchedule;
+
+	it("returns null for a database on the Dokploy host", () => {
+		expect(
+			getBackupServerId({
+				...base,
+				mysql: { serverId: null },
+			} as unknown as BackupSchedule),
+		).toBe(null);
+	});
+
+	it("returns the database's server", () => {
+		expect(
+			getBackupServerId({
+				...base,
+				mariadb: { serverId: "server-1" },
+			} as unknown as BackupSchedule),
+		).toBe("server-1");
+	});
+
+	it("returns the compose's server for compose backups", () => {
+		expect(
+			getBackupServerId({
+				...base,
+				backupType: "compose",
+				postgres: { serverId: "wrong" },
+				compose: { serverId: "server-2" },
+			} as unknown as BackupSchedule),
+		).toBe("server-2");
+	});
+});

--- a/apps/schedules/src/utils.ts
+++ b/apps/schedules/src/utils.ts
@@ -14,6 +14,7 @@ import {
 	runMySqlBackup,
 	runPostgresBackup,
 	runVolumeBackup,
+	skipScheduledBackupIfStopped,
 } from "@dokploy/server";
 import {
 	and,
@@ -51,12 +52,22 @@ export const runJobs = async (job: QueueJob) => {
 						logger.info("Server is inactive");
 						return;
 					}
+					// Skip quietly when the database itself is stopped (see
+					// shouldSkipStoppedBackup): a stopped target is not a failure.
+					if (await skipScheduledBackupIfStopped(backup)) {
+						return;
+					}
 					await runPostgresBackup(postgres, backup);
 					await keepLatestNBackups(backup, server.serverId);
 				} else if (databaseType === "mysql" && mysql) {
 					const server = await findServerById(mysql.serverId as string);
 					if (server.serverStatus === "inactive") {
 						logger.info("Server is inactive");
+						return;
+					}
+					// Skip quietly when the database itself is stopped (see
+					// shouldSkipStoppedBackup): a stopped target is not a failure.
+					if (await skipScheduledBackupIfStopped(backup)) {
 						return;
 					}
 					await runMySqlBackup(mysql, backup);
@@ -67,12 +78,22 @@ export const runJobs = async (job: QueueJob) => {
 						logger.info("Server is inactive");
 						return;
 					}
+					// Skip quietly when the database itself is stopped (see
+					// shouldSkipStoppedBackup): a stopped target is not a failure.
+					if (await skipScheduledBackupIfStopped(backup)) {
+						return;
+					}
 					await runMongoBackup(mongo, backup);
 					await keepLatestNBackups(backup, server.serverId);
 				} else if (databaseType === "mariadb" && mariadb) {
 					const server = await findServerById(mariadb.serverId as string);
 					if (server.serverStatus === "inactive") {
 						logger.info("Server is inactive");
+						return;
+					}
+					// Skip quietly when the database itself is stopped (see
+					// shouldSkipStoppedBackup): a stopped target is not a failure.
+					if (await skipScheduledBackupIfStopped(backup)) {
 						return;
 					}
 					await runMariadbBackup(mariadb, backup);
@@ -83,6 +104,11 @@ export const runJobs = async (job: QueueJob) => {
 						logger.info("Server is inactive");
 						return;
 					}
+					// Skip quietly when the database itself is stopped (see
+					// shouldSkipStoppedBackup): a stopped target is not a failure.
+					if (await skipScheduledBackupIfStopped(backup)) {
+						return;
+					}
 					await runLibsqlBackup(libsql, backup);
 					await keepLatestNBackups(backup, server.serverId);
 				}
@@ -90,6 +116,11 @@ export const runJobs = async (job: QueueJob) => {
 				const server = await findServerById(compose.serverId as string);
 				if (server.serverStatus === "inactive") {
 					logger.info("Server is inactive");
+					return;
+				}
+				// Skip quietly when the database itself is stopped (see
+				// shouldSkipStoppedBackup): a stopped target is not a failure.
+				if (await skipScheduledBackupIfStopped(backup)) {
 					return;
 				}
 				await runComposeBackup(compose, backup);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -87,6 +87,7 @@ export * from "./utils/aws/ecr";
 export * from "./utils/backups/compose";
 export * from "./utils/backups/index";
 export * from "./utils/backups/libsql";
+export * from "./utils/backups/log-tail";
 export * from "./utils/backups/mariadb";
 export * from "./utils/backups/mongo";
 export * from "./utils/backups/mysql";

--- a/packages/server/src/utils/backups/log-tail.ts
+++ b/packages/server/src/utils/backups/log-tail.ts
@@ -1,0 +1,81 @@
+import {
+	MAX_EXEC_OUTPUT_TAIL,
+	truncateOutputTail,
+} from "../process/ExecError";
+import { execAsync, ExecError, execAsyncRemote } from "../process/execAsync";
+import { redactSecrets } from "../process/redactSecrets";
+
+// Backup pipelines redirect ALL of their output (stdout AND stderr) into the
+// per-run deployment log file: `(<command>) >> <logPath> 2>&1`. That is great
+// for the log viewer but it means the ExecError thrown when the command fails
+// carries an EMPTY stderr — volume-backup tar failures reached notifications
+// and Sentry as an error with no message at all, which made them impossible to
+// diagnose without SSH access to the box.
+//
+// These helpers read back the tail of that log file (local or over SSH, the
+// same way the backup itself ran) and fold it into the error message, so the
+// notification / Sentry event finally says WHY the backup failed.
+
+/** Max characters of captured output kept in an error message. */
+export const MAX_BACKUP_LOG_TAIL = MAX_EXEC_OUTPUT_TAIL;
+
+/**
+ * Read the tail of a backup's log file, from the same host the backup ran on.
+ * Best-effort: any failure to read it (file missing, server unreachable)
+ * returns an empty string so the original error is still reported.
+ */
+export const readBackupLogTail = async (
+	logPath: string,
+	serverId?: string | null,
+	limit = MAX_BACKUP_LOG_TAIL,
+): Promise<string> => {
+	if (!logPath) {
+		return "";
+	}
+	const command = `tail -c ${limit} "${logPath}"`;
+	try {
+		const { stdout } = serverId
+			? await execAsyncRemote(serverId, command)
+			: await execAsync(command);
+		return stdout.trim();
+	} catch {
+		return "";
+	}
+};
+
+/**
+ * Build an error message that actually explains the failure: the thrown error's
+ * message, plus whatever output we could recover (the ExecError's own stderr
+ * when it has one, otherwise the tail of the run's log file).
+ *
+ * Output is redacted the same way ExecError redacts its own fields — the
+ * unredacted text stays in the log file on the server.
+ */
+export const buildBackupErrorMessage = (
+	error: unknown,
+	logTail = "",
+	limit = MAX_BACKUP_LOG_TAIL,
+): string => {
+	const baseMessage =
+		error instanceof Error ? error.message.trim() : String(error).trim();
+
+	const execStderr =
+		error instanceof ExecError ? (error.stderr || "").trim() : "";
+	const details = execStderr || logTail.trim();
+
+	if (!details) {
+		return baseMessage || "Backup failed without an error message";
+	}
+
+	const redactedDetails = truncateOutputTail(redactSecrets(details), limit);
+
+	// Don't repeat output that the error message already carries (Node's local
+	// exec error message embeds the command's stderr).
+	if (baseMessage.includes(redactedDetails)) {
+		return baseMessage;
+	}
+
+	return baseMessage
+		? `${baseMessage}\nOutput: ${redactedDetails}`
+		: `Backup failed. Output: ${redactedDetails}`;
+};

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -13,6 +13,7 @@ import { quote } from "shell-quote";
 const execFileP = promisify(execFile);
 
 import { keepLatestNBackups } from ".";
+import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { runComposeBackup } from "./compose";
 import { withBackupSlot } from "./concurrency";
 import { runLibsqlBackup } from "./libsql";
@@ -47,6 +48,11 @@ export const scheduleBackup = (backup: BackupSchedule) => {
 				libsql?.serverId);
 	scheduleJob(backupId, schedule, async () => {
 		await withBackupSlot(serverKey, backupId, async () => {
+			// A stopped database is not a backup failure: skip quietly instead of
+			// erroring on every tick (see shouldSkipStoppedBackup).
+			if (await skipScheduledBackupIfStopped(backup)) {
+				return;
+			}
 			if (backup.backupType === "database") {
 				if (databaseType === "postgres" && postgres) {
 					await runPostgresBackup(postgres, backup);
@@ -230,19 +236,35 @@ export const getPostgresBackupCommand = (
 	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -i $CONTAINER_ID bash -c 'set -o pipefail; pg_dump -Fc --no-acl --no-owner -h localhost -U "$DB_USER" --no-password "$DB_NAME" | gzip'`;
 };
 
+// MariaDB 11+ images renamed the client binaries (`mysqldump` → `mariadb-dump`)
+// and ship `mysqldump` only as a deprecated alias — or not at all. Older MariaDB
+// and every MySQL image ship `mysqldump` and have no `mariadb-dump`. On top of
+// that, users routinely register a MariaDB container as a "mysql" service (a
+// real production case: Uptime Kuma's MariaDB), so either binary can be the only
+// one present regardless of the service type. Pick whichever actually exists
+// inside the container at run time instead of hardcoding one; both accept the
+// exact same flags used below (mariadb-dump keeps --no-tablespaces and
+// --default-character-set for drop-in mysqldump compatibility).
+export const getDumpBinarySelection = (
+	preferred: "mariadb-dump" | "mysqldump",
+) => {
+	const fallback = preferred === "mariadb-dump" ? "mysqldump" : "mariadb-dump";
+	return `if command -v ${preferred} >/dev/null 2>&1; then DUMP_BIN=${preferred}; else DUMP_BIN=${fallback}; fi;`;
+};
+
 export const getMariadbBackupCommand = (
 	database: string,
 	databaseUser: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID bash -c 'set -o pipefail; mariadb-dump --user="$DB_USER" --password="$DB_PASS" --single-transaction --quick --databases "$DB_NAME" | gzip'`;
+	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID bash -c 'set -o pipefail; ${getDumpBinarySelection("mariadb-dump")} "$DUMP_BIN" --user="$DB_USER" --password="$DB_PASS" --single-transaction --quick --databases "$DB_NAME" | gzip'`;
 };
 
 export const getMysqlBackupCommand = (
 	database: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -e DB_NAME=${quote([database])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID bash -c 'set -o pipefail; mysqldump --default-character-set=utf8mb4 -u root --password="$DB_PASS" --single-transaction --no-tablespaces --quick "$DB_NAME" | gzip'`;
+	return `docker exec -e DB_NAME=${quote([database])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID bash -c 'set -o pipefail; ${getDumpBinarySelection("mysqldump")} "$DUMP_BIN" --default-character-set=utf8mb4 -u root --password="$DB_PASS" --single-transaction --no-tablespaces --quick "$DB_NAME" | gzip'`;
 };
 
 export const getMongoBackupCommand = (
@@ -302,6 +324,163 @@ const getContainerSearchCommand = (backup: BackupSchedule) => {
 			composeType,
 		);
 	}
+};
+
+export type BackupRunTrigger = "schedule" | "manual";
+export type BackupTargetState = "running" | "stopped" | "unknown";
+
+// Which server the backup's target service lives on (null = the Dokploy host).
+export const getBackupServerId = (backup: BackupSchedule): string | null => {
+	const { backupType, postgres, mysql, mariadb, mongo, libsql, compose } =
+		backup;
+	if (backupType === "compose") {
+		return compose?.serverId ?? null;
+	}
+	return (
+		postgres?.serverId ??
+		mysql?.serverId ??
+		mariadb?.serverId ??
+		mongo?.serverId ??
+		libsql?.serverId ??
+		null
+	);
+};
+
+// The same `docker ps --filter status=running` lookup the dump pipeline itself
+// performs, so the pre-flight answer always matches what the dump would find.
+// Returns null when the target can't be resolved (web-server backups, missing
+// appName/serviceName) — the caller then treats the state as unknown and runs
+// the backup as before.
+const getBackupTargetSearchCommand = (backup: BackupSchedule): string | null => {
+	const {
+		backupType,
+		databaseType,
+		postgres,
+		mysql,
+		mariadb,
+		mongo,
+		libsql,
+		compose,
+		serviceName,
+	} = backup;
+
+	if (databaseType === "web-server") {
+		return null;
+	}
+
+	if (backupType === "database") {
+		const appName =
+			postgres?.appName ||
+			mysql?.appName ||
+			mariadb?.appName ||
+			mongo?.appName ||
+			libsql?.appName;
+		return appName ? getServiceContainerCommand(appName) : null;
+	}
+
+	if (backupType === "compose") {
+		const { appName, composeType } = compose || {};
+		if (!appName || !serviceName) {
+			return null;
+		}
+		return getComposeContainerCommand(appName, serviceName, composeType);
+	}
+
+	return null;
+};
+
+/**
+ * Skip policy for a backup whose target database is not running.
+ *
+ * A "backup everything" policy materializes a schedule for every database,
+ * including the ones that are intentionally stopped. Those runs used to fail
+ * with "Container not found" on every tick, producing an endless stream of
+ * failure notifications and Sentry ExecErrors. Scheduled runs now skip such a
+ * target instead; a user-triggered ("manual") run must still surface a real
+ * error, because there the user explicitly asked for a backup now.
+ *
+ * Kept pure so the policy is unit-testable without docker.
+ */
+export const shouldSkipStoppedBackup = ({
+	trigger,
+	backupType,
+	databaseType,
+	targetState,
+}: {
+	trigger: BackupRunTrigger;
+	backupType: BackupSchedule["backupType"];
+	databaseType: BackupSchedule["databaseType"];
+	targetState: BackupTargetState;
+}): boolean => {
+	// Manual runs always attempt and report the real failure.
+	if (trigger !== "schedule") {
+		return false;
+	}
+	// Web-server backups don't dump a database container.
+	if (databaseType === "web-server") {
+		return false;
+	}
+	if (backupType !== "database" && backupType !== "compose") {
+		return false;
+	}
+	// "unknown" (docker/SSH unreachable) must never skip: that would hide a real
+	// outage. Only a confirmed "no running container" skips.
+	return targetState === "stopped";
+};
+
+export const getBackupTargetState = async (
+	backup: BackupSchedule,
+): Promise<BackupTargetState> => {
+	const searchCommand = getBackupTargetSearchCommand(backup);
+	if (!searchCommand) {
+		return "unknown";
+	}
+
+	try {
+		const serverId = getBackupServerId(backup);
+		const { stdout } = serverId
+			? await execAsyncRemote(serverId, searchCommand)
+			: await execAsync(searchCommand);
+		return stdout.trim() ? "running" : "stopped";
+	} catch (error) {
+		// Can't tell (docker down, SSH failure) — fall through to the normal run
+		// so the real error is still reported.
+		logger.warn(
+			{ backupId: backup.backupId, error },
+			"Could not determine whether the backup target is running",
+		);
+		return "unknown";
+	}
+};
+
+/**
+ * Pre-flight check for SCHEDULED backup runs. Returns true when the run was
+ * skipped (target database is stopped), in which case the caller must return
+ * without dumping, notifying or throwing.
+ */
+export const skipScheduledBackupIfStopped = async (
+	backup: BackupSchedule,
+): Promise<boolean> => {
+	const targetState = await getBackupTargetState(backup);
+	const skip = shouldSkipStoppedBackup({
+		trigger: "schedule",
+		backupType: backup.backupType,
+		databaseType: backup.databaseType,
+		targetState,
+	});
+
+	if (skip) {
+		logger.info(
+			{
+				backupId: backup.backupId,
+				backupType: backup.backupType,
+				databaseType: backup.databaseType,
+			},
+			"[Backup] Skipping scheduled backup: target database is not running",
+		);
+	}
+
+	return skip;
 };
 
 export const generateBackupCommand = (backup: BackupSchedule) => {

--- a/packages/server/src/utils/process/ExecError.ts
+++ b/packages/server/src/utils/process/ExecError.ts
@@ -1,5 +1,24 @@
 import { redactErrorSecrets, redactSecrets } from "./redactSecrets";
 
+/** Max characters of captured command output kept in an error message. */
+export const MAX_EXEC_OUTPUT_TAIL = 2000;
+
+/**
+ * Keep the LAST `limit` characters of a command's output — a failure is always
+ * reported at the end, and unbounded output must never be pasted into an error
+ * message (or a Sentry event).
+ */
+export const truncateOutputTail = (
+	output: string,
+	limit = MAX_EXEC_OUTPUT_TAIL,
+): string => {
+	const trimmed = output.trim();
+	if (trimmed.length <= limit) {
+		return trimmed;
+	}
+	return `...(truncated)...${trimmed.slice(-limit)}`;
+};
+
 export interface ExecErrorDetails {
 	command: string;
 	stdout?: string;

--- a/packages/server/src/utils/process/execAsync.ts
+++ b/packages/server/src/utils/process/execAsync.ts
@@ -2,10 +2,14 @@ import { exec, execFile } from "node:child_process";
 import util from "node:util";
 import { findServerById } from "@dokploy/server/services/server";
 import { Client } from "ssh2";
-import { ExecError } from "./ExecError";
+import { ExecError, truncateOutputTail } from "./ExecError";
 
 // Re-export ExecError for easier imports
-export { ExecError } from "./ExecError";
+export {
+	ExecError,
+	MAX_EXEC_OUTPUT_TAIL,
+	truncateOutputTail,
+} from "./ExecError";
 
 const execAsyncBase = util.promisify(exec);
 
@@ -179,9 +183,17 @@ export const execAsyncRemote = async (
 							if (code === 0) {
 								resolve({ stdout, stderr });
 							} else {
+								// Node's local exec embeds the command output in the error
+								// message; ssh2 does not, so a remote failure used to reach
+								// notifications/Sentry as a bare "exit code N". Append the
+								// tail of whatever the command printed (ExecError redacts
+								// secrets in the message).
+								const outputTail = truncateOutputTail(stderr || stdout);
 								reject(
 									new ExecError(
-										`Remote command failed with exit code ${code}`,
+										`Remote command failed with exit code ${code}${
+											outputTail ? `: ${outputTail}` : ""
+										}`,
 										{
 											command,
 											stdout,

--- a/packages/server/src/utils/restore/utils.ts
+++ b/packages/server/src/utils/restore/utils.ts
@@ -16,19 +16,28 @@ export const getPostgresRestoreCommand = (
 	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -i $CONTAINER_ID sh -c 'cat > ${tmpFile} && pg_restore ${pgArgs} --clean --if-exists --section=pre-data ${tmpFile} && pg_restore ${pgArgs} --section=data ${tmpFile} && pg_restore ${pgArgs} --section=post-data ${tmpFile}; rm -f ${tmpFile}'`;
 };
 
+// Same binary-rename problem as the dump side (see getDumpBinarySelection in
+// backups/utils.ts): MariaDB 11+ images renamed `mysql` → `mariadb`, older
+// MariaDB and all MySQL images only ship `mysql`. Restoring must survive both,
+// otherwise a backup taken by the resilient dump path can't be restored.
+export const getClientBinarySelection = (preferred: "mariadb" | "mysql") => {
+	const fallback = preferred === "mariadb" ? "mysql" : "mariadb";
+	return `if command -v ${preferred} >/dev/null 2>&1; then CLIENT_BIN=${preferred}; else CLIENT_BIN=${fallback}; fi;`;
+};
+
 export const getMariadbRestoreCommand = (
 	database: string,
 	databaseUser: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID sh -c 'mariadb -u "$DB_USER" -p"$DB_PASS" "$DB_NAME"'`;
+	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID sh -c '${getClientBinarySelection("mariadb")} "$CLIENT_BIN" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME"'`;
 };
 
 export const getMysqlRestoreCommand = (
 	database: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -e DB_NAME=${quote([database])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID sh -c 'mysql -u root -p"$DB_PASS" "$DB_NAME"'`;
+	return `docker exec -e DB_NAME=${quote([database])} -e DB_PASS=${quote([databasePassword])} -i $CONTAINER_ID sh -c '${getClientBinarySelection("mysql")} "$CLIENT_BIN" -u root -p"$DB_PASS" "$DB_NAME"'`;
 };
 
 export const getMongoRestoreCommand = (

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -12,6 +12,10 @@ import {
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
 import { withBackupSlot } from "../backups/concurrency";
+import {
+	buildBackupErrorMessage,
+	readBackupLogTail,
+} from "../backups/log-tail";
 import { getRclonePathAndFlags, normalizeS3Path } from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
@@ -166,17 +170,35 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 			);
 		}
 	} catch (error) {
+		// The whole pipeline is redirected into the deployment log, so the thrown
+		// ExecError has no stderr of its own (tar failures used to surface as an
+		// error with an EMPTY message). Recover the tail of the log so the
+		// notification and the Sentry event say why it failed.
+		const logTail = await readBackupLogTail(deployment.logPath, serverId);
+		const errorMessage = buildBackupErrorMessage(error, logTail);
+		console.error(
+			`Volume backup "${volumeBackup.name}" failed: ${errorMessage}`,
+		);
+
 		const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 		const volumeBackupPath = path.join(
 			VOLUME_BACKUPS_PATH,
 			volumeBackup.appName,
 		);
-		// delete all the .tar files
+		// delete all the .tar files. Best-effort: a cleanup failure must not
+		// swallow the original error or leave the deployment stuck on "running".
 		const command = `rm -rf ${volumeBackupPath}/*.tar`;
-		if (serverId) {
-			await execAsyncRemote(serverId, command);
-		} else {
-			await execAsync(command);
+		try {
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command);
+			}
+		} catch (cleanupError) {
+			console.error(
+				"Failed to clean up local volume backup files",
+				cleanupError,
+			);
 		}
 		await updateDeploymentStatus(deployment.deploymentId, "error");
 
@@ -194,7 +216,7 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 				serviceType: mappedServiceType,
 				type: "error",
 				organizationId,
-				errorMessage: error instanceof Error ? error.message : String(error),
+				errorMessage,
 			});
 		} catch (notificationError) {
 			console.error(


### PR DESCRIPTION
Three long-queued backup follow-ups, all motivated by real production behaviour on our self-hosted instance (and by the opt-out Sentry reporting the fork ships, which turned them into recurring noise for adopters too).

## 1. Scheduled backups of stopped databases skip instead of erroring

A "backup everything" policy materialized ~38 scheduled backups; ~19 of them target databases that are intentionally **stopped**. The dump script resolves the container with `docker ps --filter status=running ...` and `exit 1`s with "Container not found" when there is none, so every tick produced a failure notification, an `error` deployment row and a Sentry `ExecError` — an hourly ExecError storm for a non-problem.

Scheduled runs now run the *same* `docker ps` lookup as a pre-flight check and return early when the target is not running: no dump, no error, no notification, no Sentry event.

- Policy lives in a pure, unit-tested helper `shouldSkipStoppedBackup({ trigger, backupType, databaseType, targetState })`.
- The probe (`getBackupTargetState`) reuses the existing container-search command builders and runs locally or over SSH via `getBackupServerId(backup)` — same idiom the dump itself uses, so the pre-flight answer always matches what the dump would find.
- **Fail-safe:** if the probe itself fails (docker down, SSH error) the state is `unknown` and the backup runs as before, so a real outage is never hidden as a "skip".
- Applied at both scheduler entry points: `scheduleBackup()` in `packages/server/src/utils/backups/utils.ts` (monolith / node-schedule) and `runJobs()` in `apps/schedules/src/utils.ts` (queue app, inserted after the existing "server is inactive" check so an inactive server never triggers an SSH probe).
- Covers postgres / mysql / mariadb / mongo / libsql **and** compose backups (the compose runner shares the same container-search point). Web-server backups are explicitly excluded — they don't dump a database container.

### Behaviour table

| Trigger | Target state | Before | After |
|---|---|---|---|
| Scheduled | running | dump runs | dump runs (unchanged) |
| Scheduled | stopped | ExecError + error notification + Sentry event, every tick | skipped, one log line, no error |
| Scheduled | undeterminable (docker/SSH down) | ExecError | dump runs → real ExecError (unchanged) |
| Manual ("Backup now", policy "Run now") | running | dump runs | dump runs (unchanged) |
| Manual | stopped | error surfaced to the user | error surfaced to the user (unchanged) |
| Web-server backup | n/a | unchanged | unchanged |

**Divergence from the brief:** no deployment/backup row is written for a skip. `deploymentStatus` does have a `cancelled` value that would have fit, but a skip row per stopped DB per tick is ~19 rows/hour of pure noise in the Deployments list and in Backup Center's recent-activity feed. A skip is logged instead (`logger.info` with `backupId` / `backupType` / `databaseType`). No schema change, no migration.

## 2. MariaDB/MySQL dump-binary fallback

MariaDB 11+ images renamed the client binaries (`mysqldump` → `mariadb-dump`); older MariaDB images and every MySQL image only ship `mysqldump`. On top of that users routinely register a MariaDB container as a **mysql** service (our real case: Uptime Kuma's MariaDB), so either binary can be the only one present regardless of the configured service type — and the hardcoded binary produced a permanent dump failure.

Both dump builders now select the binary inside the container at run time:

- `getMariadbBackupCommand` prefers `mariadb-dump`, falls back to `mysqldump`.
- `getMysqlBackupCommand` prefers `mysqldump`, falls back to `mariadb-dump`.

`if command -v <preferred> >/dev/null 2>&1; then DUMP_BIN=<preferred>; else DUMP_BIN=<fallback>; fi;` then `"$DUMP_BIN" <unchanged flags> | gzip`. Flags, credential handling (`docker exec -e` + `"$VAR"`) and the `dump | gzip | rclone` pipeline are byte-for-byte unchanged; `--no-tablespaces` and `--default-character-set` are both supported by `mariadb-dump`, so no flag had to be dropped in either direction.

**Scope addition:** the same rename breaks the *restore* path (`mysql` → `mariadb` client), so `getMariadbRestoreCommand` / `getMysqlRestoreCommand` got the identical treatment. A backup the dump path can now take was otherwise not restorable on the same container.

## 3. Volume-backup (tar) failures now say why they failed

`runVolumeBackup` runs `(<pipeline>) >> <logPath> 2>&1` — *all* output goes to the deployment log, so the thrown `ExecError` carries an empty `stderr` and the error notification / Sentry event had a blank message. Undiagnosable without SSH into the box (this is the class of empty-message ExecErrors we've been seeing).

- New `packages/server/src/utils/backups/log-tail.ts`: `readBackupLogTail(logPath, serverId)` (best-effort `tail -c 2000`, local or over SSH) and `buildBackupErrorMessage(error, logTail)` which prefers the error's own stderr, falls back to the log tail, runs the result through the existing `redactSecrets` and tail-truncates to 2000 chars. The unredacted text stays in the server-side log file, as documented in `redactSecrets`.
- The volume-backup catch block now logs the enriched message and passes it to the failure notification (was `error.message`, i.e. empty).
- The post-failure `rm -rf *.tar` cleanup is wrapped in its own try/catch: a cleanup failure used to swallow the original error *and* leave the deployment row stuck on `running`.
- Helper fix, not just call site: `execAsyncRemote` rejected with a bare `Remote command failed with exit code N` (ssh2, unlike Node's local `exec`, doesn't embed output in the message). It now appends the tail of `stderr || stdout`. Success path and all `ExecError` fields are untouched, so existing call sites are unaffected — `truncateOutputTail` lives in `ExecError.ts` and is re-exported from `execAsync.ts`.

Database dump runners were left alone here: they already echo `Error: $(cat "$DUMP_ERROR_FILE")` into their log, and the `execAsyncRemote` improvement above covers their remote case. Folding the log tail into their notifications too is an easy follow-up if the empty-message pattern shows up for them in Sentry.

## Tests

New vitest files under `apps/dokploy/__test__/backups/`:

- `skip-stopped-backup.test.ts` — the skip decision matrix (scheduled+stopped skips; running/unknown/manual never skip; all five database types + compose; web-server excluded) and `getBackupServerId` resolution (local, database server, compose server).
- `dump-binary-fallback.test.ts` — runs the generated selection snippet in a real POSIX shell with a fake-binary PATH and asserts which binary is chosen in each of the four preferred/available combinations (skipped where `/bin/sh` is absent, e.g. Windows dev boxes), plus assertions that the flags, `set -o pipefail`, the `| gzip` tail and the `-e VAR=` credential passing are unchanged.
- `backup-error-details.test.ts` — `truncateOutputTail` (keeps the END, 2000-char budget) and `buildBackupErrorMessage` (log tail appended, stderr preferred over log, never empty, no duplication, credentials redacted, huge tails truncated, non-Error throwables).

Validated locally: `biome format` clean on the changed files, `pnpm typecheck` green, `pnpm --filter=@dokploy/server build` green, 156 passing tests across `__test__/{backups,backup,backup-policy,volume-backups,process}` (the single failure is the pre-existing Windows-only `/bin/bash` ENOENT in `restore-use-statement.test.ts`, which passes on Linux CI).

No schema changes, no migrations, no UI changes.
