### PR TITLE
feat: manual preview deployment builds for PRs/MRs (adopts #195)

### DIFF
--- a/apps/dokploy/__test__/preview-deployment/author-gate.test.ts
+++ b/apps/dokploy/__test__/preview-deployment/author-gate.test.ts
@@ -1,0 +1,227 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	findGithubById: vi.fn(),
+	checkUserRepositoryPermissions: vi.fn(),
+	checkGitlabMemberPermissions: vi.fn(),
+	checkGitlabMemberPermissionsByUserId: vi.fn(),
+}));
+
+// Only the four provider helpers the gate uses — keeps the server barrel (and
+// its DB/auth imports) out of this test.
+vi.mock("@dokploy/server", () => mocks);
+
+import {
+	assertPreviewAuthorAllowed,
+	type PreviewAuthorGateResource,
+} from "@/server/utils/preview-author-gate";
+
+const GITHUB_RESOURCE: PreviewAuthorGateResource = {
+	name: "my-app",
+	sourceType: "github",
+	previewRequireCollaboratorPermissions: true,
+	owner: "dokploy",
+	repository: "dokploy",
+	githubId: "github-provider-1",
+	gitlabId: null,
+	gitlabProjectId: null,
+};
+
+const GITLAB_RESOURCE: PreviewAuthorGateResource = {
+	name: "my-app",
+	sourceType: "gitlab",
+	previewRequireCollaboratorPermissions: true,
+	owner: null,
+	repository: null,
+	githubId: null,
+	gitlabId: "gitlab-provider-1",
+	gitlabProjectId: 42,
+};
+
+const expectTRPCError = async (promise: Promise<unknown>, code: string) => {
+	const error = await promise.then(
+		() => null,
+		(reason: unknown) => reason,
+	);
+	expect(error).toBeInstanceOf(TRPCError);
+	expect((error as TRPCError).code).toBe(code);
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+	vi.spyOn(console, "error").mockImplementation(() => {});
+	mocks.findGithubById.mockResolvedValue({ githubId: "github-provider-1" });
+});
+
+describe("assertPreviewAuthorAllowed - github", () => {
+	it("allows an author with write access", async () => {
+		mocks.checkUserRepositoryPermissions.mockResolvedValue({
+			hasWriteAccess: true,
+			permission: "write",
+		});
+
+		await expect(
+			assertPreviewAuthorAllowed(GITHUB_RESOURCE, {
+				pullRequestAuthor: "trusted-dev",
+			}),
+		).resolves.toBeUndefined();
+
+		expect(mocks.checkUserRepositoryPermissions).toHaveBeenCalledWith(
+			{ githubId: "github-provider-1" },
+			"dokploy",
+			"dokploy",
+			"trusted-dev",
+		);
+	});
+
+	it("blocks an author without write access", async () => {
+		mocks.checkUserRepositoryPermissions.mockResolvedValue({
+			hasWriteAccess: false,
+			permission: "read",
+		});
+
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(GITHUB_RESOURCE, {
+				pullRequestAuthor: "drive-by",
+			}),
+			"FORBIDDEN",
+		);
+	});
+
+	it("blocks when the author is missing entirely", async () => {
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(GITHUB_RESOURCE, {}),
+			"BAD_REQUEST",
+		);
+		expect(mocks.checkUserRepositoryPermissions).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when the permission lookup throws", async () => {
+		mocks.checkUserRepositoryPermissions.mockRejectedValue(
+			new Error("GitHub API is down"),
+		);
+
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(GITHUB_RESOURCE, {
+				pullRequestAuthor: "trusted-dev",
+			}),
+			"FORBIDDEN",
+		);
+	});
+
+	it("skips the check when previewRequireCollaboratorPermissions is false", async () => {
+		await expect(
+			assertPreviewAuthorAllowed(
+				{ ...GITHUB_RESOURCE, previewRequireCollaboratorPermissions: false },
+				{},
+			),
+		).resolves.toBeUndefined();
+
+		expect(mocks.checkUserRepositoryPermissions).not.toHaveBeenCalled();
+	});
+
+	it("still enforces the check when the flag is null (column default)", async () => {
+		mocks.checkUserRepositoryPermissions.mockResolvedValue({
+			hasWriteAccess: false,
+			permission: null,
+		});
+
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(
+				{ ...GITHUB_RESOURCE, previewRequireCollaboratorPermissions: null },
+				{ pullRequestAuthor: "drive-by" },
+			),
+			"FORBIDDEN",
+		);
+		expect(mocks.checkUserRepositoryPermissions).toHaveBeenCalled();
+	});
+});
+
+describe("assertPreviewAuthorAllowed - gitlab", () => {
+	it("authorizes by numeric author id, like the merge request webhook", async () => {
+		mocks.checkGitlabMemberPermissionsByUserId.mockResolvedValue({
+			hasWriteAccess: true,
+			accessLevel: 30,
+		});
+
+		await expect(
+			assertPreviewAuthorAllowed(GITLAB_RESOURCE, {
+				pullRequestAuthor: "trusted-dev",
+				pullRequestAuthorId: 7,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(mocks.checkGitlabMemberPermissionsByUserId).toHaveBeenCalledWith(
+			"gitlab-provider-1",
+			42,
+			7,
+		);
+		expect(mocks.checkGitlabMemberPermissions).not.toHaveBeenCalled();
+	});
+
+	it("blocks an author below Developer access", async () => {
+		mocks.checkGitlabMemberPermissionsByUserId.mockResolvedValue({
+			hasWriteAccess: false,
+			accessLevel: 20,
+		});
+
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(GITLAB_RESOURCE, {
+				pullRequestAuthorId: 7,
+			}),
+			"FORBIDDEN",
+		);
+	});
+
+	it("falls back to the username lookup when no author id is supplied", async () => {
+		mocks.checkGitlabMemberPermissions.mockResolvedValue({
+			hasWriteAccess: true,
+			accessLevel: 40,
+		});
+
+		await expect(
+			assertPreviewAuthorAllowed(GITLAB_RESOURCE, {
+				pullRequestAuthor: "trusted-dev",
+			}),
+		).resolves.toBeUndefined();
+
+		expect(mocks.checkGitlabMemberPermissions).toHaveBeenCalledWith(
+			"gitlab-provider-1",
+			42,
+			"trusted-dev",
+		);
+	});
+
+	it("blocks when neither author id nor username is supplied", async () => {
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(GITLAB_RESOURCE, {}),
+			"BAD_REQUEST",
+		);
+		expect(mocks.checkGitlabMemberPermissionsByUserId).not.toHaveBeenCalled();
+		expect(mocks.checkGitlabMemberPermissions).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when the member lookup throws", async () => {
+		mocks.checkGitlabMemberPermissionsByUserId.mockRejectedValue(
+			new Error("401 Unauthorized"),
+		);
+
+		await expectTRPCError(
+			assertPreviewAuthorAllowed(GITLAB_RESOURCE, { pullRequestAuthorId: 7 }),
+			"FORBIDDEN",
+		);
+	});
+
+	it("skips the check when previewRequireCollaboratorPermissions is false", async () => {
+		await expect(
+			assertPreviewAuthorAllowed(
+				{ ...GITLAB_RESOURCE, previewRequireCollaboratorPermissions: false },
+				{},
+			),
+		).resolves.toBeUndefined();
+
+		expect(mocks.checkGitlabMemberPermissionsByUserId).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
@@ -1,0 +1,265 @@
+import { GitPullRequest, Loader2, RocketIcon, Search } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { GithubIcon, GitlabIcon } from "@/components/icons/data-tools-icons";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/utils/api";
+
+interface Props {
+	applicationId?: string;
+	composeId?: string;
+	children: React.ReactNode;
+}
+
+interface ChangeRequest {
+	id: number | string;
+	number: number;
+	title: string;
+	html_url: string;
+	branch: string;
+	baseBranch?: string;
+	draft?: boolean;
+}
+
+export const BuildPreviewDeployment = ({
+	applicationId,
+	composeId,
+	children,
+}: Props) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [selected, setSelected] = useState<ChangeRequest | null>(null);
+	const [search, setSearch] = useState("");
+
+	const { data: application } = api.application.one.useQuery(
+		{ applicationId: applicationId || "" },
+		{ enabled: !!applicationId },
+	);
+	const { data: compose } = api.compose.one.useQuery(
+		{ composeId: composeId || "" },
+		{ enabled: !!composeId },
+	);
+
+	const data = application || compose;
+	const isGitlab = data?.sourceType === "gitlab";
+	const changeRequestLabel = isGitlab ? "Merge Request" : "Pull Request";
+	const owner = isGitlab ? data?.gitlabOwner || data?.owner : data?.owner;
+	const repo = isGitlab
+		? data?.gitlabRepository || data?.repository
+		: data?.repository;
+
+	const { data: githubPullRequests, isFetching: isFetchingGithub } =
+		api.github.getGithubPullRequests.useQuery(
+			{
+				owner: owner || "",
+				repo: repo || "",
+				githubId: data?.githubId || "",
+			},
+			{
+				enabled:
+					!!isOpen &&
+					!!data &&
+					data.sourceType === "github" &&
+					!!owner &&
+					!!repo,
+			},
+		);
+
+	const { data: gitlabMergeRequests, isFetching: isFetchingGitlab } =
+		api.gitlab.getGitlabMergeRequests.useQuery(
+			{
+				id: data?.gitlabProjectId || 0,
+				owner: data?.gitlabOwner || "",
+				repo: data?.gitlabRepository || "",
+				gitlabId: data?.gitlabId || "",
+			},
+			{
+				enabled:
+					!!isOpen &&
+					!!data &&
+					data.sourceType === "gitlab" &&
+					!!data.gitlabId &&
+					!!data.gitlabProjectId,
+			},
+		);
+
+	const changeRequests = (
+		isGitlab ? gitlabMergeRequests : githubPullRequests
+	) as ChangeRequest[] | undefined;
+	const isFetching = isFetchingGithub || isFetchingGitlab;
+
+	const filtered = changeRequests?.filter((cr) => {
+		if (!search) return true;
+		const q = search.toLowerCase();
+		return (
+			String(cr.number).includes(q) ||
+			cr.title.toLowerCase().includes(q) ||
+			cr.branch.toLowerCase().includes(q)
+		);
+	});
+
+	const { mutateAsync: createPreviewDeployment, isPending } =
+		api.previewDeployment.create.useMutation();
+
+	const handleBuild = async () => {
+		if (!selected) return;
+		try {
+			await createPreviewDeployment({
+				applicationId,
+				composeId,
+				branch: selected.branch,
+				pullRequestId: String(selected.id),
+				pullRequestNumber: String(selected.number),
+				pullRequestTitle: selected.title,
+				pullRequestURL: selected.html_url,
+			});
+			toast.success(
+				`${changeRequestLabel} #${selected.number} preview deployment started`,
+			);
+			setIsOpen(false);
+			setSelected(null);
+			setSearch("");
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: "Error building preview deployment",
+			);
+		}
+	};
+
+	useEffect(() => {
+		if (!isOpen) {
+			setSelected(null);
+			setSearch("");
+		}
+	}, [isOpen]);
+
+	const ChangeRequestIcon = isGitlab ? GitlabIcon : GithubIcon;
+
+	return (
+		<Dialog open={isOpen} onOpenChange={setIsOpen}>
+			<DialogTrigger asChild>{children}</DialogTrigger>
+			<DialogContent className="sm:max-w-lg w-full">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<GitPullRequest className="size-5" />
+						Build {changeRequestLabel}
+					</DialogTitle>
+					<DialogDescription>
+						Select an open {changeRequestLabel.toLowerCase()} from the
+						repository to create and deploy a preview deployment.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="grid gap-4">
+					{!data?.isPreviewDeploymentsActive && (
+						<AlertBlock type="warning">
+							Preview deployments are disabled for this resource.
+						</AlertBlock>
+					)}
+					{owner && repo && (
+						<div className="text-sm text-muted-foreground">
+							{owner}/{repo}
+						</div>
+					)}
+					<div className="relative">
+						<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+						<Input
+							placeholder={`Search ${changeRequestLabel.toLowerCase()}s...`}
+							className="pl-9"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+					</div>
+					{isFetching ? (
+						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
+							<Loader2 className="size-6 text-muted-foreground animate-spin" />
+							<span className="text-sm text-muted-foreground">
+								Loading open {changeRequestLabel.toLowerCase()}s...
+							</span>
+						</div>
+					) : !filtered?.length ? (
+						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
+							<ChangeRequestIcon className="size-8 text-muted-foreground" />
+							<span className="text-sm text-muted-foreground">
+								No open {changeRequestLabel.toLowerCase()}s found
+							</span>
+						</div>
+					) : (
+						<Select
+							value={selected ? String(selected.number) : undefined}
+							onValueChange={(value) => {
+								const cr = filtered?.find(
+									(item) => String(item.number) === value,
+								);
+								setSelected(cr || null);
+							}}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue
+									placeholder={`Select an open ${changeRequestLabel.toLowerCase()}`}
+								/>
+							</SelectTrigger>
+							<SelectContent>
+								{filtered?.map((cr) => (
+									<SelectItem
+										key={String(cr.id)}
+										value={String(cr.number)}
+										className="flex flex-col items-start gap-1"
+									>
+										<span className="flex items-center gap-2 font-medium">
+											#{cr.number} {cr.draft && "(draft)"}
+										</span>
+										<span className="line-clamp-1 text-xs text-muted-foreground">
+											{cr.title}
+										</span>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+					{selected && (
+						<div className="flex flex-col gap-2 rounded-lg border p-3 text-sm">
+							<div className="font-medium">
+								#{selected.number} {selected.title}
+							</div>
+							<div className="text-muted-foreground">
+								Branch: <span className="font-mono">{selected.branch}</span>
+							</div>
+						</div>
+					)}
+				</div>
+				<DialogFooter>
+					<Button variant="secondary" onClick={() => setIsOpen(false)}>
+						Cancel
+					</Button>
+					<Button
+						isLoading={isPending}
+						disabled={!selected || !data?.isPreviewDeploymentsActive}
+						onClick={handleBuild}
+					>
+						<RocketIcon className="size-4" />
+						Build preview
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
@@ -64,42 +64,42 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 		isLoading: isLoadingGithub,
 		error: githubError,
 	} = api.github.getGithubPullRequests.useQuery(
-			{
-				owner: resource.owner ?? "",
-				repo: resource.repository ?? "",
-				githubId: resource.githubId ?? "",
-			},
-			{
-				enabled:
-					isOpen &&
-					!isGitlab &&
-					!!resource.owner &&
-					!!resource.repository &&
-					!!resource.githubId,
-			},
-		);
+		{
+			owner: resource.owner ?? "",
+			repo: resource.repository ?? "",
+			githubId: resource.githubId ?? "",
+		},
+		{
+			enabled:
+				isOpen &&
+				!isGitlab &&
+				!!resource.owner &&
+				!!resource.repository &&
+				!!resource.githubId,
+		},
+	);
 
 	const {
 		data: gitlabMergeRequests,
 		isLoading: isLoadingGitlab,
 		error: gitlabError,
 	} = api.gitlab.getGitlabMergeRequests.useQuery(
-			{
-				id: resource.gitlabProjectId ?? 0,
-				owner: resource.gitlabOwner ?? "",
-				repo: resource.gitlabRepository ?? "",
-				gitlabId: resource.gitlabId ?? "",
-			},
-			{
-				enabled:
-					isOpen &&
-					isGitlab &&
-					!!resource.gitlabId &&
-					!!resource.gitlabProjectId &&
-					!!resource.gitlabOwner &&
-					!!resource.gitlabRepository,
-			},
-		);
+		{
+			id: resource.gitlabProjectId ?? 0,
+			owner: resource.gitlabOwner ?? "",
+			repo: resource.gitlabRepository ?? "",
+			gitlabId: resource.gitlabId ?? "",
+		},
+		{
+			enabled:
+				isOpen &&
+				isGitlab &&
+				!!resource.gitlabId &&
+				!!resource.gitlabProjectId &&
+				!!resource.gitlabOwner &&
+				!!resource.gitlabRepository,
+		},
+	);
 
 	const changeRequests = isGitlab ? gitlabMergeRequests : githubPullRequests;
 	const isLoading = isGitlab ? isLoadingGitlab : isLoadingGithub;

--- a/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
@@ -1,5 +1,6 @@
+import type { ChangeRequest } from "@dokploy/server";
 import { GitPullRequest, Loader2, RocketIcon, Search } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { GithubIcon, GitlabIcon } from "@/components/icons/data-tools-icons";
 import { AlertBlock } from "@/components/shared/alert-block";
@@ -23,97 +24,91 @@ import {
 } from "@/components/ui/select";
 import { api } from "@/utils/api";
 
-interface Props {
+interface PreviewResource {
 	applicationId?: string;
 	composeId?: string;
+	sourceType: string;
+	isPreviewDeploymentsActive: boolean | null;
+	owner: string | null;
+	repository: string | null;
+	githubId: string | null;
+	gitlabId: string | null;
+	gitlabOwner: string | null;
+	gitlabRepository: string | null;
+	gitlabProjectId: number | null;
+}
+
+interface Props {
+	resource: PreviewResource;
 	children: React.ReactNode;
 }
 
-interface ChangeRequest {
-	id: number | string;
-	number: number;
-	title: string;
-	html_url: string;
-	branch: string;
-	baseBranch?: string;
-	draft?: boolean;
-}
-
-export const BuildPreviewDeployment = ({
-	applicationId,
-	composeId,
-	children,
-}: Props) => {
+export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [selected, setSelected] = useState<ChangeRequest | null>(null);
 	const [search, setSearch] = useState("");
 
-	const { data: application } = api.application.one.useQuery(
-		{ applicationId: applicationId || "" },
-		{ enabled: !!applicationId },
-	);
-	const { data: compose } = api.compose.one.useQuery(
-		{ composeId: composeId || "" },
-		{ enabled: !!composeId },
-	);
-
-	const data = application || compose;
-	const isGitlab = data?.sourceType === "gitlab";
+	const isGitlab = resource.sourceType === "gitlab";
 	const changeRequestLabel = isGitlab ? "Merge Request" : "Pull Request";
-	const owner = isGitlab ? data?.gitlabOwner || data?.owner : data?.owner;
+	const changeRequestLabelPlural = `${changeRequestLabel.toLowerCase()}s`;
+
+	const owner = isGitlab
+		? (resource.gitlabOwner ?? resource.owner)
+		: resource.owner;
 	const repo = isGitlab
-		? data?.gitlabRepository || data?.repository
-		: data?.repository;
+		? (resource.gitlabRepository ?? resource.repository)
+		: resource.repository;
 
 	const { data: githubPullRequests, isFetching: isFetchingGithub } =
 		api.github.getGithubPullRequests.useQuery(
 			{
-				owner: owner || "",
-				repo: repo || "",
-				githubId: data?.githubId || "",
+				owner: resource.owner ?? "",
+				repo: resource.repository ?? "",
+				githubId: resource.githubId ?? "",
 			},
 			{
 				enabled:
-					!!isOpen &&
-					!!data &&
-					data.sourceType === "github" &&
-					!!owner &&
-					!!repo,
+					isOpen &&
+					!isGitlab &&
+					!!resource.owner &&
+					!!resource.repository &&
+					!!resource.githubId,
 			},
 		);
 
 	const { data: gitlabMergeRequests, isFetching: isFetchingGitlab } =
 		api.gitlab.getGitlabMergeRequests.useQuery(
 			{
-				id: data?.gitlabProjectId || 0,
-				owner: data?.gitlabOwner || "",
-				repo: data?.gitlabRepository || "",
-				gitlabId: data?.gitlabId || "",
+				id: resource.gitlabProjectId ?? 0,
+				owner: resource.gitlabOwner ?? "",
+				repo: resource.gitlabRepository ?? "",
+				gitlabId: resource.gitlabId ?? "",
 			},
 			{
 				enabled:
-					!!isOpen &&
-					!!data &&
-					data.sourceType === "gitlab" &&
-					!!data.gitlabId &&
-					!!data.gitlabProjectId,
+					isOpen &&
+					isGitlab &&
+					!!resource.gitlabId &&
+					!!resource.gitlabProjectId &&
+					!!resource.gitlabOwner &&
+					!!resource.gitlabRepository,
 			},
 		);
 
-	const changeRequests = (
-		isGitlab ? gitlabMergeRequests : githubPullRequests
-	) as ChangeRequest[] | undefined;
+	const changeRequests = isGitlab ? gitlabMergeRequests : githubPullRequests;
 	const isFetching = isFetchingGithub || isFetchingGitlab;
 
-	const filtered = changeRequests?.filter((cr) => {
-		if (!search) return true;
+	const filtered = useMemo(() => {
+		if (!changeRequests) return undefined;
+		if (!search) return changeRequests;
 		const q = search.toLowerCase();
-		return (
-			String(cr.number).includes(q) ||
-			cr.title.toLowerCase().includes(q) ||
-			cr.branch.toLowerCase().includes(q)
+		return changeRequests.filter(
+			(cr) =>
+				String(cr.number).includes(q) ||
+				cr.title.toLowerCase().includes(q) ||
+				cr.branch.toLowerCase().includes(q),
 		);
-	});
+	}, [changeRequests, search]);
 
 	const { mutateAsync: createPreviewDeployment, isPending } =
 		api.previewDeployment.create.useMutation();
@@ -122,20 +117,18 @@ export const BuildPreviewDeployment = ({
 		if (!selected) return;
 		try {
 			await createPreviewDeployment({
-				applicationId,
-				composeId,
+				applicationId: resource.applicationId,
+				composeId: resource.composeId,
 				branch: selected.branch,
 				pullRequestId: String(selected.id),
 				pullRequestNumber: String(selected.number),
 				pullRequestTitle: selected.title,
-				pullRequestURL: selected.html_url,
+				pullRequestURL: selected.url,
 			});
 			toast.success(
 				`${changeRequestLabel} #${selected.number} preview deployment started`,
 			);
 			setIsOpen(false);
-			setSelected(null);
-			setSearch("");
 		} catch (error) {
 			toast.error(
 				error instanceof Error
@@ -145,11 +138,13 @@ export const BuildPreviewDeployment = ({
 		}
 	};
 
+	const reset = () => {
+		setSelected(null);
+		setSearch("");
+	};
+
 	useEffect(() => {
-		if (!isOpen) {
-			setSelected(null);
-			setSearch("");
-		}
+		if (!isOpen) reset();
 	}, [isOpen]);
 
 	const ChangeRequestIcon = isGitlab ? GitlabIcon : GithubIcon;
@@ -169,7 +164,7 @@ export const BuildPreviewDeployment = ({
 					</DialogDescription>
 				</DialogHeader>
 				<div className="grid gap-4">
-					{!data?.isPreviewDeploymentsActive && (
+					{!resource.isPreviewDeploymentsActive && (
 						<AlertBlock type="warning">
 							Preview deployments are disabled for this resource.
 						</AlertBlock>
@@ -182,7 +177,7 @@ export const BuildPreviewDeployment = ({
 					<div className="relative">
 						<Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
 						<Input
-							placeholder={`Search ${changeRequestLabel.toLowerCase()}s...`}
+							placeholder={`Search ${changeRequestLabelPlural}...`}
 							className="pl-9"
 							value={search}
 							onChange={(e) => setSearch(e.target.value)}
@@ -192,25 +187,24 @@ export const BuildPreviewDeployment = ({
 						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
 							<Loader2 className="size-6 text-muted-foreground animate-spin" />
 							<span className="text-sm text-muted-foreground">
-								Loading open {changeRequestLabel.toLowerCase()}s...
+								Loading open {changeRequestLabelPlural}...
 							</span>
 						</div>
 					) : !filtered?.length ? (
 						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
 							<ChangeRequestIcon className="size-8 text-muted-foreground" />
 							<span className="text-sm text-muted-foreground">
-								No open {changeRequestLabel.toLowerCase()}s found
+								No open {changeRequestLabelPlural} found
 							</span>
 						</div>
 					) : (
 						<Select
 							value={selected ? String(selected.number) : undefined}
-							onValueChange={(value) => {
-								const cr = filtered?.find(
-									(item) => String(item.number) === value,
-								);
-								setSelected(cr || null);
-							}}
+							onValueChange={(value) =>
+								setSelected(
+									filtered.find((cr) => String(cr.number) === value) ?? null,
+								)
+							}
 						>
 							<SelectTrigger className="w-full">
 								<SelectValue
@@ -218,7 +212,7 @@ export const BuildPreviewDeployment = ({
 								/>
 							</SelectTrigger>
 							<SelectContent>
-								{filtered?.map((cr) => (
+								{filtered.map((cr) => (
 									<SelectItem
 										key={String(cr.id)}
 										value={String(cr.number)}
@@ -252,7 +246,7 @@ export const BuildPreviewDeployment = ({
 					</Button>
 					<Button
 						isLoading={isPending}
-						disabled={!selected || !data?.isPreviewDeploymentsActive}
+						disabled={!selected || !resource.isPreviewDeploymentsActive}
 						onClick={handleBuild}
 					>
 						<RocketIcon className="size-4" />

--- a/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/build-preview-deployment.tsx
@@ -59,8 +59,11 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 		? (resource.gitlabRepository ?? resource.repository)
 		: resource.repository;
 
-	const { data: githubPullRequests, isFetching: isFetchingGithub } =
-		api.github.getGithubPullRequests.useQuery(
+	const {
+		data: githubPullRequests,
+		isLoading: isLoadingGithub,
+		error: githubError,
+	} = api.github.getGithubPullRequests.useQuery(
 			{
 				owner: resource.owner ?? "",
 				repo: resource.repository ?? "",
@@ -76,8 +79,11 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 			},
 		);
 
-	const { data: gitlabMergeRequests, isFetching: isFetchingGitlab } =
-		api.gitlab.getGitlabMergeRequests.useQuery(
+	const {
+		data: gitlabMergeRequests,
+		isLoading: isLoadingGitlab,
+		error: gitlabError,
+	} = api.gitlab.getGitlabMergeRequests.useQuery(
 			{
 				id: resource.gitlabProjectId ?? 0,
 				owner: resource.gitlabOwner ?? "",
@@ -96,7 +102,8 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 		);
 
 	const changeRequests = isGitlab ? gitlabMergeRequests : githubPullRequests;
-	const isFetching = isFetchingGithub || isFetchingGitlab;
+	const isLoading = isGitlab ? isLoadingGitlab : isLoadingGithub;
+	const listError = isGitlab ? gitlabError : githubError;
 
 	const filtered = useMemo(() => {
 		if (!changeRequests) return undefined;
@@ -124,6 +131,10 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 				pullRequestNumber: String(selected.number),
 				pullRequestTitle: selected.title,
 				pullRequestURL: selected.url,
+				// Needed for the collaborator check the server runs against the
+				// change request author when the resource requires it.
+				pullRequestAuthor: selected.authorUsername ?? undefined,
+				pullRequestAuthorId: selected.authorId ?? undefined,
 			});
 			toast.success(
 				`${changeRequestLabel} #${selected.number} preview deployment started`,
@@ -169,6 +180,11 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 							Preview deployments are disabled for this resource.
 						</AlertBlock>
 					)}
+					{listError && (
+						<AlertBlock type="error">
+							{`Could not load open ${changeRequestLabelPlural}: ${listError.message}`}
+						</AlertBlock>
+					)}
 					{owner && repo && (
 						<div className="text-sm text-muted-foreground">
 							{owner}/{repo}
@@ -183,7 +199,7 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 							onChange={(e) => setSearch(e.target.value)}
 						/>
 					</div>
-					{isFetching ? (
+					{isLoading ? (
 						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
 							<Loader2 className="size-6 text-muted-foreground animate-spin" />
 							<span className="text-sm text-muted-foreground">
@@ -194,7 +210,9 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 						<div className="flex flex-col items-center justify-center gap-3 min-h-[25vh]">
 							<ChangeRequestIcon className="size-8 text-muted-foreground" />
 							<span className="text-sm text-muted-foreground">
-								No open {changeRequestLabelPlural} found
+								{listError
+									? `Could not load ${changeRequestLabelPlural}`
+									: `No open ${changeRequestLabelPlural} found`}
 							</span>
 						</div>
 					) : (
@@ -237,6 +255,14 @@ export const BuildPreviewDeployment = ({ resource, children }: Props) => {
 							<div className="text-muted-foreground">
 								Branch: <span className="font-mono">{selected.branch}</span>
 							</div>
+							{selected.authorUsername && (
+								<div className="text-muted-foreground">
+									Author:{" "}
+									<span className="font-mono">{selected.authorUsername}</span> —
+									the build is blocked unless they have write access to the
+									repository.
+								</div>
+							)}
 						</div>
 					)}
 				</div>

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
@@ -34,6 +34,7 @@ import { api } from "@/utils/api";
 import { ShowModalLogs } from "../../settings/web-server/show-modal-logs";
 import { ShowDeploymentsModal } from "../deployments/show-deployments-modal";
 import { AddPreviewDomain } from "./add-preview-domain";
+import { BuildPreviewDeployment } from "./build-preview-deployment";
 import { ShowPreviewSettings } from "./show-preview-settings";
 
 interface Props {
@@ -85,7 +86,15 @@ export const ShowPreviewDeployments = ({ applicationId }: Props) => {
 					<CardDescription>See all the preview deployments</CardDescription>
 				</div>
 				{data?.isPreviewDeploymentsActive && (
-					<ShowPreviewSettings applicationId={applicationId} />
+					<div className="flex items-center gap-2">
+						<BuildPreviewDeployment applicationId={applicationId}>
+							<Button variant="outline" className="gap-2">
+								<GitPullRequest className="size-4" />
+								Build {changeRequestLabel}
+							</Button>
+						</BuildPreviewDeployment>
+						<ShowPreviewSettings applicationId={applicationId} />
+					</div>
 				)}
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
@@ -87,7 +87,7 @@ export const ShowPreviewDeployments = ({ applicationId }: Props) => {
 				</div>
 				{data?.isPreviewDeploymentsActive && (
 					<div className="flex items-center gap-2">
-						<BuildPreviewDeployment applicationId={applicationId}>
+						<BuildPreviewDeployment resource={data}>
 							<Button variant="outline" className="gap-2">
 								<GitPullRequest className="size-4" />
 								Build {changeRequestLabel}

--- a/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
@@ -85,7 +85,7 @@ export const ShowPreviewDeploymentsCompose = ({ composeId }: Props) => {
 				</div>
 				{data?.isPreviewDeploymentsActive && (
 					<div className="flex items-center gap-2">
-						<BuildPreviewDeployment composeId={composeId}>
+						<BuildPreviewDeployment resource={data}>
 							<Button variant="outline" className="gap-2">
 								<GitPullRequest className="size-4" />
 								Build {changeRequestLabel}

--- a/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/compose/preview-deployments/show-preview-deployments.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/tooltip";
 import { api } from "@/utils/api";
 import { ShowDeploymentsModal } from "../../application/deployments/show-deployments-modal";
+import { BuildPreviewDeployment } from "../../application/preview-deployments/build-preview-deployment";
 import { ShowModalLogs } from "../../settings/web-server/show-modal-logs";
 import { ShowPreviewSettingsCompose } from "./show-preview-settings";
 
@@ -83,7 +84,15 @@ export const ShowPreviewDeploymentsCompose = ({ composeId }: Props) => {
 					<CardDescription>See all the preview deployments</CardDescription>
 				</div>
 				{data?.isPreviewDeploymentsActive && (
-					<ShowPreviewSettingsCompose composeId={composeId} />
+					<div className="flex items-center gap-2">
+						<BuildPreviewDeployment composeId={composeId}>
+							<Button variant="outline" className="gap-2">
+								<GitPullRequest className="size-4" />
+								Build {changeRequestLabel}
+							</Button>
+						</BuildPreviewDeployment>
+						<ShowPreviewSettingsCompose composeId={composeId} />
+					</div>
 				)}
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">

--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -3,6 +3,7 @@ import {
 	findGithubById,
 	getAccessibleGitProviderIds,
 	getGithubBranches,
+	getGithubPullRequests,
 	getGithubRepositories,
 	haveGithubRequirements,
 	updateGithub,
@@ -18,6 +19,7 @@ import {
 import { audit } from "@/server/api/utils/audit";
 import {
 	apiFindGithubBranches,
+	apiFindGithubPullRequests,
 	apiFindOneGithub,
 	apiUpdateGithub,
 } from "@/server/db/schema";
@@ -45,6 +47,15 @@ export const githubRouter = createTRPCRouter({
 				await assertGitProviderAccess(ctx.session, github.gitProvider);
 			}
 			return await getGithubBranches(input);
+		}),
+	getGithubPullRequests: protectedProcedure
+		.input(apiFindGithubPullRequests)
+		.query(async ({ input, ctx }) => {
+			if (input.githubId) {
+				const github = await findGithubById(input.githubId);
+				await assertGitProviderAccess(ctx.session, github.gitProvider);
+			}
+			return await getGithubPullRequests(input);
 		}),
 	githubProviders: protectedProcedure.query(async ({ ctx }) => {
 		const accessibleIds = await getAccessibleGitProviderIds(ctx.session);

--- a/apps/dokploy/server/api/routers/gitlab.ts
+++ b/apps/dokploy/server/api/routers/gitlab.ts
@@ -4,6 +4,7 @@ import {
 	findGitlabById,
 	getAccessibleGitProviderIds,
 	getGitlabBranches,
+	getGitlabMergeRequests,
 	getGitlabRepositories,
 	haveGitlabRequirements,
 	testGitlabConnection,
@@ -21,6 +22,7 @@ import { audit } from "@/server/api/utils/audit";
 import {
 	apiCreateGitlab,
 	apiFindGitlabBranches,
+	apiFindGitlabMergeRequests,
 	apiFindOneGitlab,
 	apiGitlabTestConnection,
 	apiUpdateGitlab,
@@ -105,6 +107,15 @@ export const gitlabRouter = createTRPCRouter({
 				await assertGitProviderAccess(ctx.session, gitlab.gitProvider);
 			}
 			return await getGitlabBranches(input);
+		}),
+	getGitlabMergeRequests: protectedProcedure
+		.input(apiFindGitlabMergeRequests)
+		.query(async ({ input, ctx }) => {
+			if (input.gitlabId) {
+				const gitlab = await findGitlabById(input.gitlabId);
+				await assertGitProviderAccess(ctx.session, gitlab.gitProvider);
+			}
+			return await getGitlabMergeRequests(input);
 		}),
 	testConnection: protectedProcedure
 		.input(apiGitlabTestConnection)

--- a/apps/dokploy/server/api/routers/preview-deployment.ts
+++ b/apps/dokploy/server/api/routers/preview-deployment.ts
@@ -20,6 +20,7 @@ import { apiCreatePreviewDeployment } from "@/server/db/schema";
 import type { DeploymentJob } from "@/server/queues/queue-types";
 import { myQueue } from "@/server/queues/queueSetup";
 import { deploy } from "@/server/utils/deploy";
+import { assertPreviewAuthorAllowed } from "@/server/utils/preview-author-gate";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 // A preview deployment belongs to either an application or a compose service.
@@ -237,6 +238,9 @@ const createApplicationPreviewFromApi = async (
 		});
 	}
 
+	// Same collaborator gate the webhook handler applies to the PR author.
+	await assertPreviewAuthorAllowed(application, input);
+
 	const existingPreviewDeployment = await findPreviewDeploymentByApplicationId(
 		applicationId,
 		input.pullRequestId,
@@ -246,8 +250,10 @@ const createApplicationPreviewFromApi = async (
 		existingPreviewDeployment?.previewDeploymentId || "";
 
 	if (!existingPreviewDeployment) {
-		const previewLimit = application.previewLimit || 0;
-		if ((application.previewDeployments?.length ?? 0) > previewLimit) {
+		// Matches the webhook: default 3, and the limit blocks the Nth+1 *new*
+		// preview rather than allowing one over.
+		const previewLimit = application.previewLimit ?? 3;
+		if ((application.previewDeployments?.length ?? 0) >= previewLimit) {
 			throw new TRPCError({
 				code: "BAD_REQUEST",
 				message: "Preview deployments limit reached",
@@ -321,6 +327,9 @@ const createComposePreviewFromApi = async (
 		});
 	}
 
+	// Same collaborator gate the webhook handler applies to the MR/PR author.
+	await assertPreviewAuthorAllowed(compose, input);
+
 	const existingPreviewDeployment = await findPreviewDeploymentByComposeId(
 		composeId,
 		input.pullRequestId,
@@ -330,9 +339,11 @@ const createComposePreviewFromApi = async (
 		existingPreviewDeployment?.previewDeploymentId || "";
 
 	if (!existingPreviewDeployment) {
-		const previewLimit = compose.previewLimit || 0;
+		// Matches the webhook: default 3, and the limit blocks the Nth+1 *new*
+		// preview rather than allowing one over.
+		const previewLimit = compose.previewLimit ?? 3;
 		const existingPreviews = await findPreviewDeploymentsByComposeId(composeId);
-		if (existingPreviews.length > previewLimit) {
+		if (existingPreviews.length >= previewLimit) {
 			throw new TRPCError({
 				code: "BAD_REQUEST",
 				message: "Preview deployments limit reached",

--- a/apps/dokploy/server/utils/preview-author-gate.ts
+++ b/apps/dokploy/server/utils/preview-author-gate.ts
@@ -1,0 +1,187 @@
+import {
+	checkGitlabMemberPermissions,
+	checkGitlabMemberPermissionsByUserId,
+	checkUserRepositoryPermissions,
+	findGithubById,
+} from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
+
+/**
+ * The subset of an application/compose row this gate needs. Both tables carry
+ * these columns with the same meaning.
+ */
+export interface PreviewAuthorGateResource {
+	name: string;
+	sourceType: string;
+	previewRequireCollaboratorPermissions: boolean | null;
+	owner: string | null;
+	repository: string | null;
+	githubId: string | null;
+	gitlabId: string | null;
+	gitlabProjectId: number | null;
+}
+
+export interface PreviewAuthorGateInput {
+	pullRequestAuthor?: string;
+	pullRequestAuthorId?: number;
+}
+
+const AUTHOR_REQUIRED_MESSAGE =
+	"Preview deployment blocked: the change request author is required so their repository access can be verified. Send pullRequestAuthor (and pullRequestAuthorId for GitLab), or turn off the collaborator permission requirement in the preview deployment settings.";
+
+/**
+ * Authorize a preview deployment by the *change request author*, mirroring what
+ * `pages/api/deploy/github.ts` and `pages/api/deploy/gitlab.ts` do for webhook
+ * deliveries. Without it, creating a preview through the API (or the manual
+ * "Build Pull Request" dialog) would execute an untrusted fork's build on the
+ * host even though `previewRequireCollaboratorPermissions` is on.
+ *
+ * Deliberately does *not* check the base branch: bypassing base-branch matching
+ * is the whole point of building a preview manually.
+ *
+ * Fails closed — a provider error blocks the deployment, matching the webhook
+ * handlers, which skip the app when the permission lookup throws.
+ */
+export const assertPreviewAuthorAllowed = async (
+	resource: PreviewAuthorGateResource,
+	input: PreviewAuthorGateInput,
+): Promise<void> => {
+	if (resource.previewRequireCollaboratorPermissions === false) {
+		console.warn(
+			`⚠️  SECURITY: Preview deployment for ${resource.name} allows deployment from any change request author (security check disabled)`,
+		);
+		return;
+	}
+
+	if (resource.sourceType === "github") {
+		await assertGithubAuthorAllowed(resource, input);
+		return;
+	}
+
+	if (resource.sourceType === "gitlab") {
+		await assertGitlabAuthorAllowed(resource, input);
+		return;
+	}
+
+	throw new TRPCError({
+		code: "BAD_REQUEST",
+		message: `Preview deployments cannot verify the author for source type "${resource.sourceType}"`,
+	});
+};
+
+const assertGithubAuthorAllowed = async (
+	resource: PreviewAuthorGateResource,
+	input: PreviewAuthorGateInput,
+) => {
+	const author = input.pullRequestAuthor?.trim();
+	if (!author) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: AUTHOR_REQUIRED_MESSAGE,
+		});
+	}
+
+	const { githubId, owner, repository } = resource;
+	if (!githubId || !owner || !repository) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				"Preview deployment blocked: the GitHub provider, owner and repository must be configured before the author's access can be verified",
+		});
+	}
+
+	let hasWriteAccess: boolean;
+	let permission: string | null;
+	try {
+		const githubProvider = await findGithubById(githubId);
+		({ hasWriteAccess, permission } = await checkUserRepositoryPermissions(
+			githubProvider,
+			owner,
+			repository,
+			author,
+		));
+	} catch (error) {
+		console.error(
+			`Error validating pull request author permissions for ${resource.name}:`,
+			error,
+		);
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: `Preview deployment blocked: could not verify that ${author} has write access to ${owner}/${repository}`,
+		});
+	}
+
+	if (!hasWriteAccess) {
+		console.warn(
+			`🚨 SECURITY: Blocked manual preview deployment for ${resource.name} from unauthorized user ${author} on ${owner}/${repository}. Permission: ${permission || "none"}`,
+		);
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: `Preview deployment blocked: ${author} does not have write access to ${owner}/${repository} (permission: ${permission || "none"})`,
+		});
+	}
+};
+
+const assertGitlabAuthorAllowed = async (
+	resource: PreviewAuthorGateResource,
+	input: PreviewAuthorGateInput,
+) => {
+	const authorId = input.pullRequestAuthorId;
+	const authorUsername = input.pullRequestAuthor?.trim();
+	if (!authorId && !authorUsername) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: AUTHOR_REQUIRED_MESSAGE,
+		});
+	}
+
+	const { gitlabId, gitlabProjectId } = resource;
+	if (!gitlabId || !gitlabProjectId) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				"Preview deployment blocked: the GitLab provider and project must be configured before the author's access can be verified",
+		});
+	}
+
+	const authorLabel = authorUsername
+		? `@${authorUsername}`
+		: `the merge request author (id ${authorId})`;
+
+	let hasWriteAccess: boolean;
+	let accessLevel: number | null;
+	try {
+		// Prefer the numeric id: it is the identity the MR webhook authorizes
+		// (`object_attributes.author_id`) and it cannot be spoofed by renames.
+		({ hasWriteAccess, accessLevel } = authorId
+			? await checkGitlabMemberPermissionsByUserId(
+					gitlabId,
+					gitlabProjectId,
+					authorId,
+				)
+			: await checkGitlabMemberPermissions(
+					gitlabId,
+					gitlabProjectId,
+					authorUsername as string,
+				));
+	} catch (error) {
+		console.error(
+			`Error validating merge request author permissions for ${resource.name}:`,
+			error,
+		);
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: `Preview deployment blocked: could not verify that ${authorLabel} has write access to this GitLab project`,
+		});
+	}
+
+	if (!hasWriteAccess) {
+		console.warn(
+			`🚨 SECURITY: Blocked manual preview deployment for ${resource.name} from ${authorLabel}. Access level: ${accessLevel}`,
+		);
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: `Preview deployment blocked: ${authorLabel} does not have write access to this GitLab project (access level: ${accessLevel ?? "none"})`,
+		});
+	}
+};

--- a/packages/server/src/db/schema/github.ts
+++ b/packages/server/src/db/schema/github.ts
@@ -51,6 +51,12 @@ export const apiFindGithubBranches = z.object({
 	githubId: z.string().optional(),
 });
 
+export const apiFindGithubPullRequests = z.object({
+	repo: z.string().min(1),
+	owner: z.string().min(1),
+	githubId: z.string().optional(),
+});
+
 export const apiFindOneGithub = z.object({
 	githubId: z.string().min(1),
 });

--- a/packages/server/src/db/schema/gitlab.ts
+++ b/packages/server/src/db/schema/gitlab.ts
@@ -61,6 +61,13 @@ export const apiFindGitlabBranches = z.object({
 	gitlabId: z.string().optional(),
 });
 
+export const apiFindGitlabMergeRequests = z.object({
+	id: z.number().optional(),
+	owner: z.string(),
+	repo: z.string(),
+	gitlabId: z.string().optional(),
+});
+
 export const apiUpdateGitlab = z.object({
 	applicationId: z.string().optional(),
 	secret: z.string().optional(),

--- a/packages/server/src/db/schema/preview-deployments.ts
+++ b/packages/server/src/db/schema/preview-deployments.ts
@@ -105,6 +105,13 @@ export const apiCreatePreviewDeployment = z
 		pullRequestNumber: z.string().min(1),
 		pullRequestURL: z.string().min(1),
 		pullRequestTitle: z.string().min(1),
+		// Identity of the pull/merge request author. Required (unless the service
+		// has `previewRequireCollaboratorPermissions` turned off) so this endpoint
+		// enforces the same collaborator gate the webhook handlers do — otherwise
+		// it is a way to build any branch's code without that check.
+		// GitHub authorizes by login, GitLab by numeric user id.
+		pullRequestAuthor: z.string().optional(),
+		pullRequestAuthorId: z.number().optional(),
 	})
 	.refine((data) => !!data.applicationId !== !!data.composeId, {
 		message: "Exactly one of applicationId or composeId must be provided",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -75,6 +75,7 @@ export * from "./setup/server-validate";
 export * from "./setup/setup";
 export * from "./setup/traefik-setup";
 export * from "./templates/processors";
+export * from "./types/change-request";
 export * from "./utils/access-log/handler";
 export {
 	getLogCleanupStatus,

--- a/packages/server/src/types/change-request.ts
+++ b/packages/server/src/types/change-request.ts
@@ -1,0 +1,9 @@
+export interface ChangeRequest {
+	id: number;
+	number: number;
+	title: string;
+	url: string;
+	branch: string;
+	baseBranch: string;
+	draft: boolean;
+}

--- a/packages/server/src/types/change-request.ts
+++ b/packages/server/src/types/change-request.ts
@@ -6,4 +6,16 @@ export interface ChangeRequest {
 	branch: string;
 	baseBranch: string;
 	draft: boolean;
+	/**
+	 * Author handle — GitHub `pull_request.user.login`, GitLab `author.username`.
+	 * Carried so a manually triggered preview can run the same collaborator check
+	 * the webhook handlers run against the change request author.
+	 */
+	authorUsername: string | null;
+	/**
+	 * Numeric author id. GitLab only: it matches `object_attributes.author_id`
+	 * from the merge request webhook, which is what the member permission check
+	 * authorizes against. Null for GitHub, which authorizes by login.
+	 */
+	authorId: number | null;
 }

--- a/packages/server/src/utils/providers/github.ts
+++ b/packages/server/src/utils/providers/github.ts
@@ -1,6 +1,9 @@
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
-import type { apiFindGithubBranches } from "@dokploy/server/db/schema";
+import type {
+	apiFindGithubBranches,
+	apiFindGithubPullRequests,
+} from "@dokploy/server/db/schema";
 import { findGithubById, type Github } from "@dokploy/server/services/github";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { createAppAuth } from "@octokit/auth-app";
@@ -261,6 +264,44 @@ export const getGithubRepositories = async (githubId?: string) => {
 	>["data"]["repositories"];
 
 	return repositories;
+};
+
+export const getGithubPullRequests = async (
+	input: z.infer<typeof apiFindGithubPullRequests>,
+) => {
+	if (!input.githubId) {
+		return [];
+	}
+	const githubProvider = await findGithubById(input.githubId);
+
+	const octokit = new Octokit({
+		authStrategy: createAppAuth,
+		auth: {
+			appId: githubProvider.githubAppId,
+			privateKey: githubProvider.githubPrivateKey,
+			installationId: githubProvider.githubInstallationId,
+		},
+		baseUrl: deriveGithubApiUrl(githubProvider.githubUrl),
+	});
+
+	const pullRequests = (await octokit.paginate(octokit.rest.pulls.list, {
+		owner: input.owner,
+		repo: input.repo,
+		state: "open",
+		sort: "updated",
+		direction: "desc",
+	})) as unknown as Awaited<ReturnType<typeof octokit.rest.pulls.list>>["data"];
+
+	return pullRequests.map((pr) => ({
+		id: pr.id,
+		number: pr.number,
+		title: pr.title,
+		html_url: pr.html_url,
+		branch: pr.head?.ref,
+		headSha: pr.head?.sha,
+		baseBranch: pr.base?.ref,
+		draft: pr.draft,
+	}));
 };
 
 export const getGithubBranches = async (

--- a/packages/server/src/utils/providers/github.ts
+++ b/packages/server/src/utils/providers/github.ts
@@ -291,6 +291,7 @@ export const getGithubPullRequests = async (
 		state: "open",
 		sort: "updated",
 		direction: "desc",
+		per_page: 100,
 	})) as unknown as Awaited<ReturnType<typeof octokit.rest.pulls.list>>["data"];
 
 	return pullRequests.map((pr) => ({
@@ -301,6 +302,10 @@ export const getGithubPullRequests = async (
 		branch: pr.head?.ref ?? "",
 		baseBranch: pr.base?.ref ?? "",
 		draft: pr.draft ?? false,
+		// The author drives the collaborator check on the manual build path, the
+		// same way `pull_request.user.login` does for webhook-triggered previews.
+		authorUsername: pr.user?.login ?? null,
+		authorId: null,
 	}));
 };
 

--- a/packages/server/src/utils/providers/github.ts
+++ b/packages/server/src/utils/providers/github.ts
@@ -5,6 +5,7 @@ import type {
 	apiFindGithubPullRequests,
 } from "@dokploy/server/db/schema";
 import { findGithubById, type Github } from "@dokploy/server/services/github";
+import type { ChangeRequest } from "@dokploy/server/types/change-request";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { createAppAuth } from "@octokit/auth-app";
 import { TRPCError } from "@trpc/server";
@@ -268,7 +269,7 @@ export const getGithubRepositories = async (githubId?: string) => {
 
 export const getGithubPullRequests = async (
 	input: z.infer<typeof apiFindGithubPullRequests>,
-) => {
+): Promise<ChangeRequest[]> => {
 	if (!input.githubId) {
 		return [];
 	}
@@ -296,11 +297,10 @@ export const getGithubPullRequests = async (
 		id: pr.id,
 		number: pr.number,
 		title: pr.title,
-		html_url: pr.html_url,
-		branch: pr.head?.ref,
-		headSha: pr.head?.sha,
-		baseBranch: pr.base?.ref,
-		draft: pr.draft,
+		url: pr.html_url,
+		branch: pr.head?.ref ?? "",
+		baseBranch: pr.base?.ref ?? "",
+		draft: pr.draft ?? false,
 	}));
 };
 

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -278,6 +278,10 @@ interface GitlabMergeRequest {
 	source_branch: string;
 	target_branch: string;
 	draft: boolean;
+	author?: {
+		id?: number;
+		username?: string;
+	} | null;
 }
 
 export const getGitlabMergeRequests = async (input: {
@@ -290,6 +294,9 @@ export const getGitlabMergeRequests = async (input: {
 		return [];
 	}
 
+	// GitLab OAuth access tokens are short lived; without this the listing 401s
+	// as soon as the stored token expires, like every other helper here does.
+	await refreshGitlabToken(input.gitlabId);
 	const gitlabProvider = await findGitlabById(input.gitlabId);
 
 	const allMergeRequests: GitlabMergeRequest[] = [];
@@ -339,6 +346,11 @@ export const getGitlabMergeRequests = async (input: {
 		branch: mr.source_branch,
 		baseBranch: mr.target_branch,
 		draft: mr.draft,
+		// `author.id` is the same identity the MR webhook authorizes through
+		// `object_attributes.author_id`; keep it so the manual path can reuse
+		// `checkGitlabMemberPermissionsByUserId`.
+		authorUsername: mr.author?.username ?? null,
+		authorId: mr.author?.id ?? null,
 	}));
 };
 

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -269,6 +269,70 @@ export const getGitlabBranches = async (input: {
 	}[];
 };
 
+export const getGitlabMergeRequests = async (input: {
+	id?: number;
+	gitlabId?: string;
+	owner: string;
+	repo: string;
+}) => {
+	if (!input.gitlabId || !input.id || input.id === 0) {
+		return [];
+	}
+
+	const gitlabProvider = await findGitlabById(input.gitlabId);
+
+	const allMergeRequests: Record<string, unknown>[] = [];
+	let page = 1;
+	const perPage = 100; // GitLab's max per page is 100
+	const baseUrl = (
+		gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl
+	).replace(/\/+$/, "");
+
+	while (true) {
+		const mergeRequestsResponse = await fetch(
+			`${baseUrl}/api/v4/projects/${input.id}/merge_requests?state=opened&page=${page}&per_page=${perPage}`,
+			{
+				headers: {
+					Authorization: `Bearer ${gitlabProvider.accessToken}`,
+				},
+			},
+		);
+
+		if (!mergeRequestsResponse.ok) {
+			throw new Error(
+				`Failed to fetch merge requests: ${mergeRequestsResponse.statusText}`,
+			);
+		}
+
+		const mergeRequests = (await mergeRequestsResponse.json()) as Record<
+			string,
+			unknown
+		>[];
+
+		if (mergeRequests.length === 0) {
+			break;
+		}
+
+		allMergeRequests.push(...mergeRequests);
+		page++;
+
+		const total = mergeRequestsResponse.headers.get("x-total");
+		if (total && allMergeRequests.length >= Number.parseInt(total)) {
+			break;
+		}
+	}
+
+	return allMergeRequests.map((mr) => ({
+		id: mr.id,
+		number: mr.iid,
+		title: mr.title,
+		html_url: mr.web_url,
+		branch: mr.source_branch,
+		baseBranch: mr.target_branch,
+		draft: mr.draft,
+	}));
+};
+
 export const testGitlabConnection = async (
 	input: z.infer<typeof apiGitlabTestConnection>,
 ) => {

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -6,6 +6,7 @@ import {
 	type Gitlab,
 	updateGitlab,
 } from "@dokploy/server/services/gitlab";
+import type { ChangeRequest } from "@dokploy/server/types/change-request";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { TRPCError } from "@trpc/server";
 import { quote } from "shell-quote";
@@ -269,19 +270,29 @@ export const getGitlabBranches = async (input: {
 	}[];
 };
 
+interface GitlabMergeRequest {
+	id: number;
+	iid: number;
+	title: string;
+	web_url: string;
+	source_branch: string;
+	target_branch: string;
+	draft: boolean;
+}
+
 export const getGitlabMergeRequests = async (input: {
 	id?: number;
 	gitlabId?: string;
 	owner: string;
 	repo: string;
-}) => {
+}): Promise<ChangeRequest[]> => {
 	if (!input.gitlabId || !input.id || input.id === 0) {
 		return [];
 	}
 
 	const gitlabProvider = await findGitlabById(input.gitlabId);
 
-	const allMergeRequests: Record<string, unknown>[] = [];
+	const allMergeRequests: GitlabMergeRequest[] = [];
 	let page = 1;
 	const perPage = 100; // GitLab's max per page is 100
 	const baseUrl = (
@@ -304,10 +315,8 @@ export const getGitlabMergeRequests = async (input: {
 			);
 		}
 
-		const mergeRequests = (await mergeRequestsResponse.json()) as Record<
-			string,
-			unknown
-		>[];
+		const mergeRequests =
+			(await mergeRequestsResponse.json()) as GitlabMergeRequest[];
 
 		if (mergeRequests.length === 0) {
 			break;
@@ -326,7 +335,7 @@ export const getGitlabMergeRequests = async (input: {
 		id: mr.id,
 		number: mr.iid,
 		title: mr.title,
-		html_url: mr.web_url,
+		url: mr.web_url,
 		branch: mr.source_branch,
 		baseBranch: mr.target_branch,
 		draft: mr.draft,


### PR DESCRIPTION
Adds a **Build Pull Request** button to the Preview Deployments tab of applications and compose services: pick any open pull request / merge request on the resource's repository and create + deploy a preview for it, without waiting for a webhook. This covers the case where your PRs don't target the configured base branch, so the webhook never fires and you'd otherwise be forging deploy payloads by hand.

## Credit

The feature is **@ajnart's** work — it adopts #195, and their two commits are cherry-picked here with their authorship intact:

- `043e3cbb6` feat(preview-deployments): manually build a preview deployment from an open PR
- `56716e291` refactor(preview-deployments): clean up manual build dialog and providers

We offered in the review on #195 to carry the remaining work ourselves rather than leave it on the contributor, so this supersedes that PR. #195 is left open for the maintainer to close; nothing here auto-closes it. Both commits rebased onto post-v0.30.3-sync canary with no conflicts.

## What @ajnart's commits do

- `getGithubPullRequests` / `getGitlabMergeRequests` providers, plus `github.getGithubPullRequests` and `gitlab.getGitlabMergeRequests` tRPC endpoints, both behind `assertGitProviderAccess`.
- A shared `ChangeRequest` type exported from `@dokploy/server`.
- A `BuildPreviewDeployment` dialog wired into both the application and compose preview tabs, which calls the existing `previewDeployment.create` mutation.

The dedupe key is right: the dialog sends `String(pr.id)` / `String(mr.id)`, which is what the GitHub (`pull_request.id`) and GitLab (`object_attributes.id`) webhooks store, so a manually built preview and a later webhook event land on the same `(applicationId, pullRequestId)` row instead of duplicating.

## Fixes applied on top

**1. Blocker — the manual path skipped `previewRequireCollaboratorPermissions`.**

`previewDeployment.create` never checked whether the change request author has write access to the repository. That's pre-existing debt in the endpoint, not something #195 introduced, but the dialog is its first UI caller, so it turned "an API call you had to know about" into a one-click button that will happily build an untrusted fork's code on the host.

Both webhook handlers do enforce it: `pages/api/deploy/github.ts` runs `checkUserRepositoryPermissions` against `pull_request.user.login`, and `pages/api/deploy/gitlab.ts` runs `checkGitlabMemberPermissionsByUserId` against `object_attributes.author_id`. The new `assertPreviewAuthorAllowed` (`apps/dokploy/server/utils/preview-author-gate.ts`) reuses those exact helpers and runs inside `createApplicationPreviewFromApi` / `createComposePreviewFromApi`.

Behaviour:

| | flag on (default, incl. `null`) | flag off |
|---|---|---|
| GitHub | `checkUserRepositoryPermissions(provider, owner, repo, author)`; needs `write`/`maintain`/`admin`, else `FORBIDDEN` | check skipped |
| GitLab | `checkGitlabMemberPermissionsByUserId(gitlabId, projectId, authorId)`; needs Developer (30) or above, else `FORBIDDEN`. Falls back to the username lookup when only a username is available | check skipped |
| author missing | `BAD_REQUEST` telling you to send the author or turn the requirement off | check skipped |
| provider lookup throws | `FORBIDDEN` — fails closed, matching the webhooks, which skip the app on a permission-lookup error | check skipped |

The base-branch match is still deliberately bypassed — that is the whole point of the manual button.

**Behaviour change worth calling out:** `previewDeployment.create` now needs `pullRequestAuthor` (and `pullRequestAuthorId` for GitLab) on services that require collaborator permissions. Existing scripted callers that don't send it will get a `BAD_REQUEST` with instructions rather than a silent bypass. Both fields are optional in the schema so callers on services with the requirement turned off are unaffected.

**2. `getGitlabMergeRequests` never refreshed the GitLab token.** Every other helper in `packages/server/src/utils/providers/gitlab.ts` calls `refreshGitlabToken` first; GitLab OAuth access tokens are short lived, so as written the MR list would 401 for most users most of the time. (`getGitlabBranches` has the same pre-existing bug, which is where the pattern was copied from — not fixed here.)

**3. The dialog had no error state.** A failed query left `data` undefined, fell into `!filtered?.length` and rendered "No open merge requests found" — combined with (2), a 401 was indistinguishable from an empty repo. Errors now render in the `AlertBlock` the component already imported.

**4. Limit semantics aligned with the webhook.** `previewDeployment.create` used `previewLimit || 0` with `>`; the webhook uses `previewLimit ?? 3` with `>=`. The router now matches, so a service with the limit left at the column default behaves the same whether the preview came from a webhook or the button, and the limit blocks the Nth+1 preview instead of allowing one over. It still only gates *new* previews — rebuilding an existing one is never blocked.

**5. Nits from the review:** `per_page: 100` on the octokit paginate call (it was paging 30 at a time), and `isLoading` instead of `isFetching` so a background refetch doesn't throw the list back to a spinner. The dialog also now shows the selected change request's author, since that is what decides whether the build is allowed to run.

## Tests

`apps/dokploy/__test__/preview-deployment/author-gate.test.ts` — 12 cases covering the gate for both providers: author with write access passes, author without write access is rejected, missing author is rejected without calling the provider, a throwing provider fails closed, the flag being `false` skips the check entirely, and the flag being `null` (the column default) still enforces it. GitLab additionally asserts the numeric-id path is preferred and the username lookup is the fallback.

## Verification

- `pnpm --filter=dokploy run typecheck` — clean
- `pnpm --filter=@dokploy/server build` — clean
- `pnpm --filter=dokploy test -- run` — 1621 passed; the 5 failing files are the known Windows-only ones (`command -v`, `/bin/bash`, Windows path resolution, docker-dependent `.real` tests) and are unrelated to this change

## Not addressed

Remaining nits from the #195 review, left for later: fork pull requests aren't labelled or filtered in the picker (they still fail at clone time, same as the webhook path); `apiFindGitlabMergeRequests` requires `owner`/`repo` that the provider never reads; there's no "will rebuild the existing preview" hint; and selecting a PR then filtering it out of the search leaves the trigger showing the placeholder. `getGitlabBranches` still lacks its `refreshGitlabToken` call.
