### PR TITLE
feat(preview-deployments): manually build a preview deployment from an open PR

### DIFF
--- a/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
@@ -1,0 +1,265 @@
+import { GitPullRequest, Loader2, RocketIcon, Search } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { GithubIcon, GitlabIcon } from "@/components/icons/data-tools-icons";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/utils/api";
+
+interface Props {
+	applicationId?: string;
+	composeId?: string;
+	children: React.ReactNode;
+}
+
+interface ChangeRequest {
+	id: number | string;
+	number: number;
+	title: string;
+	html_url: string;
+	branch: string;
+	baseBranch?: string;
+	draft?: boolean;
+}
+
+export const BuildPreviewDeployment = ({
+	applicationId,
+	composeId,
+	children,
+}: Props) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [selected, setSelected] = useState<ChangeRequest | null>(null);
+	const [search, setSearch] = useState("");
+
+	const { data: application } = api.application.one.useQuery(
+		{ applicationId: applicationId || "" },
+		{ enabled: !!applicationId },
+	);
+	const { data: compose } = api.compose.one.useQuery(
+		{ composeId: composeId || "" },
+		{ enabled: !!composeId },
+	);
+
+	const data = application || compose;
+	const isGitlab = data?.sourceType === "gitlab";
+	const changeRequestLabel = isGitlab ? "Merge Request" : "Pull Request";
+	const owner = isGitlab ? data?.gitlabOwner || data?.owner : data?.owner;
+	const repo = isGitlab
+		? data?.gitlabRepository || data?.repository
+		: data?.repository;
+
+	const { data: githubPullRequests, isFetching: isFetchingGithub } =
+		api.github.getGithubPullRequests.useQuery(
+			{
+				owner: owner || "",
+				repo: repo || "",
+				githubId: data?.githubId || "",
+			},
+			{
+				enabled:
+					!!isOpen &&
+					!!data &&
+					data.sourceType === "github" &&
+					!!owner &&
+					!!repo,
+			},
+		);
+
+	const { data: gitlabMergeRequests, isFetching: isFetchingGitlab } =
+		api.gitlab.getGitlabMergeRequests.useQuery(
+			{
+				id: data?.gitlabProjectId || 0,
+				owner: data?.gitlabOwner || "",
+				repo: data?.gitlabRepository || "",
+				gitlabId: data?.gitlabId || "",
+			},
+			{
+				enabled:
+					!!isOpen &&
+					!!data &&
+					data.sourceType === "gitlab" &&
+					!!data.gitlabId &&
+					!!data.gitlabProjectId,
+			},
+		);
+
+	const changeRequests = (
+		isGitlab ? gitlabMergeRequests : githubPullRequests
+	) as ChangeRequest[] | undefined;
+	const isFetching = isFetchingGithub || isFetchingGitlab;
+
+	const filtered = changeRequests?.filter((cr) => {
+		if (!search) return true;
+		const q = search.toLowerCase();
+		return (
+			String(cr.number).includes(q) ||
+			cr.title.toLowerCase().includes(q) ||
+			cr.branch.toLowerCase().includes(q)
+		);
+	});
+
+	const { mutateAsync: createPreviewDeployment, isPending } =
+		api.previewDeployment.create.useMutation();
+
+	const handleBuild = async () => {
+		if (!selected) return;
+		try {
+			await createPreviewDeployment({
+				applicationId,
+				composeId,
+				branch: selected.branch,
+				pullRequestId: String(selected.id),
+				pullRequestNumber: String(selected.number),
+				pullRequestTitle: selected.title,
+				pullRequestURL: selected.html_url,
+			});
+			toast.success(
+				`${changeRequestLabel} #${selected.number} preview deployment started`,
+			);
+			setIsOpen(false);
+			setSelected(null);
+			setSearch("");
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Error building preview deployment",
+			);
+		}
+	};
+
+	useEffect(() => {
+		if (!isOpen) {
+			setSelected(null);
+			setSearch("");
+		}
+	}, [isOpen]);
+
+	const ChangeRequestIcon = isGitlab ? GitlabIcon : GithubIcon;
+
+	return (
+		<Dialog open={isOpen} onOpenChange={setIsOpen}>
+			<DialogTrigger asChild>{children}</DialogTrigger>
+			<DialogContent className="sm:max-w-lg w-full">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<GitPullRequest className="size-5" />
+						Build {changeRequestLabel}
+					</DialogTitle>
+					<DialogDescription>
+						Select an open {changeRequestLabel.toLowerCase()} from the
+						repository to create and deploy a preview deployment.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="grid gap-4">
+					{!data?.isPreviewDeploymentsActive && (
+						<AlertBlock type="warning">
+							Preview deployments are disabled for this resource.
+						</AlertBlock>
+					)}
+					{owner && repo && (
+						<div className="text-sm text-muted-foreground">
+							{owner}/{repo}
+						</div>
+					)}
+					<div className="relative">
+						<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+						<Input
+							placeholder={`Search ${changeRequestLabel.toLowerCase()}s...`}
+							className="pl-9"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+					</div>
+					{isFetching ? (
+						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
+							<Loader2 className="size-6 text-muted-foreground animate-spin" />
+							<span className="text-sm text-muted-foreground">
+								Loading open {changeRequestLabel.toLowerCase()}s...
+							</span>
+						</div>
+					) : !filtered?.length ? (
+						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
+							<ChangeRequestIcon className="size-8 text-muted-foreground" />
+							<span className="text-sm text-muted-foreground">
+								No open {changeRequestLabel.toLowerCase()}s found
+							</span>
+						</div>
+					) : (
+						<Select
+							value={selected ? String(selected.number) : undefined}
+							onValueChange={(value) => {
+								const cr = filtered?.find(
+									(item) => String(item.number) === value,
+								);
+								setSelected(cr || null);
+							}}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue
+									placeholder={`Select an open ${changeRequestLabel.toLowerCase()}`}
+								/>
+							</SelectTrigger>
+							<SelectContent>
+								{filtered?.map((cr) => (
+									<SelectItem
+										key={String(cr.id)}
+										value={String(cr.number)}
+										className="flex flex-col items-start gap-1"
+									>
+										<span className="flex items-center gap-2 font-medium">
+											#{cr.number} {cr.draft && "(draft)"}
+										</span>
+										<span className="line-clamp-1 text-xs text-muted-foreground">
+											{cr.title}
+										</span>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+					{selected && (
+						<div className="flex flex-col gap-2 rounded-lg border p-3 text-sm">
+							<div className="font-medium">
+								#{selected.number} {selected.title}
+							</div>
+							<div className="text-muted-foreground">
+								Branch: <span className="font-mono">{selected.branch}</span>
+							</div>
+						</div>
+					)}
+				</div>
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => setIsOpen(false)}>
+						Cancel
+					</Button>
+					<Button
+						isLoading={isPending}
+						disabled={!selected || !data?.isPreviewDeploymentsActive}
+						onClick={handleBuild}
+					>
+						<RocketIcon className="size-4" />
+						Build preview
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
@@ -1,5 +1,6 @@
+import type { ChangeRequest } from "@dokploy/server";
 import { GitPullRequest, Loader2, RocketIcon, Search } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { GithubIcon, GitlabIcon } from "@/components/icons/data-tools-icons";
 import { AlertBlock } from "@/components/shared/alert-block";
@@ -23,97 +24,91 @@ import {
 } from "@/components/ui/select";
 import { api } from "@/utils/api";
 
-interface Props {
+interface PreviewResource {
 	applicationId?: string;
 	composeId?: string;
+	sourceType: string;
+	isPreviewDeploymentsActive: boolean | null;
+	owner: string | null;
+	repository: string | null;
+	githubId: string | null;
+	gitlabId: string | null;
+	gitlabOwner: string | null;
+	gitlabRepository: string | null;
+	gitlabProjectId: number | null;
+}
+
+interface Props {
+	resource: PreviewResource;
 	children: React.ReactNode;
 }
 
-interface ChangeRequest {
-	id: number | string;
-	number: number;
-	title: string;
-	html_url: string;
-	branch: string;
-	baseBranch?: string;
-	draft?: boolean;
-}
-
-export const BuildPreviewDeployment = ({
-	applicationId,
-	composeId,
-	children,
-}: Props) => {
+export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [selected, setSelected] = useState<ChangeRequest | null>(null);
 	const [search, setSearch] = useState("");
 
-	const { data: application } = api.application.one.useQuery(
-		{ applicationId: applicationId || "" },
-		{ enabled: !!applicationId },
-	);
-	const { data: compose } = api.compose.one.useQuery(
-		{ composeId: composeId || "" },
-		{ enabled: !!composeId },
-	);
-
-	const data = application || compose;
-	const isGitlab = data?.sourceType === "gitlab";
+	const isGitlab = resource.sourceType === "gitlab";
 	const changeRequestLabel = isGitlab ? "Merge Request" : "Pull Request";
-	const owner = isGitlab ? data?.gitlabOwner || data?.owner : data?.owner;
+	const changeRequestLabelPlural = `${changeRequestLabel.toLowerCase()}s`;
+
+	const owner = isGitlab
+		? (resource.gitlabOwner ?? resource.owner)
+		: resource.owner;
 	const repo = isGitlab
-		? data?.gitlabRepository || data?.repository
-		: data?.repository;
+		? (resource.gitlabRepository ?? resource.repository)
+		: resource.repository;
 
 	const { data: githubPullRequests, isFetching: isFetchingGithub } =
 		api.github.getGithubPullRequests.useQuery(
 			{
-				owner: owner || "",
-				repo: repo || "",
-				githubId: data?.githubId || "",
+				owner: resource.owner ?? "",
+				repo: resource.repository ?? "",
+				githubId: resource.githubId ?? "",
 			},
 			{
 				enabled:
-					!!isOpen &&
-					!!data &&
-					data.sourceType === "github" &&
-					!!owner &&
-					!!repo,
+					isOpen &&
+					!isGitlab &&
+					!!resource.owner &&
+					!!resource.repository &&
+					!!resource.githubId,
 			},
 		);
 
 	const { data: gitlabMergeRequests, isFetching: isFetchingGitlab } =
 		api.gitlab.getGitlabMergeRequests.useQuery(
 			{
-				id: data?.gitlabProjectId || 0,
-				owner: data?.gitlabOwner || "",
-				repo: data?.gitlabRepository || "",
-				gitlabId: data?.gitlabId || "",
+				id: resource.gitlabProjectId ?? 0,
+				owner: resource.gitlabOwner ?? "",
+				repo: resource.gitlabRepository ?? "",
+				gitlabId: resource.gitlabId ?? "",
 			},
 			{
 				enabled:
-					!!isOpen &&
-					!!data &&
-					data.sourceType === "gitlab" &&
-					!!data.gitlabId &&
-					!!data.gitlabProjectId,
+					isOpen &&
+					isGitlab &&
+					!!resource.gitlabId &&
+					!!resource.gitlabProjectId &&
+					!!resource.gitlabOwner &&
+					!!resource.gitlabRepository,
 			},
 		);
 
-	const changeRequests = (
-		isGitlab ? gitlabMergeRequests : githubPullRequests
-	) as ChangeRequest[] | undefined;
+	const changeRequests = isGitlab ? gitlabMergeRequests : githubPullRequests;
 	const isFetching = isFetchingGithub || isFetchingGitlab;
 
-	const filtered = changeRequests?.filter((cr) => {
-		if (!search) return true;
+	const filtered = useMemo(() => {
+		if (!changeRequests) return undefined;
+		if (!search) return changeRequests;
 		const q = search.toLowerCase();
-		return (
-			String(cr.number).includes(q) ||
-			cr.title.toLowerCase().includes(q) ||
-			cr.branch.toLowerCase().includes(q)
+		return changeRequests.filter(
+			(cr) =>
+				String(cr.number).includes(q) ||
+				cr.title.toLowerCase().includes(q) ||
+				cr.branch.toLowerCase().includes(q),
 		);
-	});
+	}, [changeRequests, search]);
 
 	const { mutateAsync: createPreviewDeployment, isPending } =
 		api.previewDeployment.create.useMutation();
@@ -122,20 +117,18 @@ export const BuildPreviewDeployment = ({
 		if (!selected) return;
 		try {
 			await createPreviewDeployment({
-				applicationId,
-				composeId,
+				applicationId: resource.applicationId,
+				composeId: resource.composeId,
 				branch: selected.branch,
 				pullRequestId: String(selected.id),
 				pullRequestNumber: String(selected.number),
 				pullRequestTitle: selected.title,
-				pullRequestURL: selected.html_url,
+				pullRequestURL: selected.url,
 			});
 			toast.success(
 				`${changeRequestLabel} #${selected.number} preview deployment started`,
 			);
 			setIsOpen(false);
-			setSelected(null);
-			setSearch("");
 		} catch (error) {
 			toast.error(
 				error instanceof Error
@@ -145,11 +138,13 @@ export const BuildPreviewDeployment = ({
 		}
 	};
 
+	const reset = () => {
+		setSelected(null);
+		setSearch("");
+	};
+
 	useEffect(() => {
-		if (!isOpen) {
-			setSelected(null);
-			setSearch("");
-		}
+		if (!isOpen) reset();
 	}, [isOpen]);
 
 	const ChangeRequestIcon = isGitlab ? GitlabIcon : GithubIcon;
@@ -169,7 +164,7 @@ export const BuildPreviewDeployment = ({
 					</DialogDescription>
 				</DialogHeader>
 				<div className="grid gap-4">
-					{!data?.isPreviewDeploymentsActive && (
+					{!resource.isPreviewDeploymentsActive && (
 						<AlertBlock type="warning">
 							Preview deployments are disabled for this resource.
 						</AlertBlock>
@@ -182,7 +177,7 @@ export const BuildPreviewDeployment = ({
 					<div className="relative">
 						<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
 						<Input
-							placeholder={`Search ${changeRequestLabel.toLowerCase()}s...`}
+							placeholder={`Search ${changeRequestLabelPlural}...`}
 							className="pl-9"
 							value={search}
 							onChange={(e) => setSearch(e.target.value)}
@@ -192,25 +187,24 @@ export const BuildPreviewDeployment = ({
 						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
 							<Loader2 className="size-6 text-muted-foreground animate-spin" />
 							<span className="text-sm text-muted-foreground">
-								Loading open {changeRequestLabel.toLowerCase()}s...
+								Loading open {changeRequestLabelPlural}...
 							</span>
 						</div>
 					) : !filtered?.length ? (
 						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
 							<ChangeRequestIcon className="size-8 text-muted-foreground" />
 							<span className="text-sm text-muted-foreground">
-								No open {changeRequestLabel.toLowerCase()}s found
+								No open {changeRequestLabelPlural} found
 							</span>
 						</div>
 					) : (
 						<Select
 							value={selected ? String(selected.number) : undefined}
-							onValueChange={(value) => {
-								const cr = filtered?.find(
-									(item) => String(item.number) === value,
-								);
-								setSelected(cr || null);
-							}}
+							onValueChange={(value) =>
+								setSelected(
+									filtered.find((cr) => String(cr.number) === value) ?? null,
+								)
+							}
 						>
 							<SelectTrigger className="w-full">
 								<SelectValue
@@ -218,7 +212,7 @@ export const BuildPreviewDeployment = ({
 								/>
 							</SelectTrigger>
 							<SelectContent>
-								{filtered?.map((cr) => (
+								{filtered.map((cr) => (
 									<SelectItem
 										key={String(cr.id)}
 										value={String(cr.number)}
@@ -252,7 +246,7 @@ export const BuildPreviewDeployment = ({
 					</Button>
 					<Button
 						isLoading={isPending}
-						disabled={!selected || !data?.isPreviewDeploymentsActive}
+						disabled={!selected || !resource.isPreviewDeploymentsActive}
 						onClick={handleBuild}
 					>
 						<RocketIcon className="size-4" />

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
@@ -34,6 +34,7 @@ import { api } from "@/utils/api";
 import { ShowModalLogs } from "../../settings/web-server/show-modal-logs";
 import { ShowDeploymentsModal } from "../deployments/show-deployments-modal";
 import { AddPreviewDomain } from "./add-preview-domain";
+import { BuildPreviewDeployment } from "./build-preview-deployment";
 import { ShowPreviewSettings } from "./show-preview-settings";
 
 interface Props {
@@ -85,7 +86,15 @@ export const ShowPreviewDeployments = ({ applicationId }: Props) => {
 					<CardDescription>See all the preview deployments</CardDescription>
 				</div>
 				{data?.isPreviewDeploymentsActive && (
-					<ShowPreviewSettings applicationId={applicationId} />
+					<div className="flex items-center gap-2">
+						<BuildPreviewDeployment applicationId={applicationId}>
+							<Button variant="outline" className="gap-2">
+								<GitPullRequest className="size-4" />
+								Build {changeRequestLabel}
+							</Button>
+						</BuildPreviewDeployment>
+						<ShowPreviewSettings applicationId={applicationId} />
+					</div>
 				)}
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
@@ -87,7 +87,7 @@ export const ShowPreviewDeployments = ({ applicationId }: Props) => {
 				</div>
 				{data?.isPreviewDeploymentsActive && (
 					<div className="flex items-center gap-2">
-						<BuildPreviewDeployment applicationId={applicationId}>
+						<BuildPreviewDeployment resource={data}>
 							<Button variant="outline" className="gap-2">
 								<GitPullRequest className="size-4" />
 								Build {changeRequestLabel}

--- a/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
@@ -85,7 +85,7 @@ export const ShowPreviewDeploymentsCompose = ({ composeId }: Props) => {
 				</div>
 				{data?.isPreviewDeploymentsActive && (
 					<div className="flex items-center gap-2">
-						<BuildPreviewDeployment composeId={composeId}>
+						<BuildPreviewDeployment resource={data}>
 							<Button variant="outline" className="gap-2">
 								<GitPullRequest className="size-4" />
 								Build {changeRequestLabel}

--- a/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/tooltip";
 import { api } from "@/utils/api";
 import { ShowDeploymentsModal } from "../../application/deployments/show-deployments-modal";
+import { BuildPreviewDeployment } from "../../application/preview-deployments/build-preview-deployment";
 import { ShowModalLogs } from "../../settings/web-server/show-modal-logs";
 import { ShowPreviewSettingsCompose } from "./show-preview-settings";
 
@@ -83,7 +84,15 @@ export const ShowPreviewDeploymentsCompose = ({ composeId }: Props) => {
 					<CardDescription>See all the preview deployments</CardDescription>
 				</div>
 				{data?.isPreviewDeploymentsActive && (
-					<ShowPreviewSettingsCompose composeId={composeId} />
+					<div className="flex items-center gap-2">
+						<BuildPreviewDeployment composeId={composeId}>
+							<Button variant="outline" className="gap-2">
+								<GitPullRequest className="size-4" />
+								Build {changeRequestLabel}
+							</Button>
+						</BuildPreviewDeployment>
+						<ShowPreviewSettingsCompose composeId={composeId} />
+					</div>
 				)}
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">

--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -3,6 +3,7 @@ import {
 	findGithubById,
 	getAccessibleGitProviderIds,
 	getGithubBranches,
+	getGithubPullRequests,
 	getGithubRepositories,
 	haveGithubRequirements,
 	updateGithub,
@@ -18,6 +19,7 @@ import {
 import { audit } from "@/server/api/utils/audit";
 import {
 	apiFindGithubBranches,
+	apiFindGithubPullRequests,
 	apiFindOneGithub,
 	apiUpdateGithub,
 } from "@/server/db/schema";
@@ -45,6 +47,15 @@ export const githubRouter = createTRPCRouter({
 				await assertGitProviderAccess(ctx.session, github.gitProvider);
 			}
 			return await getGithubBranches(input);
+		}),
+	getGithubPullRequests: protectedProcedure
+		.input(apiFindGithubPullRequests)
+		.query(async ({ input, ctx }) => {
+			if (input.githubId) {
+				const github = await findGithubById(input.githubId);
+				await assertGitProviderAccess(ctx.session, github.gitProvider);
+			}
+			return await getGithubPullRequests(input);
 		}),
 	githubProviders: protectedProcedure.query(async ({ ctx }) => {
 		const accessibleIds = await getAccessibleGitProviderIds(ctx.session);

--- a/apps/dokploy/server/api/routers/gitlab.ts
+++ b/apps/dokploy/server/api/routers/gitlab.ts
@@ -4,6 +4,7 @@ import {
 	findGitlabById,
 	getAccessibleGitProviderIds,
 	getGitlabBranches,
+	getGitlabMergeRequests,
 	getGitlabRepositories,
 	haveGitlabRequirements,
 	testGitlabConnection,
@@ -21,6 +22,7 @@ import { audit } from "@/server/api/utils/audit";
 import {
 	apiCreateGitlab,
 	apiFindGitlabBranches,
+	apiFindGitlabMergeRequests,
 	apiFindOneGitlab,
 	apiGitlabTestConnection,
 	apiUpdateGitlab,
@@ -105,6 +107,15 @@ export const gitlabRouter = createTRPCRouter({
 				await assertGitProviderAccess(ctx.session, gitlab.gitProvider);
 			}
 			return await getGitlabBranches(input);
+		}),
+	getGitlabMergeRequests: protectedProcedure
+		.input(apiFindGitlabMergeRequests)
+		.query(async ({ input, ctx }) => {
+			if (input.gitlabId) {
+				const gitlab = await findGitlabById(input.gitlabId);
+				await assertGitProviderAccess(ctx.session, gitlab.gitProvider);
+			}
+			return await getGitlabMergeRequests(input);
 		}),
 	testConnection: protectedProcedure
 		.input(apiGitlabTestConnection)

--- a/packages/server/src/db/schema/github.ts
+++ b/packages/server/src/db/schema/github.ts
@@ -51,6 +51,12 @@ export const apiFindGithubBranches = z.object({
 	githubId: z.string().optional(),
 });
 
+export const apiFindGithubPullRequests = z.object({
+	repo: z.string().min(1),
+	owner: z.string().min(1),
+	githubId: z.string().optional(),
+});
+
 export const apiFindOneGithub = z.object({
 	githubId: z.string().min(1),
 });

--- a/packages/server/src/db/schema/gitlab.ts
+++ b/packages/server/src/db/schema/gitlab.ts
@@ -61,6 +61,13 @@ export const apiFindGitlabBranches = z.object({
 	gitlabId: z.string().optional(),
 });
 
+export const apiFindGitlabMergeRequests = z.object({
+	id: z.number().optional(),
+	owner: z.string(),
+	repo: z.string(),
+	gitlabId: z.string().optional(),
+});
+
 export const apiUpdateGitlab = z.object({
 	applicationId: z.string().optional(),
 	secret: z.string().optional(),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -75,6 +75,7 @@ export * from "./setup/server-validate";
 export * from "./setup/setup";
 export * from "./setup/traefik-setup";
 export * from "./templates/processors";
+export * from "./types/change-request";
 export * from "./utils/access-log/handler";
 export {
 	getLogCleanupStatus,

--- a/packages/server/src/types/change-request.ts
+++ b/packages/server/src/types/change-request.ts
@@ -1,0 +1,9 @@
+export interface ChangeRequest {
+	id: number;
+	number: number;
+	title: string;
+	url: string;
+	branch: string;
+	baseBranch: string;
+	draft: boolean;
+}

--- a/packages/server/src/utils/providers/github.ts
+++ b/packages/server/src/utils/providers/github.ts
@@ -1,6 +1,9 @@
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
-import type { apiFindGithubBranches } from "@dokploy/server/db/schema";
+import type {
+	apiFindGithubBranches,
+	apiFindGithubPullRequests,
+} from "@dokploy/server/db/schema";
 import { findGithubById, type Github } from "@dokploy/server/services/github";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { createAppAuth } from "@octokit/auth-app";
@@ -261,6 +264,44 @@ export const getGithubRepositories = async (githubId?: string) => {
 	>["data"]["repositories"];
 
 	return repositories;
+};
+
+export const getGithubPullRequests = async (
+	input: z.infer<typeof apiFindGithubPullRequests>,
+) => {
+	if (!input.githubId) {
+		return [];
+	}
+	const githubProvider = await findGithubById(input.githubId);
+
+	const octokit = new Octokit({
+		authStrategy: createAppAuth,
+		auth: {
+			appId: githubProvider.githubAppId,
+			privateKey: githubProvider.githubPrivateKey,
+			installationId: githubProvider.githubInstallationId,
+		},
+		baseUrl: deriveGithubApiUrl(githubProvider.githubUrl),
+	});
+
+	const pullRequests = (await octokit.paginate(octokit.rest.pulls.list, {
+		owner: input.owner,
+		repo: input.repo,
+		state: "open",
+		sort: "updated",
+		direction: "desc",
+	})) as unknown as Awaited<ReturnType<typeof octokit.rest.pulls.list>>["data"];
+
+	return pullRequests.map((pr) => ({
+		id: pr.id,
+		number: pr.number,
+		title: pr.title,
+		html_url: pr.html_url,
+		branch: pr.head?.ref,
+		headSha: pr.head?.sha,
+		baseBranch: pr.base?.ref,
+		draft: pr.draft,
+	}));
 };
 
 export const getGithubBranches = async (

--- a/packages/server/src/utils/providers/github.ts
+++ b/packages/server/src/utils/providers/github.ts
@@ -5,6 +5,7 @@ import type {
 	apiFindGithubPullRequests,
 } from "@dokploy/server/db/schema";
 import { findGithubById, type Github } from "@dokploy/server/services/github";
+import type { ChangeRequest } from "@dokploy/server/types/change-request";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { createAppAuth } from "@octokit/auth-app";
 import { TRPCError } from "@trpc/server";
@@ -268,7 +269,7 @@ export const getGithubRepositories = async (githubId?: string) => {
 
 export const getGithubPullRequests = async (
 	input: z.infer<typeof apiFindGithubPullRequests>,
-) => {
+): Promise<ChangeRequest[]> => {
 	if (!input.githubId) {
 		return [];
 	}
@@ -296,11 +297,10 @@ export const getGithubPullRequests = async (
 		id: pr.id,
 		number: pr.number,
 		title: pr.title,
-		html_url: pr.html_url,
-		branch: pr.head?.ref,
-		headSha: pr.head?.sha,
-		baseBranch: pr.base?.ref,
-		draft: pr.draft,
+		url: pr.html_url,
+		branch: pr.head?.ref ?? "",
+		baseBranch: pr.base?.ref ?? "",
+		draft: pr.draft ?? false,
 	}));
 };
 

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -269,6 +269,70 @@ export const getGitlabBranches = async (input: {
 	}[];
 };
 
+export const getGitlabMergeRequests = async (input: {
+	id?: number;
+	gitlabId?: string;
+	owner: string;
+	repo: string;
+}) => {
+	if (!input.gitlabId || !input.id || input.id === 0) {
+		return [];
+	}
+
+	const gitlabProvider = await findGitlabById(input.gitlabId);
+
+	const allMergeRequests: Record<string, unknown>[] = [];
+	let page = 1;
+	const perPage = 100; // GitLab's max per page is 100
+	const baseUrl = (
+		gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl
+	).replace(/\/+$/, "");
+
+	while (true) {
+		const mergeRequestsResponse = await fetch(
+			`${baseUrl}/api/v4/projects/${input.id}/merge_requests?state=opened&page=${page}&per_page=${perPage}`,
+			{
+				headers: {
+					Authorization: `Bearer ${gitlabProvider.accessToken}`,
+				},
+			},
+		);
+
+		if (!mergeRequestsResponse.ok) {
+			throw new Error(
+				`Failed to fetch merge requests: ${mergeRequestsResponse.statusText}`,
+			);
+		}
+
+		const mergeRequests = (await mergeRequestsResponse.json()) as Record<
+			string,
+			unknown
+		>[];
+
+		if (mergeRequests.length === 0) {
+			break;
+		}
+
+		allMergeRequests.push(...mergeRequests);
+		page++;
+
+		const total = mergeRequestsResponse.headers.get("x-total");
+		if (total && allMergeRequests.length >= Number.parseInt(total)) {
+			break;
+		}
+	}
+
+	return allMergeRequests.map((mr) => ({
+		id: mr.id,
+		number: mr.iid,
+		title: mr.title,
+		html_url: mr.web_url,
+		branch: mr.source_branch,
+		baseBranch: mr.target_branch,
+		draft: mr.draft,
+	}));
+};
+
 export const testGitlabConnection = async (
 	input: z.infer<typeof apiGitlabTestConnection>,
 ) => {

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -6,6 +6,7 @@ import {
 	type Gitlab,
 	updateGitlab,
 } from "@dokploy/server/services/gitlab";
+import type { ChangeRequest } from "@dokploy/server/types/change-request";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { TRPCError } from "@trpc/server";
 import { quote } from "shell-quote";
@@ -269,19 +270,29 @@ export const getGitlabBranches = async (input: {
 	}[];
 };
 
+interface GitlabMergeRequest {
+	id: number;
+	iid: number;
+	title: string;
+	web_url: string;
+	source_branch: string;
+	target_branch: string;
+	draft: boolean;
+}
+
 export const getGitlabMergeRequests = async (input: {
 	id?: number;
 	gitlabId?: string;
 	owner: string;
 	repo: string;
-}) => {
+}): Promise<ChangeRequest[]> => {
 	if (!input.gitlabId || !input.id || input.id === 0) {
 		return [];
 	}
 
 	const gitlabProvider = await findGitlabById(input.gitlabId);
 
-	const allMergeRequests: Record<string, unknown>[] = [];
+	const allMergeRequests: GitlabMergeRequest[] = [];
 	let page = 1;
 	const perPage = 100; // GitLab's max per page is 100
 	const baseUrl = (
@@ -304,10 +315,8 @@ export const getGitlabMergeRequests = async (input: {
 			);
 		}
 
-		const mergeRequests = (await mergeRequestsResponse.json()) as Record<
-			string,
-			unknown
-		>[];
+		const mergeRequests =
+			(await mergeRequestsResponse.json()) as GitlabMergeRequest[];
 
 		if (mergeRequests.length === 0) {
 			break;
@@ -326,7 +335,7 @@ export const getGitlabMergeRequests = async (input: {
 		id: mr.id,
 		number: mr.iid,
 		title: mr.title,
-		html_url: mr.web_url,
+		url: mr.web_url,
 		branch: mr.source_branch,
 		baseBranch: mr.target_branch,
 		draft: mr.draft,


### PR DESCRIPTION
TLDR (from a human)

Tried to add a button to "build pull request" that bypasses the automatic logic and just lets you build a PR manually, I have setup a small script on my instance to allow me to do that even tho my PRs aren't targeting the default branch. (By leveraging the webook)

Sidenote I am unsure how to test this, it's vibe-coded out of frustration.

Much love @AminDhouib for this fork,


## Summary

Adds a **"Build Pull Request"** button to the **Preview Deployments** tab that lets you pick any open pull request / merge request on the resource's repository and immediately create + deploy a preview deployment — no webhook or GitHub event required.

This covers the flow that previously required manually calling the deploy endpoint with a forged payload: select a PR, dokploy creates the preview row, generates the domain from the wildcard template, posts the PR comment, and queues the build.

## Changes

- **Providers** (`packages/server/src/utils/providers/`)
  - `getGithubPullRequests` — lists open PRs for `owner/repo` via the GitHub App (paginated, sorted by recency).
  - `getGitlabMergeRequests` — lists open merge requests for a GitLab project (paginated).
- **Schemas** (`packages/server/src/db/schema/`)
  - `apiFindGithubPullRequests`, `apiFindGitlabMergeRequests`.
- **tRPC routers** (`apps/dokploy/server/api/routers/`)
  - `github.getGithubPullRequests`, `gitlab.getGitlabMergeRequests` (both behind `assertGitProviderAccess`).
- **UI** (`apps/dokploy/components/dashboard/.../preview-deployments/`)
  - New shared `BuildPreviewDeployment` dialog: searches open PRs/MRs, shows PR # / title / branch / draft state, and calls the existing `previewDeployment.create` mutation.
  - Wired into both the **application** and **compose** preview deployments tabs.

## Why this is safe

- The create path reuses the existing `previewDeployment.create` tRPC flow, so dedupe (`(applicationId, pullRequestId)` unique index), preview limit, domain generation, comment posting, and authz all behave identically to a webhook-triggered preview.
- The new endpoints only *read* from the git provider and are permission-gated like the existing `getGithubBranches` / `getGitlabBranches`.

## Notes

- GitHub: works for both `draft` and open PRs (draft flagged in the picker).
- GitLab: uses `gitlabProjectId` (the existing branch fetch already depends on it).