### PR TITLE
fix(security): org-scope project, service and environment access helpers (wave 4)

### DIFF
--- a/apps/dokploy/__test__/permissions/access-helpers-org-scope.test.ts
+++ b/apps/dokploy/__test__/permissions/access-helpers-org-scope.test.ts
@@ -1,0 +1,471 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Wave 4 of the cross-organization id sweep.
+ *
+ * `checkProjectAccess`, `checkServiceAccess`, `checkEnvironmentAccess`,
+ * `checkEnvironmentCreationPermission` and `checkEnvironmentDeletionPermission`
+ * all shared the same shape: `checkPermission` proves the caller holds a role
+ * inside their *active* organization, and the `accessedProjects` /
+ * `accessedServices` / `accessedEnvironments` allow-list was only consulted for
+ * plain members. Owners and admins therefore passed with an id belonging to a
+ * different organization, and an allow-list entry was never proof of
+ * organization membership either (nothing validates the ids an admin assigns
+ * through `user.assignPermissions`).
+ */
+const mocks = vi.hoisted(() => ({
+	memberFindFirst: vi.fn(),
+	organizationRoleFindMany: vi.fn(),
+	projectFindFirst: vi.fn(),
+	environmentFindFirst: vi.fn(),
+	execute: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		// Raw SQL escape hatch used by the wave 3 service -> organization resolver.
+		execute: mocks.execute,
+		query: {
+			member: {
+				findFirst: mocks.memberFindFirst,
+				findMany: vi.fn(() => Promise.resolve([])),
+			},
+			organizationRole: {
+				findFirst: vi.fn(),
+				findMany: mocks.organizationRoleFindMany,
+			},
+			projects: {
+				findFirst: mocks.projectFindFirst,
+			},
+			environments: {
+				findFirst: mocks.environmentFindFirst,
+			},
+		},
+	},
+}));
+
+vi.mock("@dokploy/server/services/proprietary/license-key", () => ({
+	hasValidLicense: vi.fn(() => Promise.resolve(false)),
+}));
+
+const {
+	checkProjectAccess,
+	checkServiceAccess,
+	checkEnvironmentAccess,
+	checkEnvironmentCreationPermission,
+	checkEnvironmentDeletionPermission,
+} = await import("@dokploy/server/services/permission");
+
+const mockMemberData = (
+	role: string,
+	overrides: Partial<{
+		accessedProjects: string[];
+		accessedServices: string[];
+		accessedEnvironments: string[];
+		canCreateProjects: boolean;
+		canDeleteProjects: boolean;
+		canCreateServices: boolean;
+		canDeleteServices: boolean;
+		canCreateEnvironments: boolean;
+		canDeleteEnvironments: boolean;
+	}> = {},
+) => ({
+	id: "member-1",
+	role,
+	userId: "user-1",
+	organizationId: "org-1",
+	accessedProjects: [] as string[],
+	accessedServices: [] as string[],
+	accessedEnvironments: [] as string[],
+	canCreateProjects: false,
+	canDeleteProjects: false,
+	canCreateServices: false,
+	canDeleteServices: false,
+	canCreateEnvironments: false,
+	canDeleteEnvironments: false,
+	canAccessToTraefikFiles: false,
+	canAccessToDocker: false,
+	canAccessToAPI: false,
+	canAccessToSSHKeys: false,
+	canAccessToGitProviders: false,
+	user: { id: "user-1", email: "test@test.com" },
+	...overrides,
+});
+
+let memberToReturn = mockMemberData("owner");
+
+/** Organization each resolver reports; `null` models "no such row exists". */
+let projectOrganizationId: string | null = "org-1";
+let environmentOrganizationId: string | null = "org-1";
+let serviceOrganizationId: string | null = "org-1";
+
+const ctx = {
+	user: { id: "user-1" },
+	session: { activeOrganizationId: "org-1" },
+};
+
+const projectMessage =
+	"You are not authorized to access this project or it does not exist";
+const environmentMessage =
+	"You are not authorized to access this environment or it does not exist";
+const serviceMessage =
+	"You are not authorized to access this service or it does not exist";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	memberToReturn = mockMemberData("owner");
+	projectOrganizationId = "org-1";
+	environmentOrganizationId = "org-1";
+	serviceOrganizationId = "org-1";
+
+	mocks.memberFindFirst.mockImplementation(() =>
+		Promise.resolve(memberToReturn),
+	);
+	mocks.organizationRoleFindMany.mockImplementation(() => Promise.resolve([]));
+	mocks.projectFindFirst.mockImplementation(() =>
+		Promise.resolve(
+			projectOrganizationId === null
+				? undefined
+				: { organizationId: projectOrganizationId },
+		),
+	);
+	mocks.environmentFindFirst.mockImplementation(() =>
+		Promise.resolve(
+			environmentOrganizationId === null
+				? undefined
+				: {
+						environmentId: "env-1",
+						project: { organizationId: environmentOrganizationId },
+					},
+		),
+	);
+	mocks.execute.mockImplementation(() =>
+		Promise.resolve(
+			serviceOrganizationId === null
+				? []
+				: [{ organizationId: serviceOrganizationId }],
+		),
+	);
+});
+
+describe("checkProjectAccess is organization-scoped", () => {
+	it("allows an owner passing a project from their own organization", async () => {
+		await expect(
+			checkProjectAccess(ctx, "delete", "project-1"),
+		).resolves.toBeUndefined();
+		expect(mocks.projectFindFirst).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an owner passing a project from another organization", async () => {
+		projectOrganizationId = "org-2";
+		await expect(checkProjectAccess(ctx, "delete", "project-1")).rejects.toThrow(
+			projectMessage,
+		);
+	});
+
+	it("rejects an admin passing a project from another organization", async () => {
+		memberToReturn = mockMemberData("admin");
+		projectOrganizationId = "org-2";
+		await expect(checkProjectAccess(ctx, "delete", "project-1")).rejects.toThrow(
+			projectMessage,
+		);
+	});
+
+	it("gives a non-existent project the same error as a foreign one (no existence oracle)", async () => {
+		projectOrganizationId = null;
+		await expect(
+			checkProjectAccess(ctx, "delete", "project-does-not-exist"),
+		).rejects.toThrow(projectMessage);
+	});
+
+	it("does not query when no project id is supplied", async () => {
+		await expect(checkProjectAccess(ctx, "create")).resolves.toBeUndefined();
+		expect(mocks.projectFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("keeps the member allow-list error when the member simply lacks access", async () => {
+		memberToReturn = mockMemberData("member", {
+			canDeleteProjects: true,
+			accessedProjects: [],
+		});
+		await expect(checkProjectAccess(ctx, "delete", "project-1")).rejects.toThrow(
+			"You don't have access to this project",
+		);
+		// Ordering control: the allow-list rejects before the organization
+		// resolver runs, so the member-facing message is unchanged.
+		expect(mocks.projectFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("allows a member whose allow-list lists a same-organization project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canDeleteProjects: true,
+			accessedProjects: ["project-1"],
+		});
+		await expect(
+			checkProjectAccess(ctx, "delete", "project-1"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a member whose allow-list lists a foreign project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canDeleteProjects: true,
+			accessedProjects: ["project-1"],
+		});
+		projectOrganizationId = "org-2";
+		await expect(checkProjectAccess(ctx, "delete", "project-1")).rejects.toThrow(
+			projectMessage,
+		);
+	});
+});
+
+describe("checkServiceAccess is organization-scoped", () => {
+	it("allows an owner reading a service from their own organization", async () => {
+		await expect(
+			checkServiceAccess(ctx, "service-1", "read"),
+		).resolves.toBeUndefined();
+		expect(mocks.execute).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an owner reading a service from another organization", async () => {
+		serviceOrganizationId = "org-2";
+		await expect(checkServiceAccess(ctx, "service-1", "read")).rejects.toThrow(
+			serviceMessage,
+		);
+	});
+
+	it("rejects an owner deleting a service from another organization", async () => {
+		serviceOrganizationId = "org-2";
+		await expect(checkServiceAccess(ctx, "service-1", "delete")).rejects.toThrow(
+			serviceMessage,
+		);
+	});
+
+	it("gives a non-existent service the same error as a foreign one (no existence oracle)", async () => {
+		serviceOrganizationId = null;
+		await expect(
+			checkServiceAccess(ctx, "service-does-not-exist", "read"),
+		).rejects.toThrow(serviceMessage);
+	});
+
+	it("scopes the create action through the PROJECT resolver", async () => {
+		// On "create" the second parameter is a project id, not a service id.
+		await expect(
+			checkServiceAccess(ctx, "project-1", "create"),
+		).resolves.toBeUndefined();
+		expect(mocks.projectFindFirst).toHaveBeenCalledTimes(1);
+		expect(mocks.execute).not.toHaveBeenCalled();
+	});
+
+	it("rejects an owner creating a service under a foreign project", async () => {
+		projectOrganizationId = "org-2";
+		await expect(checkServiceAccess(ctx, "project-1", "create")).rejects.toThrow(
+			projectMessage,
+		);
+	});
+
+	it("keeps the member allow-list error when the member simply lacks the service", async () => {
+		memberToReturn = mockMemberData("member", { accessedServices: [] });
+		await expect(checkServiceAccess(ctx, "service-1", "read")).rejects.toThrow(
+			"You don't have access to this service",
+		);
+		expect(mocks.execute).not.toHaveBeenCalled();
+	});
+
+	it("keeps the member allow-list error when the member simply lacks the project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canCreateServices: true,
+			accessedProjects: [],
+		});
+		await expect(checkServiceAccess(ctx, "project-1", "create")).rejects.toThrow(
+			"You don't have access to this project",
+		);
+		expect(mocks.projectFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("allows a member whose allow-list lists a same-organization service", async () => {
+		memberToReturn = mockMemberData("member", {
+			accessedServices: ["service-1"],
+		});
+		await expect(
+			checkServiceAccess(ctx, "service-1", "read"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a member whose allow-list lists a foreign service", async () => {
+		memberToReturn = mockMemberData("member", {
+			accessedServices: ["service-1"],
+		});
+		serviceOrganizationId = "org-2";
+		await expect(checkServiceAccess(ctx, "service-1", "read")).rejects.toThrow(
+			serviceMessage,
+		);
+	});
+});
+
+describe("checkEnvironmentAccess is organization-scoped", () => {
+	it("allows an owner passing an environment from their own organization", async () => {
+		await expect(
+			checkEnvironmentAccess(ctx, "env-1", "read"),
+		).resolves.toBeUndefined();
+		expect(mocks.environmentFindFirst).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an owner passing an environment from another organization", async () => {
+		environmentOrganizationId = "org-2";
+		await expect(checkEnvironmentAccess(ctx, "env-1", "read")).rejects.toThrow(
+			environmentMessage,
+		);
+	});
+
+	it("rejects an admin passing an environment from another organization", async () => {
+		memberToReturn = mockMemberData("admin");
+		environmentOrganizationId = "org-2";
+		await expect(checkEnvironmentAccess(ctx, "env-1", "read")).rejects.toThrow(
+			environmentMessage,
+		);
+	});
+
+	it("gives a non-existent environment the same error as a foreign one (no existence oracle)", async () => {
+		environmentOrganizationId = null;
+		await expect(
+			checkEnvironmentAccess(ctx, "env-does-not-exist", "read"),
+		).rejects.toThrow(environmentMessage);
+	});
+
+	it("keeps the member allow-list error when the member simply lacks access", async () => {
+		memberToReturn = mockMemberData("member", { accessedEnvironments: [] });
+		await expect(checkEnvironmentAccess(ctx, "env-1", "read")).rejects.toThrow(
+			"You don't have access to this environment",
+		);
+		expect(mocks.environmentFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("allows a member whose allow-list lists a same-organization environment", async () => {
+		memberToReturn = mockMemberData("member", {
+			accessedEnvironments: ["env-1"],
+		});
+		await expect(
+			checkEnvironmentAccess(ctx, "env-1", "read"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a member whose allow-list lists a foreign environment", async () => {
+		memberToReturn = mockMemberData("member", {
+			accessedEnvironments: ["env-1"],
+		});
+		environmentOrganizationId = "org-2";
+		await expect(checkEnvironmentAccess(ctx, "env-1", "read")).rejects.toThrow(
+			environmentMessage,
+		);
+	});
+});
+
+describe("checkEnvironmentCreationPermission is organization-scoped", () => {
+	it("allows an owner passing a project from their own organization", async () => {
+		await expect(
+			checkEnvironmentCreationPermission(ctx, "project-1"),
+		).resolves.toBeUndefined();
+		expect(mocks.projectFindFirst).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an owner passing a project from another organization", async () => {
+		projectOrganizationId = "org-2";
+		await expect(
+			checkEnvironmentCreationPermission(ctx, "project-1"),
+		).rejects.toThrow(projectMessage);
+	});
+
+	it("gives a non-existent project the same error as a foreign one (no existence oracle)", async () => {
+		projectOrganizationId = null;
+		await expect(
+			checkEnvironmentCreationPermission(ctx, "project-does-not-exist"),
+		).rejects.toThrow(projectMessage);
+	});
+
+	it("keeps the member allow-list error when the member simply lacks access", async () => {
+		memberToReturn = mockMemberData("member", {
+			canCreateEnvironments: true,
+			accessedProjects: [],
+		});
+		await expect(
+			checkEnvironmentCreationPermission(ctx, "project-1"),
+		).rejects.toThrow("You don't have access to this project");
+		expect(mocks.projectFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("allows a member whose allow-list lists a same-organization project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canCreateEnvironments: true,
+			accessedProjects: ["project-1"],
+		});
+		await expect(
+			checkEnvironmentCreationPermission(ctx, "project-1"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a member whose allow-list lists a foreign project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canCreateEnvironments: true,
+			accessedProjects: ["project-1"],
+		});
+		projectOrganizationId = "org-2";
+		await expect(
+			checkEnvironmentCreationPermission(ctx, "project-1"),
+		).rejects.toThrow(projectMessage);
+	});
+});
+
+describe("checkEnvironmentDeletionPermission is organization-scoped", () => {
+	it("allows an owner passing a project from their own organization", async () => {
+		await expect(
+			checkEnvironmentDeletionPermission(ctx, "project-1"),
+		).resolves.toBeUndefined();
+		expect(mocks.projectFindFirst).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an owner passing a project from another organization", async () => {
+		projectOrganizationId = "org-2";
+		await expect(
+			checkEnvironmentDeletionPermission(ctx, "project-1"),
+		).rejects.toThrow(projectMessage);
+	});
+
+	it("gives a non-existent project the same error as a foreign one (no existence oracle)", async () => {
+		projectOrganizationId = null;
+		await expect(
+			checkEnvironmentDeletionPermission(ctx, "project-does-not-exist"),
+		).rejects.toThrow(projectMessage);
+	});
+
+	it("keeps the member allow-list error when the member simply lacks access", async () => {
+		memberToReturn = mockMemberData("member", {
+			canDeleteEnvironments: true,
+			accessedProjects: [],
+		});
+		await expect(
+			checkEnvironmentDeletionPermission(ctx, "project-1"),
+		).rejects.toThrow("You don't have access to this project");
+		expect(mocks.projectFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("allows a member whose allow-list lists a same-organization project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canDeleteEnvironments: true,
+			accessedProjects: ["project-1"],
+		});
+		await expect(
+			checkEnvironmentDeletionPermission(ctx, "project-1"),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a member whose allow-list lists a foreign project", async () => {
+		memberToReturn = mockMemberData("member", {
+			canDeleteEnvironments: true,
+			accessedProjects: ["project-1"],
+		});
+		projectOrganizationId = "org-2";
+		await expect(
+			checkEnvironmentDeletionPermission(ctx, "project-1"),
+		).rejects.toThrow(projectMessage);
+	});
+});

--- a/apps/dokploy/__test__/permissions/service-access.test.ts
+++ b/apps/dokploy/__test__/permissions/service-access.test.ts
@@ -36,6 +36,12 @@ let memberToReturn: ReturnType<typeof mockMemberData> =
  */
 let serviceOrganizationId: string | null = "org-1";
 
+/**
+ * Wave 4: `checkServiceAccess(..., "create")` receives a *project* id, so it is
+ * scoped through the project resolver instead.
+ */
+let projectOrganizationId: string | null = "org-1";
+
 vi.mock("@dokploy/server/db", () => ({
 	db: {
 		execute: vi.fn(() =>
@@ -53,6 +59,15 @@ vi.mock("@dokploy/server/db", () => ({
 			organizationRole: {
 				findFirst: vi.fn(),
 				findMany: vi.fn(() => Promise.resolve([])),
+			},
+			projects: {
+				findFirst: vi.fn(() =>
+					Promise.resolve(
+						projectOrganizationId === null
+							? undefined
+							: { organizationId: projectOrganizationId },
+					),
+				),
 			},
 		},
 	},
@@ -74,6 +89,7 @@ const ctx = {
 beforeEach(() => {
 	vi.clearAllMocks();
 	serviceOrganizationId = "org-1";
+	projectOrganizationId = "org-1";
 });
 
 describe("checkServicePermissionAndAccess", () => {

--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -1,5 +1,10 @@
 import { db } from "@dokploy/server/db";
-import { member, organizationRole } from "@dokploy/server/db/schema";
+import {
+	environments,
+	member,
+	organizationRole,
+	projects,
+} from "@dokploy/server/db/schema";
 import { hasValidLicense } from "@dokploy/server/services/proprietary/license-key";
 import { TRPCError } from "@trpc/server";
 import { and, eq, sql } from "drizzle-orm";
@@ -215,6 +220,100 @@ export const resolvePermissions = async (
 	return result;
 };
 
+/**
+ * `project` carries `organizationId` directly, so a single row lookup resolves
+ * the owning organization of an opaque project id.
+ *
+ * Returns `null` when no project matches, which callers must treat exactly like
+ * "belongs to another organization" so the check cannot be used as an existence
+ * oracle.
+ */
+export const findProjectOrganizationId = async (
+	projectId: string,
+): Promise<string | null> => {
+	if (!projectId) {
+		return null;
+	}
+	const row = await db.query.projects.findFirst({
+		where: eq(projects.projectId, projectId),
+		columns: { organizationId: true },
+	});
+	return row?.organizationId ?? null;
+};
+
+/**
+ * Fail-closed row-level organization scope for an arbitrary project id.
+ *
+ * Mirrors `assertServiceInOrganization`: a missing project and a
+ * cross-organization project produce the identical UNAUTHORIZED error.
+ */
+export const assertProjectInOrganization = async (
+	projectId: string,
+	organizationId: string,
+) => {
+	const projectOrganizationId = await findProjectOrganizationId(projectId);
+	if (
+		projectOrganizationId === null ||
+		projectOrganizationId !== organizationId
+	) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message:
+				"You are not authorized to access this project or it does not exist",
+		});
+	}
+};
+
+/**
+ * Environments hang off `project`, which owns `organizationId`, so the relation
+ * resolves the owning organization of an opaque environment id.
+ *
+ * Returns `null` when no environment matches, which callers must treat exactly
+ * like "belongs to another organization" so the check cannot be used as an
+ * existence oracle.
+ */
+export const findEnvironmentOrganizationId = async (
+	environmentId: string,
+): Promise<string | null> => {
+	if (!environmentId) {
+		return null;
+	}
+	const row = await db.query.environments.findFirst({
+		where: eq(environments.environmentId, environmentId),
+		columns: { environmentId: true },
+		with: {
+			project: {
+				columns: { organizationId: true },
+			},
+		},
+	});
+	return row?.project?.organizationId ?? null;
+};
+
+/**
+ * Fail-closed row-level organization scope for an arbitrary environment id.
+ *
+ * Mirrors `assertServiceInOrganization`: a missing environment and a
+ * cross-organization environment produce the identical UNAUTHORIZED error.
+ */
+export const assertEnvironmentInOrganization = async (
+	environmentId: string,
+	organizationId: string,
+) => {
+	const environmentOrganizationId =
+		await findEnvironmentOrganizationId(environmentId);
+	if (
+		environmentOrganizationId === null ||
+		environmentOrganizationId !== organizationId
+	) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message:
+				"You are not authorized to access this environment or it does not exist",
+		});
+	}
+};
+
 export const checkProjectAccess = async (
 	ctx: PermissionCtx,
 	action: "create" | "delete",
@@ -238,6 +337,13 @@ export const checkProjectAccess = async (
 				message: "You don't have access to this project",
 			});
 		}
+	}
+
+	// Runs for every role, including owner/admin, and after the member
+	// allow-list check so the member-path error message is unchanged. Callers
+	// that pass no project id (the `create` path) have nothing to scope.
+	if (projectId) {
+		await assertProjectInOrganization(projectId, organizationId);
 	}
 };
 
@@ -377,6 +483,17 @@ export const checkServiceAccess = async (
 			}
 		}
 	}
+
+	// Runs for every role, including owner/admin, and after the member
+	// allow-list check so the member-path error messages are unchanged. On the
+	// `create` action the second parameter is a *project* id (that is what the
+	// member branch above compares against `accessedProjects`, and what every
+	// call site passes), so it has to be scoped with the project resolver.
+	if (action === "create") {
+		await assertProjectInOrganization(serviceId, organizationId);
+	} else {
+		await assertServiceInOrganization(serviceId, organizationId);
+	}
 };
 
 export const checkEnvironmentAccess = async (
@@ -402,6 +519,13 @@ export const checkEnvironmentAccess = async (
 			});
 		}
 	}
+
+	// Runs for every role, including owner/admin, and after the member
+	// allow-list check so the member-path error message is unchanged. The
+	// second parameter is an environment id for every action (no call site uses
+	// the `create` action, which only skips the member allow-list), so the
+	// environment resolver scopes all of them.
+	await assertEnvironmentInOrganization(environmentId, organizationId);
 };
 
 export const checkEnvironmentCreationPermission = async (
@@ -422,6 +546,10 @@ export const checkEnvironmentCreationPermission = async (
 			});
 		}
 	}
+
+	// Runs for every role, including owner/admin, and after the member
+	// allow-list check so the member-path error message is unchanged.
+	await assertProjectInOrganization(projectId, organizationId);
 };
 
 export const checkEnvironmentDeletionPermission = async (
@@ -442,6 +570,10 @@ export const checkEnvironmentDeletionPermission = async (
 			});
 		}
 	}
+
+	// Runs for every role, including owner/admin, and after the member
+	// allow-list check so the member-path error message is unchanged.
+	await assertProjectInOrganization(projectId, organizationId);
 };
 
 export const addNewProject = async (ctx: PermissionCtx, projectId: string) => {


### PR DESCRIPTION
## Wave 4: cross-organization authorization hardening for the access helpers

Follow-up to #191, #192 and #196. Same vulnerability class, applied to the five remaining access helpers in `packages/server/src/services/permission.ts`.

### The vulnerability

`checkPermission` proves only that the caller holds a role **inside their active organization**. It says nothing about the id the caller passed in. Five helpers then consulted the member allow-list (`accessedProjects` / `accessedServices` / `accessedEnvironments`) **only for plain members** — owners and admins short-circuited it entirely:

| Helper | Id argument | Impact before this PR |
| --- | --- | --- |
| `checkProjectAccess(ctx, action, projectId?)` | project | owner/admin of org A could delete org B's project |
| `checkServiceAccess(ctx, serviceId, action)` | service, or **project** when `action === "create"` | owner/admin could read/delete any org's service, or create under a foreign project |
| `checkEnvironmentAccess(ctx, environmentId, action)` | environment | owner/admin could read any org's environment |
| `checkEnvironmentCreationPermission(ctx, projectId)` | project | owner/admin could create environments under a foreign project |
| `checkEnvironmentDeletionPermission(ctx, projectId)` | project | owner/admin could delete environments of a foreign project |

An allow-list entry is not proof of organization membership either — nothing validates the ids an admin assigns through `user.assignPermissions` — so a member with a stale or foreign entry was equally unscoped.

Only exploitable on multi-organization installs, but every one of these helpers sits in front of read/deploy/delete paths across roughly 90 router call sites.

### The fix

Two new resolver + assert pairs, mirroring wave 3's `findServiceOrganizationId` / `assertServiceInOrganization`:

- **`findProjectOrganizationId(projectId)`** — `project` carries `organizationId` directly, so a single row lookup resolves it: `db.query.projects.findFirst({ where: eq(projects.projectId, projectId), columns: { organizationId: true } })`. Returns `null` when no row matches.
- **`assertProjectInOrganization(projectId, organizationId)`** — throws `UNAUTHORIZED` `"You are not authorized to access this project or it does not exist"` on null-or-mismatch.
- **`findEnvironmentOrganizationId(environmentId)`** — environment joined to project through the drizzle relation: `db.query.environments.findFirst({ where: eq(environments.environmentId, environmentId), columns: { environmentId: true }, with: { project: { columns: { organizationId: true } } } })`. Returns `null` when no row matches.
- **`assertEnvironmentInOrganization(environmentId, organizationId)`** — throws `UNAUTHORIZED` `"You are not authorized to access this environment or it does not exist"` on null-or-mismatch.
- The existing **`assertServiceInOrganization`** (wave 3, raw-SQL `UNION ALL` over the 8 service tables joined `environment` to `project`) is reused unchanged for the service case.

`organizationId` always comes from `ctx.session.activeOrganizationId`, which each helper already reads.

### Placement and compatibility

Every assertion runs **for all roles** (owner, admin, member, custom) and is placed **after** the existing member allow-list check — exactly as #196 did in `checkServicePermissionAndAccess`. Consequences:

- Member-path error messages stay byte-identical for ids that fail the allow-list (`"You don't have access to this project"` / `"...this service"` / `"...this environment"`), and the allow-list short-circuits before any extra query is issued.
- The organization assertion still runs for members who *pass* the allow-list, closing the stale-entry hole.
- No signature changed and no call site was edited. All call sites inherit the fix.

Edge cases:

- `checkProjectAccess` with **no** `projectId` (the `create` path used by `project.create` / `project.duplicate`) has nothing to scope and issues no query — behavior unchanged.
- `checkServiceAccess(..., "create")` receives a **project** id — that is what the member branch compares against `accessedProjects`, and what every call site passes (`project.projectId` / `environment.projectId`) — so it is scoped with the **project** resolver, not the service one.
- `checkEnvironmentAccess` is scoped with the environment resolver for every action. The `create` action only skipped the member allow-list and has no call site today; the parameter is an environment id in the signature and at all three real call sites (`environment.one`, `environment.byProjectId`, `environment.duplicate`).

### No existence oracle

A missing id and a foreign id are indistinguishable: both resolvers return `null`, and both cases raise the identical `UNAUTHORIZED` message. This mirrors `mount.listByServiceId` and wave 3.

### Related files verified, no change needed

- `apps/dokploy/server/wss/authorize.ts` — inherits the fix through `checkServiceAccess`; it holds no separate copy of the short-circuit.
- `packages/server/src/services/user.ts` — holds *legacy duplicates* of these helper names with different signatures (`userId, ..., organizationId`) and the same owner/admin short-circuit. They are exported from the `@dokploy/server` barrel but have **zero call sites** — every router imports from `services/permission`. Flagged for a wave-5 cleanup rather than touched here.

### Tests

New `apps/dokploy/__test__/permissions/access-helpers-org-scope.test.ts` — 37 cases, mirroring the wave-3 mock setup. For each of the five helpers:

- owner/admin with a **same-org** id passes, and the resolver was called
- owner/admin with a **foreign-org** id throws `UNAUTHORIZED`
- a **nonexistent** id throws the *same* error as a foreign one (no oracle)
- member allow-list rejection message unchanged, with a negative control asserting the resolver was **not** called (ordering proof)
- member with an allow-listed same-org id passes
- member with an allow-listed **foreign** id is rejected
- `checkServiceAccess` `create` asserts via the **project** resolver, with a negative control that the service `db.execute` resolver was **not** called
- `checkProjectAccess` without a `projectId` issues **no** query

`apps/dokploy/__test__/permissions/service-access.test.ts` gained a `db.query.projects.findFirst` mock so its existing `create`-action case exercises the new project resolver.

Verified locally: `vitest run __test__/permissions` gives 149 passed / 0 failed, and `tsc --noEmit` is clean for both `apps/dokploy` and `packages/server`. The only failures in the full local suite are pre-existing Windows-shell artifacts (`/bin/bash` ENOENT, `mkdir -p`) in `restore-use-statement`, `application.real`, `server-setup` and `readValidDirectory` — unrelated to this change and green on Linux CI.
