### PR TITLE
fix(security): org-scope service access for owner/admin, network/domain/ai routers, metrics URL derivation

### DIFF
--- a/apps/dokploy/__test__/permissions/routers-org-scope-wave3.test.ts
+++ b/apps/dokploy/__test__/permissions/routers-org-scope-wave3.test.ts
@@ -1,0 +1,485 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Wave 3 of the cross-organization id sweep.
+ *
+ * `withPermission(...)` / `adminProcedure` / `protectedProcedure` only prove the
+ * caller holds a role or permission inside their *active* organization. They say
+ * nothing about the `serverId` / `aiId` / `environmentId` the caller passes in,
+ * so every procedure that turns one of those ids into a Docker call, an SSH
+ * exec, an outbound `fetch`, a credential read or a write has to assert the row
+ * belongs to the caller's organization first.
+ */
+vi.mock("@/server/api/utils/audit", () => ({
+	audit: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@dokploy/server/services/permission", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("@dokploy/server/services/permission")
+		>();
+	return {
+		...actual,
+		checkPermission: vi.fn(async () => {}),
+		checkServiceAccess: vi.fn(async () => {}),
+		addNewService: vi.fn(async () => {}),
+	};
+});
+
+vi.mock("@dokploy/server/services/ai", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@dokploy/server/services/ai")>();
+	return {
+		...actual,
+		getAiSettingById: vi.fn(async () => aiRow),
+		deleteAiSettings: vi.fn(async () => ({ aiId: "ai-1" })),
+		saveAiSettings: vi.fn(async () => ({ aiId: "ai-1" })),
+		suggestVariants: vi.fn(async () => ({ suggestions: [] })),
+	};
+});
+
+vi.mock("@dokploy/server", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@dokploy/server")>();
+	return {
+		...actual,
+		findServerById: vi.fn(async () => serverRow),
+		getWebServerSettings: vi.fn(async () => ({
+			serverIp: "10.0.0.1",
+			metricsConfig: { server: { port: 4500, token: "local-token" } },
+		})),
+		findEnvironmentById: vi.fn(async () => ({
+			environmentId: "env-1",
+			projectId: "project-1",
+		})),
+		createNetwork: vi.fn(async () => ({ networkId: "net-1", name: "net" })),
+		importDockerNetworks: vi.fn(async () => ({ imported: [], errors: [] })),
+		findNetworksToSync: vi.fn(async () => []),
+		generateTraefikMeDomain: vi.fn(async () => "app.traefik.me"),
+		createComposeByTemplate: vi.fn(async () => ({ composeId: "compose-1" })),
+	};
+});
+
+vi.mock("@dokploy/server/services/project", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@dokploy/server/services/project")>();
+	return {
+		...actual,
+		findProjectById: vi.fn(async () => projectRow),
+	};
+});
+
+vi.mock("@dokploy/server/services/compose", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@dokploy/server/services/compose")>();
+	return {
+		...actual,
+		createComposeByTemplate: vi.fn(async () => ({ composeId: "compose-1" })),
+	};
+});
+
+let serverRow: Record<string, unknown> = {};
+let aiRow: Record<string, unknown> = {};
+let projectRow: Record<string, unknown> = {};
+
+const { appRouter } = await import("@/server/api/root");
+const { createCallerFactory } = await import("@/server/api/trpc");
+const {
+	createNetwork,
+	findNetworksToSync,
+	findServerById,
+	generateTraefikMeDomain,
+	importDockerNetworks,
+} = await import("@dokploy/server");
+const { deleteAiSettings, saveAiSettings, suggestVariants } = await import(
+	"@dokploy/server/services/ai"
+);
+const { createComposeByTemplate } = await import(
+	"@dokploy/server/services/compose"
+);
+
+const createCaller = createCallerFactory(appRouter);
+
+const ownerCtx = {
+	user: {
+		id: "user-1",
+		email: "owner@test.com",
+		role: "owner",
+		ownerId: "user-1",
+	},
+	session: { activeOrganizationId: "org-1" },
+	req: {} as unknown,
+	res: {} as unknown,
+} as never;
+
+const serverInOrganization = (organizationId: string) => {
+	serverRow = {
+		serverId: "srv-1",
+		name: "srv",
+		organizationId,
+		ipAddress: "203.0.113.10",
+		serverType: "build",
+		serverStatus: "active",
+		defaultDomain: null,
+		metricsConfig: { server: { port: 4500, token: "remote-token" } },
+	};
+	vi.mocked(findServerById).mockResolvedValue(
+		serverRow as Awaited<ReturnType<typeof findServerById>>,
+	);
+};
+
+const aiInOrganization = (organizationId: string) => {
+	aiRow = {
+		aiId: "ai-1",
+		organizationId,
+		isEnabled: true,
+		name: "provider",
+		apiUrl: "https://api.example.com",
+		apiKey: "sk-secret",
+		model: "gpt",
+	};
+};
+
+const projectInOrganization = (organizationId: string) => {
+	projectRow = {
+		projectId: "project-1",
+		name: "project",
+		organizationId,
+	};
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	serverInOrganization("org-1");
+	aiInOrganization("org-1");
+	projectInOrganization("org-1");
+	fetchMock.mockReset();
+	fetchMock.mockResolvedValue({
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		json: async () => [{ cpu: "1", timestamp: "now" }],
+	});
+	vi.stubGlobal("fetch", fetchMock);
+});
+
+const crossOrganization = { code: "UNAUTHORIZED" };
+
+describe("network router is organization-scoped", () => {
+	it("network.create rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.network.create({
+				name: "net",
+				driver: "overlay",
+				serverId: "srv-1",
+			} as never),
+		).rejects.toMatchObject(crossOrganization);
+		expect(createNetwork).not.toHaveBeenCalled();
+	});
+
+	it("network.create allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.network.create({
+				name: "net",
+				driver: "overlay",
+				serverId: "srv-1",
+			} as never),
+		).resolves.toMatchObject({ networkId: "net-1" });
+		expect(createNetwork).toHaveBeenCalled();
+	});
+
+	it("network.import rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.network.import({ serverId: "srv-1", names: ["bridge"] }),
+		).rejects.toMatchObject(crossOrganization);
+		expect(importDockerNetworks).not.toHaveBeenCalled();
+	});
+
+	it("network.networksToSync rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.network.networksToSync({ serverId: "srv-1" }),
+		).rejects.toMatchObject(crossOrganization);
+		expect(findNetworksToSync).not.toHaveBeenCalled();
+	});
+
+	it("network.networksToSync still works for the local host", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.network.networksToSync({})).resolves.toEqual([]);
+		expect(findServerById).not.toHaveBeenCalled();
+		expect(findNetworksToSync).toHaveBeenCalledWith("org-1", null);
+	});
+});
+
+describe("domain router is organization-scoped", () => {
+	it("domain.generateDomain rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.domain.generateDomain({ appName: "app", serverId: "srv-1" }),
+		).rejects.toMatchObject(crossOrganization);
+		expect(generateTraefikMeDomain).not.toHaveBeenCalled();
+	});
+
+	it("domain.generateDomain allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.domain.generateDomain({ appName: "app", serverId: "srv-1" }),
+		).resolves.toBe("app.traefik.me");
+		expect(generateTraefikMeDomain).toHaveBeenCalled();
+	});
+
+	it("domain.canGenerateTraefikMeDomains does not leak a foreign server ip", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.domain.canGenerateTraefikMeDomains({ serverId: "srv-1" }),
+		).rejects.toMatchObject(crossOrganization);
+	});
+
+	it("domain.canGenerateTraefikMeDomains returns the ip for an own server", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.domain.canGenerateTraefikMeDomains({ serverId: "srv-1" }),
+		).resolves.toBe("203.0.113.10");
+	});
+});
+
+describe("ai router is organization-scoped", () => {
+	it("ai.one hides a provider (and its api key) from another organization", async () => {
+		aiInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.ai.one({ aiId: "ai-1" })).rejects.toMatchObject({
+			code: "NOT_FOUND",
+		});
+	});
+
+	it("ai.delete refuses a provider from another organization", async () => {
+		aiInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(caller.ai.delete({ aiId: "ai-1" })).rejects.toMatchObject({
+			code: "NOT_FOUND",
+		});
+		expect(deleteAiSettings).not.toHaveBeenCalled();
+	});
+
+	it("ai.update refuses to overwrite a provider from another organization", async () => {
+		aiInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.update({ aiId: "ai-1", name: "hijacked" }),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+		expect(saveAiSettings).not.toHaveBeenCalled();
+	});
+
+	it("ai.suggest refuses a provider from another organization", async () => {
+		aiInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.suggest({ aiId: "ai-1", input: "a wordpress site" }),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+		expect(suggestVariants).not.toHaveBeenCalled();
+	});
+
+	it("ai.suggest refuses a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.suggest({
+				aiId: "ai-1",
+				input: "a wordpress site",
+				serverId: "srv-1",
+			}),
+		).rejects.toMatchObject(crossOrganization);
+		expect(suggestVariants).not.toHaveBeenCalled();
+	});
+
+	it("ai.suggest works with an in-organization provider", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.suggest({ aiId: "ai-1", input: "a wordpress site" }),
+		).resolves.toEqual({ suggestions: [] });
+		expect(suggestVariants).toHaveBeenCalled();
+	});
+
+	it("ai.deploy refuses an environment from another organization", async () => {
+		projectInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.deploy({
+				id: "suggestion-1",
+				name: "app",
+				description: "an app",
+				environmentId: "env-1",
+				dockerCompose: "services: {}",
+				envVariables: "",
+				domains: [],
+				configFiles: [],
+			} as never),
+		).rejects.toMatchObject(crossOrganization);
+		expect(createComposeByTemplate).not.toHaveBeenCalled();
+	});
+
+	it("ai.deploy refuses a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.deploy({
+				id: "suggestion-1",
+				name: "app",
+				description: "an app",
+				environmentId: "env-1",
+				serverId: "srv-1",
+				dockerCompose: "services: {}",
+				envVariables: "",
+				domains: [],
+				configFiles: [],
+			} as never),
+		).rejects.toMatchObject(crossOrganization);
+		expect(createComposeByTemplate).not.toHaveBeenCalled();
+	});
+
+	it("ai.deploy still works when project and server are in the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.ai.deploy({
+				id: "suggestion-1",
+				name: "app",
+				description: "an app",
+				environmentId: "env-1",
+				serverId: "srv-1",
+				dockerCompose: "services: {}",
+				envVariables: "",
+				domains: [],
+				configFiles: [],
+			} as never),
+		).resolves.toBeNull();
+		expect(createComposeByTemplate).toHaveBeenCalled();
+	});
+});
+
+describe("server.getDefaultCommand is organization-scoped", () => {
+	it("rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.server.getDefaultCommand({ serverId: "srv-1" }),
+		).rejects.toMatchObject(crossOrganization);
+	});
+
+	it("allows a serverId from the caller's organization", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.server.getDefaultCommand({ serverId: "srv-1" }),
+		).resolves.toEqual(expect.any(String));
+	});
+});
+
+/**
+ * The metrics procedures used to `fetch(input.url)` with `input.token`: an
+ * authenticated user could aim the Dokploy host at any internal address and
+ * read the response back. The URL and token are now derived from the (scoped)
+ * server row.
+ */
+describe("metrics procedures derive their endpoint from the server row", () => {
+	it("server.getServerMetrics rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.server.getServerMetrics({ serverId: "srv-1", dataPoints: "50" }),
+		).rejects.toMatchObject(crossOrganization);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("server.getServerMetrics fetches the stored endpoint with the stored token", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await caller.server.getServerMetrics({
+			serverId: "srv-1",
+			dataPoints: "50",
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://203.0.113.10:4500/metrics?limit=50",
+			{ headers: { Authorization: "Bearer remote-token" } },
+		);
+	});
+
+	it("user.getContainerMetrics rejects a serverId from another organization", async () => {
+		serverInOrganization("org-2");
+		const caller = createCaller(ownerCtx);
+
+		await expect(
+			caller.user.getContainerMetrics({
+				serverId: "srv-1",
+				appName: "app",
+				dataPoints: "50",
+			}),
+		).rejects.toMatchObject(crossOrganization);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("user.getContainerMetrics fetches the stored endpoint with the stored token", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await caller.user.getContainerMetrics({
+			serverId: "srv-1",
+			appName: "app",
+			dataPoints: "50",
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://203.0.113.10:4500/metrics/containers?limit=50&appName=app",
+			{ headers: { Authorization: "Bearer remote-token" } },
+		);
+	});
+
+	it("ignores a caller-supplied url/token entirely (SSRF negative control)", async () => {
+		const caller = createCaller(ownerCtx);
+
+		await caller.server.getServerMetrics({
+			serverId: "srv-1",
+			dataPoints: "50",
+			url: "http://169.254.169.254/latest/meta-data/",
+			token: "attacker-token",
+		} as never);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"http://203.0.113.10:4500/metrics?limit=50",
+			{ headers: { Authorization: "Bearer remote-token" } },
+		);
+		expect(fetchMock).not.toHaveBeenCalledWith(
+			expect.stringContaining("169.254.169.254"),
+			expect.anything(),
+		);
+	});
+});

--- a/apps/dokploy/__test__/permissions/service-access.test.ts
+++ b/apps/dokploy/__test__/permissions/service-access.test.ts
@@ -29,8 +29,22 @@ const mockMemberData = (
 let memberToReturn: ReturnType<typeof mockMemberData> =
 	mockMemberData("member");
 
+/**
+ * Organization the service id resolves to, as returned by the single
+ * `environment -> project` lookup inside `findServiceOrganizationId`.
+ * `null` models "no service with that id exists".
+ */
+let serviceOrganizationId: string | null = "org-1";
+
 vi.mock("@dokploy/server/db", () => ({
 	db: {
+		execute: vi.fn(() =>
+			Promise.resolve(
+				serviceOrganizationId === null
+					? []
+					: [{ organizationId: serviceOrganizationId }],
+			),
+		),
 		query: {
 			member: {
 				findFirst: vi.fn(() => Promise.resolve(memberToReturn)),
@@ -59,6 +73,7 @@ const ctx = {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	serviceOrganizationId = "org-1";
 });
 
 describe("checkServicePermissionAndAccess", () => {
@@ -103,6 +118,80 @@ describe("checkServicePermissionAndAccess", () => {
 		await expect(
 			checkServicePermissionAndAccess(ctx, "service-123", {
 				domain: ["delete"],
+			}),
+		).rejects.toThrow("You don't have access to this service");
+	});
+});
+
+/**
+ * Wave 3: owner/admin short-circuit the `accessedServices` allow-list, and
+ * nothing else proved the id they passed belongs to their organization -- so an
+ * owner of org-1 could deploy/stop/read logs of org-2's services purely by id.
+ */
+describe("checkServicePermissionAndAccess is organization-scoped", () => {
+	const crossOrganizationMessage =
+		"You are not authorized to access this service or it does not exist";
+
+	it("rejects an owner passing a service from another organization", async () => {
+		memberToReturn = mockMemberData("owner", []);
+		serviceOrganizationId = "org-2";
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["create"],
+			}),
+		).rejects.toThrow(crossOrganizationMessage);
+	});
+
+	it("rejects an admin passing a service from another organization", async () => {
+		memberToReturn = mockMemberData("admin", []);
+		serviceOrganizationId = "org-2";
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["create"],
+			}),
+		).rejects.toThrow(crossOrganizationMessage);
+	});
+
+	it("gives a non-existent service the same error as a foreign one (no existence oracle)", async () => {
+		memberToReturn = mockMemberData("owner", []);
+		serviceOrganizationId = null;
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-does-not-exist", {
+				deployment: ["create"],
+			}),
+		).rejects.toThrow(crossOrganizationMessage);
+	});
+
+	it("allows an owner passing a service from their own organization", async () => {
+		memberToReturn = mockMemberData("owner", []);
+		serviceOrganizationId = "org-1";
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["create"],
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a member whose accessedServices lists a foreign service", async () => {
+		// `accessedServices` is not proof of organization membership: nothing
+		// validates the ids an admin assigns through `user.assignPermissions`.
+		memberToReturn = mockMemberData("member", ["service-123"]);
+		serviceOrganizationId = "org-2";
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["read"],
+			}),
+		).rejects.toThrow(crossOrganizationMessage);
+	});
+
+	it("keeps the member allow-list error when the member simply lacks access", async () => {
+		// Ordering control: the allow-list check still runs first, so the
+		// member-facing message is unchanged by the new organization check.
+		memberToReturn = mockMemberData("member", []);
+		serviceOrganizationId = "org-1";
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["read"],
 			}),
 		).rejects.toThrow("You don't have access to this service");
 	});

--- a/apps/dokploy/__test__/setup.ts
+++ b/apps/dokploy/__test__/setup.ts
@@ -28,6 +28,10 @@ vi.mock("@dokploy/server/db", () => {
 
 	return {
 		db: {
+			// Raw SQL escape hatch (used by e.g. the service -> organization
+			// resolver in `checkServicePermissionAndAccess`). Defaults to "no
+			// rows"; tests that need a hit override it per case.
+			execute: vi.fn(() => Promise.resolve([] as unknown[])),
 			select: vi.fn(() => chain),
 			insert: vi.fn(() => ({
 				values: () => ({ returning: () => Promise.resolve([{}]) }),

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/show-paid-compose-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/show-paid-compose-monitoring.tsx
@@ -28,16 +28,12 @@ interface Props {
 	appName: string;
 	serverId?: string;
 	appType: "stack" | "docker-compose";
-	baseUrl: string;
-	token: string;
 }
 
 export const ComposePaidMonitoring = ({
 	appName,
 	appType = "stack",
 	serverId,
-	baseUrl,
-	token,
 }: Props) => {
 	const { data, isPending } = api.docker.getContainersByAppNameMatch.useQuery(
 		{
@@ -129,8 +125,7 @@ export const ComposePaidMonitoring = ({
 					<div className="flex flex-col gap-4">
 						<ContainerPaidMonitoring
 							appName={containerAppName || ""}
-							baseUrl={baseUrl}
-							token={token}
+							serverId={serverId}
 						/>
 					</div>
 				</CardContent>

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/show-paid-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/show-paid-container-monitoring.tsx
@@ -62,11 +62,15 @@ interface ContainerMetric {
 
 interface Props {
 	appName: string;
-	baseUrl: string;
-	token: string;
+	/**
+	 * Server the container runs on; omit for the local Dokploy host. The metrics
+	 * endpoint and bearer token are derived server-side from this id -- the
+	 * client no longer supplies a URL or a token.
+	 */
+	serverId?: string;
 }
 
-export const ContainerPaidMonitoring = ({ appName, baseUrl, token }: Props) => {
+export const ContainerPaidMonitoring = ({ appName, serverId }: Props) => {
 	const [historicalData, setHistoricalData] = useState<ContainerMetric[]>([]);
 	const [metrics, setMetrics] = useState<ContainerMetric>(
 		{} as ContainerMetric,
@@ -81,8 +85,7 @@ export const ContainerPaidMonitoring = ({ appName, baseUrl, token }: Props) => {
 		error: queryError,
 	} = api.user.getContainerMetrics.useQuery(
 		{
-			url: baseUrl,
-			token,
+			serverId,
 			dataPoints,
 			appName,
 		},
@@ -123,7 +126,6 @@ export const ContainerPaidMonitoring = ({ appName, baseUrl, token }: Props) => {
 							? queryError.message
 							: "Failed to fetch metrics, Please check your monitoring Instance is Configured correctly."}
 					</p>
-					<p className="text-sm text-muted-foreground">URL: {baseUrl}</p>
 				</div>
 			</div>
 		);

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/show-paid-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/show-paid-monitoring.tsx
@@ -53,15 +53,16 @@ interface SystemMetrics {
 }
 
 interface Props {
-	BASE_URL?: string;
-	token?: string;
+	/**
+	 * Remote server to read metrics from. Omit for the local Dokploy host. The
+	 * metrics endpoint and its bearer token are resolved server-side from this
+	 * id -- the client never supplies a URL or a token (see
+	 * `server/api/utils/metrics-endpoint.ts`).
+	 */
+	serverId?: string;
 }
 
-export const ShowPaidMonitoring = ({
-	BASE_URL = process.env.NEXT_PUBLIC_METRICS_URL ||
-		"http://localhost:3001/metrics",
-	token = process.env.NEXT_PUBLIC_METRICS_TOKEN || "my-token",
-}: Props) => {
+export const ShowPaidMonitoring = ({ serverId }: Props) => {
 	const [historicalData, setHistoricalData] = useState<SystemMetrics[]>([]);
 	const [metrics, setMetrics] = useState<SystemMetrics>({} as SystemMetrics);
 	const [dataPoints, setDataPoints] =
@@ -74,8 +75,7 @@ export const ShowPaidMonitoring = ({
 		error: queryError,
 	} = api.server.getServerMetrics.useQuery(
 		{
-			url: BASE_URL,
-			token,
+			serverId,
 			dataPoints,
 		},
 		{
@@ -143,7 +143,6 @@ export const ShowPaidMonitoring = ({
 							? queryError.message
 							: "Failed to fetch metrics, Please check your monitoring Instance is Configured correctly."}
 					</p>
-					<p className="text-sm text-muted-foreground">URL: {BASE_URL}</p>
 				</div>
 			</div>
 		);

--- a/apps/dokploy/components/dashboard/settings/servers/show-monitoring-modal.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-monitoring-modal.tsx
@@ -5,11 +5,10 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { ShowPaidMonitoring } from "../../monitoring/paid/servers/show-paid-monitoring";
 
 interface Props {
-	url: string;
-	token: string;
+	serverId: string;
 }
 
-export const ShowMonitoringModal = ({ url, token }: Props) => {
+export const ShowMonitoringModal = ({ serverId }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (
@@ -21,7 +20,7 @@ export const ShowMonitoringModal = ({ url, token }: Props) => {
 			</DialogTrigger>
 			<DialogContent className="sm:max-w-7xl  ">
 				<div className="flex gap-4 py-4 w-full">
-					<ShowPaidMonitoring BASE_URL={url} token={token} />
+					<ShowPaidMonitoring serverId={serverId} />
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
@@ -311,11 +311,7 @@ export const ShowServers = () => {
 																							<TooltipTrigger asChild>
 																								<div>
 																									<ShowMonitoringModal
-																										url={`http://${server.ipAddress}:${server?.metricsConfig?.server?.port}/metrics`}
-																										token={
-																											server?.metricsConfig
-																												?.server?.token
-																										}
+																										serverId={server.serverId}
 																									/>
 																								</div>
 																							</TooltipTrigger>

--- a/apps/dokploy/pages/dashboard/monitoring.tsx
+++ b/apps/dokploy/pages/dashboard/monitoring.tsx
@@ -22,10 +22,6 @@ import {
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { api } from "@/utils/api";
 
-const BASE_URL = "http://localhost:3001/metrics";
-
-const DEFAULT_TOKEN = "metrics";
-
 const Dashboard = () => {
 	const [toggleMonitoring, _setToggleMonitoring] = useLocalStorage(
 		"monitoring-enabled",
@@ -52,21 +48,11 @@ const Dashboard = () => {
 		{ enabled: isRemoteSelected },
 	);
 
-	// In dev, ShowPaidMonitoring talks to a local stub at `BASE_URL` with
-	// `DEFAULT_TOKEN` regardless of which server is selected. In prod we point
-	// it at the real ip:port/metrics endpoint and pass the configured token.
-	const resolveMetricsEndpoint = (
-		ip: string | undefined | null,
-		port: number | undefined | null,
-		token: string | undefined | null,
-	): { url: string; token: string | undefined } => {
-		const isProd = process.env.NODE_ENV === "production";
-		return {
-			url: isProd ? `http://${ip}:${port}/metrics` : BASE_URL,
-			token: isProd ? (token ?? undefined) : DEFAULT_TOKEN,
-		};
-	};
-
+	// The metrics endpoint and its token are resolved server-side from the
+	// selected `serverId` (or from the web-server settings for the local host);
+	// this page only decides *which* server to ask about. `getMonitoringConfig`
+	// is still queried so we can show the "not configured" hint before firing a
+	// metrics request that would fail.
 	let paidMonitoringContent: ReactElement;
 	if (selectedServer) {
 		const remotePort = remoteMonitoringConfig?.port;
@@ -99,35 +85,22 @@ const Dashboard = () => {
 				</Card>
 			);
 		} else {
-			const endpoint = resolveMetricsEndpoint(
-				remoteMonitoringConfig?.ipAddress,
-				remotePort,
-				remoteToken,
-			);
 			paidMonitoringContent = (
 				<Card
 					key={`paid-${selectedServerId}`}
 					className="bg-sidebar  p-2.5 rounded-xl  mx-auto"
 				>
 					<div className="rounded-xl bg-background shadow-md">
-						<ShowPaidMonitoring
-							BASE_URL={endpoint.url}
-							token={endpoint.token}
-						/>
+						<ShowPaidMonitoring serverId={selectedServerId} />
 					</div>
 				</Card>
 			);
 		}
 	} else {
-		const endpoint = resolveMetricsEndpoint(
-			monitoring?.serverIp,
-			monitoring?.metricsConfig?.server?.port,
-			monitoring?.metricsConfig?.server?.token,
-		);
 		paidMonitoringContent = (
 			<Card className="bg-sidebar  p-2.5 rounded-xl  mx-auto">
 				<div className="rounded-xl bg-background shadow-md">
-					<ShowPaidMonitoring BASE_URL={endpoint.url} token={endpoint.token} />
+					<ShowPaidMonitoring />
 				</div>
 			</Card>
 		);

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -304,10 +304,7 @@ const Service = (
 													{data?.serverId && isCloud ? (
 														<ContainerPaidMonitoring
 															appName={data?.appName || ""}
-															baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
-															token={
-																data?.server?.metricsConfig?.server?.token || ""
-															}
+															serverId={data?.serverId ?? undefined}
 														/>
 													) : (
 														<>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -341,11 +341,7 @@ const Service = (
 													{data?.serverId && isCloud ? (
 														<ComposePaidMonitoring
 															serverId={data?.serverId || ""}
-															baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
 															appName={data?.appName || ""}
-															token={
-																data?.server?.metricsConfig?.server?.token || ""
-															}
 															appType={data?.composeType || "docker-compose"}
 														/>
 													) : (

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -225,10 +225,7 @@ const Libsql = (
 												{data?.serverId && isCloud ? (
 													<ContainerPaidMonitoring
 														appName={data?.appName || ""}
-														baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
-														token={
-															data?.server?.metricsConfig?.server?.token || ""
-														}
+														serverId={data?.serverId ?? undefined}
 													/>
 												) : (
 													<>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -253,10 +253,7 @@ const Mariadb = (
 													{data?.serverId && isCloud ? (
 														<ContainerPaidMonitoring
 															appName={data?.appName || ""}
-															baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
-															token={
-																data?.server?.metricsConfig?.server?.token || ""
-															}
+															serverId={data?.serverId ?? undefined}
 														/>
 													) : (
 														<>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -253,10 +253,7 @@ const Mongo = (
 													{data?.serverId && isCloud ? (
 														<ContainerPaidMonitoring
 															appName={data?.appName || ""}
-															baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
-															token={
-																data?.server?.metricsConfig?.server?.token || ""
-															}
+															serverId={data?.serverId ?? undefined}
 														/>
 													) : (
 														<>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -253,11 +253,7 @@ const MySql = (
 														{data?.serverId && isCloud ? (
 															<ContainerPaidMonitoring
 																appName={data?.appName || ""}
-																baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
-																token={
-																	data?.server?.metricsConfig?.server?.token ||
-																	""
-																}
+																serverId={data?.serverId ?? undefined}
 															/>
 														) : (
 															<>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -258,14 +258,7 @@ const Postgresql = (
 													{data?.serverId && isCloud ? (
 														<ContainerPaidMonitoring
 															appName={data?.appName || ""}
-															baseUrl={`${
-																data?.serverId
-																	? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}`
-																	: "http://localhost:4500"
-															}`}
-															token={
-																data?.server?.metricsConfig?.server?.token || ""
-															}
+															serverId={data?.serverId ?? undefined}
 														/>
 													) : (
 														<>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -251,10 +251,7 @@ const Redis = (
 													{data?.serverId && isCloud ? (
 														<ContainerPaidMonitoring
 															appName={data?.appName || ""}
-															baseUrl={`${data?.serverId ? `http://${data?.server?.ipAddress}:${data?.server?.metricsConfig?.server?.port}` : "http://localhost:4500"}`}
-															token={
-																data?.server?.metricsConfig?.server?.token || ""
-															}
+															serverId={data?.serverId ?? undefined}
 														/>
 													) : (
 														<>

--- a/apps/dokploy/server/api/routers/ai.ts
+++ b/apps/dokploy/server/api/routers/ai.ts
@@ -40,13 +40,43 @@ import {
 	createTRPCRouter,
 	protectedProcedure,
 } from "@/server/api/trpc";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import { generatePassword } from "@/templates/utils";
+
+/**
+ * `getAiSettingById` looks an AI provider up by primary key only, so every
+ * procedure that accepts a caller-supplied `aiId` has to prove the row belongs
+ * to the caller's active organization before returning it (the row carries the
+ * provider `apiKey`) or using its credentials to talk to a model.
+ */
+const findAiSettingInOrganization = async (
+	aiId: string,
+	activeOrganizationId: string,
+) => {
+	const notFound = new TRPCError({
+		code: "NOT_FOUND",
+		message: "AI settings not found",
+	});
+	let aiSettings: Awaited<ReturnType<typeof getAiSettingById>>;
+	try {
+		aiSettings = await getAiSettingById(aiId);
+	} catch {
+		throw notFound;
+	}
+	if (aiSettings.organizationId !== activeOrganizationId) {
+		throw notFound;
+	}
+	return aiSettings;
+};
 
 export const aiRouter = createTRPCRouter({
 	one: adminProcedure
 		.input(z.object({ aiId: z.string() }))
-		.query(async ({ input }) => {
-			return await getAiSettingById(input.aiId);
+		.query(async ({ ctx, input }) => {
+			return await findAiSettingInOrganization(
+				input.aiId,
+				ctx.session.activeOrganizationId,
+			);
 		}),
 
 	getModels: protectedProcedure
@@ -182,6 +212,12 @@ export const aiRouter = createTRPCRouter({
 	}),
 
 	update: adminProcedure.input(apiUpdateAi).mutation(async ({ ctx, input }) => {
+		// `saveAiSettings` upserts on the `aiId` primary key, so an unscoped
+		// `aiId` would let an admin overwrite another organization's provider.
+		await findAiSettingInOrganization(
+			input.aiId,
+			ctx.session.activeOrganizationId,
+		);
 		return await saveAiSettings(ctx.session.activeOrganizationId, input);
 	}),
 
@@ -193,13 +229,20 @@ export const aiRouter = createTRPCRouter({
 
 	get: adminProcedure
 		.input(z.object({ aiId: z.string() }))
-		.query(async ({ input }) => {
-			return await getAiSettingById(input.aiId);
+		.query(async ({ ctx, input }) => {
+			return await findAiSettingInOrganization(
+				input.aiId,
+				ctx.session.activeOrganizationId,
+			);
 		}),
 
 	delete: adminProcedure
 		.input(z.object({ aiId: z.string() }))
-		.mutation(async ({ input }) => {
+		.mutation(async ({ ctx, input }) => {
+			await findAiSettingInOrganization(
+				input.aiId,
+				ctx.session.activeOrganizationId,
+			);
 			return await deleteAiSettings(input.aiId);
 		}),
 
@@ -234,19 +277,17 @@ export const aiRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
+			// Resolved outside the try/catch below, which rewrites every failure
+			// to BAD_REQUEST and would otherwise swallow the authorization code.
+			const aiSettings = await findAiSettingInOrganization(
+				input.aiId,
+				ctx.session.activeOrganizationId,
+			);
 			try {
-				const aiSettings = await getAiSettingById(input.aiId);
 				if (!aiSettings?.isEnabled) {
 					throw new TRPCError({
 						code: "BAD_REQUEST",
 						message: "AI provider is not enabled",
-					});
-				}
-
-				if (aiSettings.organizationId !== ctx.session.activeOrganizationId) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message: "Access denied",
 					});
 				}
 
@@ -326,6 +367,17 @@ ${input.logs}`,
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Both ids are scoped before the try/catch (which flattens errors to
+			// BAD_REQUEST): `suggestVariants` uses the provider credentials behind
+			// `aiId` and reads the ip address behind `serverId`.
+			await findAiSettingInOrganization(
+				input.aiId,
+				ctx.session.activeOrganizationId,
+			);
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			try {
 				return await suggestVariants({
 					...input,
@@ -343,6 +395,21 @@ ${input.logs}`,
 		.mutation(async ({ ctx, input }) => {
 			const environment = await findEnvironmentById(input.environmentId);
 			const project = await findProjectById(environment.projectId);
+			// `checkServiceAccess(..., "create")` only consults `accessedProjects`
+			// and short-circuits entirely for owner/admin, so the target project
+			// and server must be organization-scoped explicitly before anything
+			// is created or deployed.
+			if (project.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message:
+						"You are not authorized to access this project or it does not exist",
+				});
+			}
+			await assertServerInOrganization(
+				input.serverId ?? undefined,
+				ctx.session.activeOrganizationId,
+			);
 			await checkServiceAccess(ctx, environment.projectId, "create");
 
 			if (IS_CLOUD && !input.serverId) {

--- a/apps/dokploy/server/api/routers/domain.ts
+++ b/apps/dokploy/server/api/routers/domain.ts
@@ -37,6 +37,7 @@ import {
 	withPermission,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiCreateDomain,
 	apiFindCompose,
@@ -309,6 +310,14 @@ export const domainRouter = createTRPCRouter({
 	generateDomain: withPermission("domain", "create")
 		.input(z.object({ appName: z.string(), serverId: z.string().optional() }))
 		.mutation(async ({ input, ctx }) => {
+			// `generateTraefikMeDomain` reads the target server's ip and can SSH
+			// into it (`getRemotePublicIp`) when that ip is private, so an
+			// unscoped serverId is both a cross-org exec and an ip/existence
+			// oracle.
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			return generateTraefikMeDomain(
 				input.appName,
 				ctx.user.ownerId,
@@ -317,8 +326,14 @@ export const domainRouter = createTRPCRouter({
 		}),
 	canGenerateTraefikMeDomains: withPermission("domain", "read")
 		.input(z.object({ serverId: z.string() }))
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
 			if (input.serverId) {
+				// Returns the raw ip address of the server, so it must be scoped
+				// to the caller's organization.
+				await assertServerInOrganization(
+					input.serverId,
+					ctx.session.activeOrganizationId,
+				);
 				const server = await findServerById(input.serverId);
 				return server.ipAddress;
 			}

--- a/apps/dokploy/server/api/routers/network.ts
+++ b/apps/dokploy/server/api/routers/network.ts
@@ -19,6 +19,7 @@ import {
 	network as networkTable,
 } from "@/server/db/schema";
 import { audit } from "../utils/audit";
+import { assertServerInOrganization } from "../utils/server-org-scope";
 
 export const networkRouter = createTRPCRouter({
 	all: withPermission("network", "read")
@@ -51,6 +52,10 @@ export const networkRouter = createTRPCRouter({
 	create: withPermission("network", "create")
 		.input(apiCreateNetwork)
 		.mutation(async ({ ctx, input }) => {
+			await assertServerInOrganization(
+				input.serverId ?? undefined,
+				ctx.session.activeOrganizationId,
+			);
 			const created = await createNetwork(
 				input,
 				ctx.session.activeOrganizationId,
@@ -66,6 +71,10 @@ export const networkRouter = createTRPCRouter({
 	networksToSync: withPermission("network", "read")
 		.input(z.object({ serverId: z.string().optional() }))
 		.query(async ({ ctx, input }) => {
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			return findNetworksToSync(
 				ctx.session.activeOrganizationId,
 				input.serverId ?? null,
@@ -80,6 +89,10 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			const result = await importDockerNetworks(
 				ctx.session.activeOrganizationId,
 				input.serverId ?? null,

--- a/apps/dokploy/server/api/routers/server.ts
+++ b/apps/dokploy/server/api/routers/server.ts
@@ -32,6 +32,8 @@ import {
 	withPermission,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { resolveMetricsEndpoint } from "@/server/api/utils/metrics-endpoint";
+import { assertServerInOrganization } from "@/server/api/utils/server-org-scope";
 import {
 	apiCreateServer,
 	apiFindOneServer,
@@ -155,7 +157,13 @@ export const serverRouter = createTRPCRouter({
 	),
 	getDefaultCommand: withPermission("server", "read")
 		.input(apiFindOneServer)
-		.query(async ({ input }) => {
+		.query(async ({ ctx, input }) => {
+			// Reveals whether a serverId exists and whether it is a build server,
+			// so it has to be scoped to the caller's organization.
+			await assertServerInOrganization(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			const server = await findServerById(input.serverId);
 			const isBuildServer = server.serverType === "build";
 			return defaultCommand(isBuildServer);
@@ -566,18 +574,25 @@ export const serverRouter = createTRPCRouter({
 	getServerMetrics: withPermission("monitoring", "read")
 		.input(
 			z.object({
-				url: z.string(),
-				token: z.string(),
+				serverId: z.string().optional(),
 				dataPoints: z.string(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ ctx, input }) => {
+			// Endpoint + token come from the server row (or the web-server
+			// settings for the local host), never from the client -- see
+			// `resolveMetricsEndpoint` for the SSRF this closes. Resolved outside
+			// the try/catch so the authorization error is not reshaped.
+			const { baseUrl, token } = await resolveMetricsEndpoint(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			try {
-				const url = new URL(input.url);
+				const url = new URL(`${baseUrl}/metrics`);
 				url.searchParams.append("limit", input.dataPoints);
 				const response = await fetch(url.toString(), {
 					headers: {
-						Authorization: `Bearer ${input.token}`,
+						Authorization: `Bearer ${token}`,
 					},
 				});
 				if (!response.ok) {

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -38,6 +38,7 @@ import { and, asc, desc, eq, gt, ne } from "drizzle-orm";
 import { z } from "zod";
 import { apiKeyNameSchema } from "@/lib/api-keys";
 import { audit } from "@/server/api/utils/audit";
+import { resolveMetricsEndpoint } from "@/server/api/utils/metrics-endpoint";
 import {
 	adminProcedure,
 	createTRPCRouter,
@@ -538,13 +539,20 @@ export const userRouter = createTRPCRouter({
 	getContainerMetrics: withPermission("monitoring", "read")
 		.input(
 			z.object({
-				url: z.string(),
-				token: z.string(),
+				serverId: z.string().optional(),
 				appName: z.string(),
 				dataPoints: z.string(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ ctx, input }) => {
+			// Endpoint + token are derived from the (organization-scoped) server
+			// row instead of being taken from the client; see
+			// `resolveMetricsEndpoint`. Resolved outside the try/catch so the
+			// authorization error is not reshaped.
+			const { baseUrl, token } = await resolveMetricsEndpoint(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			try {
 				if (!input.appName) {
 					throw new Error(
@@ -555,12 +563,12 @@ export const userRouter = createTRPCRouter({
 						].join("\n"),
 					);
 				}
-				const url = new URL(`${input.url}/metrics/containers`);
+				const url = new URL(`${baseUrl}/metrics/containers`);
 				url.searchParams.append("limit", input.dataPoints);
 				url.searchParams.append("appName", input.appName);
 				const response = await fetch(url.toString(), {
 					headers: {
-						Authorization: `Bearer ${input.token}`,
+						Authorization: `Bearer ${token}`,
 					},
 				});
 				if (!response.ok) {

--- a/apps/dokploy/server/api/utils/metrics-endpoint.ts
+++ b/apps/dokploy/server/api/utils/metrics-endpoint.ts
@@ -1,0 +1,58 @@
+import { findServerById, getWebServerSettings } from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
+import { assertServerInOrganization } from "./server-org-scope";
+
+/**
+ * `server.getServerMetrics` and `user.getContainerMetrics` used to take the
+ * metrics `url` and bearer `token` straight from the client and `fetch()` them
+ * from the Dokploy host. That is a server-side request forgery primitive: any
+ * authenticated user holding `monitoring:read` could make the host issue a GET
+ * against an arbitrary internal address (other containers, cloud metadata
+ * endpoints, ...) and read the response body back through tRPC, with an
+ * attacker-chosen `Authorization` header attached.
+ *
+ * Both procedures now take a `serverId` instead and derive the endpoint from
+ * the stored row, so the URL can only ever be a Dokploy-managed monitoring
+ * endpoint inside the caller's own organization.
+ *
+ * Returns the endpoint *base* (`http://ip:port`); callers append their own path
+ * (`/metrics`, `/metrics/containers`).
+ */
+export const resolveMetricsEndpoint = async (
+	serverId: string | undefined,
+	activeOrganizationId: string | null | undefined,
+): Promise<{ baseUrl: string; token: string }> => {
+	const notConfigured = new TRPCError({
+		code: "BAD_REQUEST",
+		message:
+			"Monitoring is not configured for this server. Go to Settings → Servers → Setup Monitoring.",
+	});
+
+	if (serverId) {
+		// Fail-closed before any row is read: a cross-organization serverId must
+		// not even reveal whether monitoring is configured.
+		await assertServerInOrganization(serverId, activeOrganizationId);
+		const server = await findServerById(serverId);
+		const port = server.metricsConfig?.server?.port;
+		const token = server.metricsConfig?.server?.token;
+		if (!server.ipAddress || !port || !token) {
+			throw notConfigured;
+		}
+		return { baseUrl: `http://${server.ipAddress}:${port}`, token };
+	}
+
+	// Local Dokploy host. `pnpm dev` runs the metrics collector as a standalone
+	// stub on localhost:3001 with a fixed token; this mirrors the dev-only
+	// endpoint the monitoring page used to hardcode client-side.
+	if (process.env.NODE_ENV !== "production") {
+		return { baseUrl: "http://localhost:3001", token: "metrics" };
+	}
+
+	const settings = await getWebServerSettings();
+	const port = settings?.metricsConfig?.server?.port;
+	const token = settings?.metricsConfig?.server?.token;
+	if (!settings?.serverIp || !port || !token) {
+		throw notConfigured;
+	}
+	return { baseUrl: `http://${settings.serverIp}:${port}`, token };
+};

--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -2,7 +2,7 @@ import { db } from "@dokploy/server/db";
 import { member, organizationRole } from "@dokploy/server/db/schema";
 import { hasValidLicense } from "@dokploy/server/services/proprietary/license-key";
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
 	ac,
 	adminRole,
@@ -241,6 +241,89 @@ export const checkProjectAccess = async (
 	}
 };
 
+/**
+ * Every deployable service (application, compose and the seven database
+ * flavours) hangs off `environment -> project -> organization`, and the id
+ * columns are globally unique, so a single query resolves the owning
+ * organization of an opaque service id without the caller having to know its
+ * type.
+ *
+ * Returns `null` when the id matches no service at all, which callers must
+ * treat exactly like "belongs to another organization" so the check cannot be
+ * used as an existence oracle.
+ */
+export const findServiceOrganizationId = async (
+	serviceId: string,
+): Promise<string | null> => {
+	if (!serviceId) {
+		return null;
+	}
+	const rows = await db.execute(sql`
+		SELECT p."organizationId" AS "organizationId"
+		FROM "environment" e
+		INNER JOIN "project" p ON p."projectId" = e."projectId"
+		WHERE e."environmentId" IN (
+			SELECT "environmentId" FROM "application" WHERE "applicationId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "compose" WHERE "composeId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "postgres" WHERE "postgresId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "mysql" WHERE "mysqlId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "mariadb" WHERE "mariadbId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "mongo" WHERE "mongoId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "redis" WHERE "redisId" = ${serviceId}
+			UNION ALL
+			SELECT "environmentId" FROM "libsql" WHERE "libsqlId" = ${serviceId}
+		)
+		LIMIT 1
+	`);
+	// postgres-js returns a row array directly; be defensive about the
+	// `{ rows: [] }` shape other drivers use so this keeps working if the
+	// driver is ever swapped.
+	const result = rows as unknown;
+	const list = (
+		Array.isArray(result)
+			? result
+			: ((result as { rows?: unknown[] } | null)?.rows ?? [])
+	) as { organizationId?: string }[];
+	return list[0]?.organizationId ?? null;
+};
+
+/**
+ * Fail-closed row-level organization scope for an arbitrary service id.
+ *
+ * `checkPermission` only proves the caller holds a permission *inside their
+ * active organization*; it says nothing about the id they passed in. Owners and
+ * admins additionally short-circuit the `accessedServices` allow-list, so
+ * without this assertion an owner of organization A could deploy, stop, read
+ * logs of, or rewrite env vars on organization B's services simply by passing
+ * their id.
+ *
+ * A missing service and a cross-organization service produce the identical
+ * UNAUTHORIZED error (mirroring `mount.listByServiceId`) so no existence oracle
+ * is introduced.
+ */
+export const assertServiceInOrganization = async (
+	serviceId: string,
+	organizationId: string,
+) => {
+	const serviceOrganizationId = await findServiceOrganizationId(serviceId);
+	if (
+		serviceOrganizationId === null ||
+		serviceOrganizationId !== organizationId
+	) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message:
+				"You are not authorized to access this service or it does not exist",
+		});
+	}
+};
+
 export const checkServicePermissionAndAccess = async (
 	ctx: PermissionCtx,
 	serviceId: string,
@@ -258,6 +341,12 @@ export const checkServicePermissionAndAccess = async (
 			});
 		}
 	}
+	// Runs for every role, including owner/admin, and after the member
+	// allow-list check so the member-path error message is unchanged. An
+	// `accessedServices` entry is not proof of organization membership either:
+	// nothing validates the ids an admin assigns through
+	// `user.assignPermissions`.
+	await assertServiceInOrganization(serviceId, organizationId);
 };
 
 export const checkServiceAccess = async (


### PR DESCRIPTION
Wave 3 of the cross-organization authorization sweep, after #191 (settings) and #192 (certificate / registry / destination / patch + the canonical `assertServerInOrganization` helper).

Every claim below was re-verified against the code on `canary` before fixing; the "differs from the brief" notes at the bottom list where reality was different.

## Findings

| # | Hole (verified) | Fix | Test |
|---|---|---|---|
| 1 | `checkServicePermissionAndAccess` (`packages/server/src/services/permission.ts`) never proved the target service belongs to `activeOrganizationId`. Owner/admin skip the `accessedServices` allow-list entirely, so **an owner of org A could deploy / start / stop / read logs of / rewrite env vars on org B's services by passing their id**. | Resolve the service's organization for **all** roles and fail closed. | `service-access.test.ts` — owner cross-org, admin cross-org, unknown id, owner same-org (positive), member with a foreign id in `accessedServices`, member-path message unchanged. |
| 2 | `network.create` / `network.import` / `networksToSync` took `serverId` straight to `getRemoteDocker(serverId)` (list/create/import Docker networks on another org's host). | `assertServerInOrganization` before each. | `routers-org-scope-wave3.test.ts` — cross-org rejected + `createNetwork` / `importDockerNetworks` / `findNetworksToSync` never called; same-org allowed; local (no serverId) path still skips the lookup. |
| 3 | `domain.generateDomain` → `generateTraefikMeDomain` reads the server's `ipAddress` and **SSHes into it** (`getRemotePublicIp`) when that ip is private. `domain.canGenerateTraefikMeDomains` returns the raw `ipAddress` of any `serverId`. | `assertServerInOrganization` on both. | Cross-org rejected + `generateTraefikMeDomain` never called; same-org returns the ip. |
| 4a | `ai.deploy` only called `checkServiceAccess(ctx, projectId, "create")`, which consults `accessedProjects` and short-circuits for owner/admin — the target project and `serverId` were never organization-checked before `createComposeByTemplate`. | Explicit `project.organizationId` check + `assertServerInOrganization`, both before the existing `checkServiceAccess`. | Cross-org project rejected, cross-org server rejected, `createComposeByTemplate` never called; same-org positive control. |
| 4b | `ai.suggest` → `suggestVariants` used the provider credentials behind an unscoped `aiId` and read the ip behind an unscoped `serverId`. | Scope both, **outside** the `try/catch` that flattens everything to `BAD_REQUEST`. | Cross-org `aiId` → `NOT_FOUND`, cross-org `serverId` → `UNAUTHORIZED`, `suggestVariants` never called; same-org positive control. |
| 4c | `server.getDefaultCommand` leaked whether a `serverId` exists and whether it is a build server. | `assertServerInOrganization`. | Cross-org rejected, same-org returns the command. |
| 5 | `server.getServerMetrics` and `user.getContainerMetrics` did `fetch(input.url, { Authorization: Bearer ${input.token} })` — **SSRF**: any user with `monitoring:read` could make the Dokploy host GET an arbitrary internal address (other containers, `169.254.169.254`, …) with an attacker-chosen bearer header, and read the response body back through tRPC. | Input is now `serverId` (optional) and the endpoint + token are derived from the server row (or web-server settings for the local host) after org-scoping. | Cross-org `serverId` → `UNAUTHORIZED` **and `fetch` never called**; same-org asserts the exact derived URL + `Bearer` token; a negative control passes an attacker `url`/`token` alongside a valid `serverId` and asserts the derived endpoint is used and `169.254.169.254` is never fetched. |

## Extra holes found while auditing (same routers, same class)

These were not in the brief but are the same bug in the same files, so they are fixed here:

- **`ai.one` / `ai.get`** — `adminProcedure` + `getAiSettingById(aiId)` (primary-key lookup, no org filter) returned the full row **including `apiKey`** for any organization's provider.
- **`ai.delete`** — deleted any organization's provider by id.
- **`ai.update`** — `saveAiSettings` does `insert(...).onConflictDoUpdate({ target: ai.aiId })`, so an admin could **overwrite another organization's provider** (name, apiUrl, apiKey, model) by passing its `aiId`.
- **`ai.analyzeLogs`** — it *did* have an org check, but it sat **inside** a `try/catch` that rewrites every error to `BAD_REQUEST`, so the `FORBIDDEN` never reached the client. Moved out (wave-2 lesson: guards must run outside error-rewriting `try/catch`).

All four now go through a single `findAiSettingInOrganization` helper that collapses "missing" and "other org" into the same `NOT_FOUND`.

## Blast-radius analysis: `checkServicePermissionAndAccess`

This helper gates ~200 call sites across 22 files (application 26, compose 23, backup 13, redis/postgres/mysql/mongo/mariadb/domain 12 each, patch/libsql 11, preview-deployment 8, deployment 7, volume-backups/schedule 6, mount 5, security/redirects/port 4, backup-policy 3, rollbacks 2, `proprietary/forward-auth.ts` 2). Enumerating every call site showed:

1. **Every argument is a deployable-service id.** The second argument is always `applicationId`, `composeId`, `postgresId`, `mysqlId`, `mariadbId`, `mongoId`, `redisId`, `libsqlId`, or a variable derived from one of those (`resolvePatchServiceId(patch)`, `vb.applicationId || vb.postgresId || …`, `backup.postgresId || …`, `schedule.applicationId || schedule.composeId`, `previewDeployment.composeId ?? previewDeployment.applicationId`, …). No caller passes a `previewDeploymentId`, `projectId`, `environmentId` or `serverId`, so a single resolver covering the eight service tables is complete.
2. **Query cost: exactly one extra query per call, not N.** The eight tables all carry `environmentId` and their id columns are globally unique, so one statement resolves any of them:
   `environment ⨝ project` where `environmentId IN (SELECT … FROM application WHERE applicationId = $1 UNION ALL … × 8)`. All predicates are primary-key lookups. No call site was changed, and no caller had the organization already in hand (the ones that do — e.g. `mount.listByServiceId` — do their own check on top and are untouched).
3. **Member path is behaviourally unchanged.** The new assertion runs *after* the `accessedServices` allow-list check, so a member who simply lacks access still gets the exact same `"You don't have access to this service"` error (covered by an explicit ordering test). The new check only additionally rejects a member whose `accessedServices` contains a foreign id — `user.assignPermissions` does not validate the ids an admin assigns, so allow-list membership is not proof of organization membership.
4. **No new existence oracle.** A non-existent id and a cross-organization id produce the identical `UNAUTHORIZED` / `"You are not authorized to access this service or it does not exist"`, matching the established sibling `mount.listByServiceId`.
5. **Graceful-degradation call sites still degrade.** `backup-policy.coverage` wraps the helper in `try/catch` and skips rows the caller cannot reach; a cross-org row now simply drops out of the coverage tree instead of throwing.
6. **Out-of-scope files inherit the fix without being edited.** `preview-deployment.ts` and the github/gitlab providers/routers were not touched (PR #195 is active there), but their existing `checkServicePermissionAndAccess` calls are hardened automatically.

## Metrics SSRF: why derivation, not validation

The brief allowed a fallback to "validate the URL matches the stored one" if the UI surgery was too large. It wasn't — the client already knew the `serverId` at every call site, so full derivation was possible:

- `show-paid-monitoring.tsx`: props `BASE_URL`/`token` → `serverId?`.
- `show-paid-container-monitoring.tsx`: props `baseUrl`/`token` → `serverId?`.
- `show-paid-compose-monitoring.tsx`: dropped `baseUrl`/`token` (it already had `serverId`).
- `show-monitoring-modal.tsx` + `show-servers.tsx`: `url`/`token` → `serverId={server.serverId}`.
- `pages/dashboard/monitoring.tsx`: dropped the client-side `resolveMetricsEndpoint` helper and the hardcoded `BASE_URL`/`DEFAULT_TOKEN`; still queries `getMonitoringConfig` to render the "Monitoring is not configured" hint before firing a metrics request.
- 7 service pages (application, libsql, mariadb, mongo, mysql, postgres, redis) + compose: the `baseUrl={…metricsConfig.server.port}` / `token={…metricsConfig.server.token}` pair collapses to `serverId={data?.serverId ?? undefined}`.

Server side, `apps/dokploy/server/api/utils/metrics-endpoint.ts` returns the endpoint *base* (`http://ip:port`) and the token: for a `serverId` it org-scopes first and then reads `server.metricsConfig.server.{port,token}`; without one it uses `getWebServerSettings()`. A missing config raises a `BAD_REQUEST` that points at Settings → Servers → Setup Monitoring.

Two small behaviour notes:
- The **dev stub is preserved but narrowed**. The old page sent `http://localhost:3001/metrics` + token `metrics` in non-production *regardless of which server was selected*. The helper keeps that stub only for the **local host** path; selecting a remote server in dev now points at its real ip:port (which is what production already did). Dev-only convenience, documented in the helper.
- The two components used to render `URL: {baseUrl}` inside their error state. The client no longer knows the URL, so that line is dropped — it was also the one place the internal metrics endpoint was echoed into the DOM.

## Already guarded / differs from the briefing

- **`domain.certificateResolvers`** already had an inline `server.organizationId !== activeOrganizationId` check. Left as-is (not converted to the helper) to keep the diff focused.
- **`network.all` and `network.one`/`inspect`/`recreate`/`remove`** are already organization-scoped (`all` filters on `network.organizationId`; the rest compare `findNetworkById(...).organizationId`). Only `create`, `import` and `networksToSync` were unguarded. `network.all` takes a `serverId` but only uses it as a **DB filter** on already-org-scoped rows, so it is not a leak and did not get an extra query.
- **`user.getServerMetrics`** (distinct from `server.getServerMetrics`) takes no input and just returns the caller's own member/user row — not an oracle, untouched.
- **`server.getMonitoringConfig`** already collapses missing/foreign servers into one `NOT_FOUND`; the new metrics path is consistent with it.
- **`ai.deploy`'s existing `checkServiceAccess(ctx, environment.projectId, "create")`** is kept — the new checks are additive, not a replacement.
- **`checkServiceAccess` / `checkProjectAccess` / `checkEnvironmentAccess`** have the *same* owner/admin short-circuit shape and are **not** fixed here (they take project/environment ids, which need a different resolver). `ai.deploy` is guarded explicitly instead. Worth a wave 4.
- `__test__/setup.ts` gained a `db.execute` mock (defaults to "no rows") because the global DB mock had no raw-SQL escape hatch.

## Out of scope (untouched, as instructed)

`previewDeployment.create` author-gate / preview-limit off-by-one and the github/gitlab providers & routers — PR #195 is active there. Routers already verified correct in earlier waves (docker*, cluster, swarm, forward-auth, schedule, deployment) were not re-touched.

## Validation

- `pnpm --filter=dokploy typecheck` — clean.
- `pnpm --filter=@dokploy/server build` — clean (`packages/server/package.json` restored after `switch:prod`).
- `vitest __test__/permissions` — 10 files / 112 tests green, including the wave-1 and wave-2 suites (`check-permission`, `resolve-permissions`, `server-access-scope`, `settings-server-org-scope`, `routers-server-org-scope`) to prove no regression.
- Full suite: 1538 passed / 10 failed, and those 10 were verified failing identically on a clean `origin/canary` checkout of the same worktree (`application.real.test.ts` real-git-clone, `server-setup.test.ts` `command -v`, `readValidDirectory` path separators, `restore-use-statement` — all Windows-local, not related to this change).
- `biome format` is clean on every file this PR touches (the only remaining reports in the repo are pre-existing CRLF-only diffs on files this PR does not modify).

No migrations.
