### PR TITLE
fix(deployment): allByType 401 on non-service types (preview/backup/volumeBackup/server)

### DIFF
--- a/apps/dokploy/__test__/deploy/deployment-all-by-type-target.test.ts
+++ b/apps/dokploy/__test__/deploy/deployment-all-by-type-target.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	findScheduleById: vi.fn(),
+	findPreviewDeploymentById: vi.fn(),
+	findBackupById: vi.fn(),
+	findVolumeBackupById: vi.fn(),
+}));
+
+vi.mock("@dokploy/server", () => mocks);
+
+import { resolveDeploymentAllByTypeAuthTarget } from "@/server/utils/deployment-all-by-type-target";
+
+describe("resolveDeploymentAllByTypeAuthTarget", () => {
+	beforeEach(() => {
+		mocks.findScheduleById.mockReset();
+		mocks.findPreviewDeploymentById.mockReset();
+		mocks.findBackupById.mockReset();
+		mocks.findVolumeBackupById.mockReset();
+	});
+
+	describe("application / compose (id is already the service id)", () => {
+		it("returns the id verbatim for application", async () => {
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "app-1",
+				type: "application",
+			});
+			expect(target).toEqual({ kind: "service", serviceId: "app-1" });
+		});
+
+		it("returns the id verbatim for compose", async () => {
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "compose-1",
+				type: "compose",
+			});
+			expect(target).toEqual({ kind: "service", serviceId: "compose-1" });
+		});
+	});
+
+	describe("server (id is a server id)", () => {
+		it("returns a server target", async () => {
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "server-1",
+				type: "server",
+			});
+			expect(target).toEqual({ kind: "server", serverId: "server-1" });
+		});
+	});
+
+	describe("schedule", () => {
+		it("resolves to the schedule's applicationId when set", async () => {
+			mocks.findScheduleById.mockResolvedValue({
+				scheduleType: "application",
+				applicationId: "app-2",
+				composeId: null,
+				serverId: null,
+				organizationId: "org-1",
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "schedule-1",
+				type: "schedule",
+			});
+			expect(target).toEqual({ kind: "service", serviceId: "app-2" });
+		});
+
+		it("resolves to composeId when applicationId is absent", async () => {
+			mocks.findScheduleById.mockResolvedValue({
+				scheduleType: "compose",
+				applicationId: null,
+				composeId: "compose-3",
+				serverId: null,
+				organizationId: "org-1",
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "schedule-2",
+				type: "schedule",
+			});
+			expect(target).toEqual({ kind: "service", serviceId: "compose-3" });
+		});
+
+		it("falls back to serverId for a server-only schedule", async () => {
+			mocks.findScheduleById.mockResolvedValue({
+				scheduleType: "server",
+				applicationId: null,
+				composeId: null,
+				serverId: "server-2",
+				organizationId: "org-1",
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "schedule-3",
+				type: "schedule",
+			});
+			expect(target).toEqual({ kind: "server", serverId: "server-2" });
+		});
+
+		// A `dokploy-server` schedule runs on the Dokploy host itself: no
+		// applicationId, no composeId, no serverId — only an organizationId.
+		// Failing this one closed would break /dashboard/schedules.
+		it("falls back to the organization for a dokploy-server schedule", async () => {
+			mocks.findScheduleById.mockResolvedValue({
+				scheduleType: "dokploy-server",
+				applicationId: null,
+				composeId: null,
+				serverId: null,
+				organizationId: "org-1",
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "schedule-4",
+				type: "schedule",
+			});
+			expect(target).toEqual({ kind: "organization", organizationId: "org-1" });
+		});
+
+		it("surfaces a null organizationId so the router can fail closed", async () => {
+			mocks.findScheduleById.mockResolvedValue({
+				scheduleType: "dokploy-server",
+				applicationId: null,
+				composeId: null,
+				serverId: null,
+				organizationId: null,
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "schedule-5",
+				type: "schedule",
+			});
+			expect(target).toEqual({ kind: "organization", organizationId: null });
+		});
+
+		it("returns 'none' for a service-typed schedule with nothing attached", async () => {
+			mocks.findScheduleById.mockResolvedValue({
+				scheduleType: "application",
+				applicationId: null,
+				composeId: null,
+				serverId: null,
+				organizationId: "org-1",
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "schedule-6",
+				type: "schedule",
+			});
+			expect(target).toEqual({ kind: "none" });
+		});
+	});
+
+	describe("previewDeployment (regression — the modal-KO case)", () => {
+		it("resolves to the preview's applicationId when set", async () => {
+			mocks.findPreviewDeploymentById.mockResolvedValue({
+				applicationId: "app-3",
+				composeId: null,
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "preview-1",
+				type: "previewDeployment",
+			});
+			expect(target).toEqual({ kind: "service", serviceId: "app-3" });
+		});
+
+		it("resolves to composeId when applicationId is absent", async () => {
+			mocks.findPreviewDeploymentById.mockResolvedValue({
+				applicationId: null,
+				composeId: "compose-4",
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "preview-2",
+				type: "previewDeployment",
+			});
+			expect(target).toEqual({ kind: "service", serviceId: "compose-4" });
+		});
+
+		it("returns 'none' when the preview has no attached service", async () => {
+			mocks.findPreviewDeploymentById.mockResolvedValue({
+				applicationId: null,
+				composeId: null,
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "preview-3",
+				type: "previewDeployment",
+			});
+			expect(target).toEqual({ kind: "none" });
+		});
+	});
+
+	describe("backup", () => {
+		it("resolves through composeId, then the six database id columns", async () => {
+			const cases = [
+				["composeId", "compose-5"],
+				["postgresId", "pg-1"],
+				["mysqlId", "my-1"],
+				["mariadbId", "maria-1"],
+				["mongoId", "mongo-1"],
+				["libsqlId", "libsql-1"],
+			] as const;
+			for (const [column, id] of cases) {
+				mocks.findBackupById.mockResolvedValueOnce({
+					composeId: null,
+					postgresId: null,
+					mysqlId: null,
+					mariadbId: null,
+					mongoId: null,
+					libsqlId: null,
+					[column]: id,
+				});
+				const target = await resolveDeploymentAllByTypeAuthTarget({
+					id: "backup-x",
+					type: "backup",
+				});
+				expect(target).toEqual({ kind: "service", serviceId: id });
+			}
+		});
+
+		it("returns 'none' when a backup has no attached service", async () => {
+			mocks.findBackupById.mockResolvedValue({
+				composeId: null,
+				postgresId: null,
+				mysqlId: null,
+				mariadbId: null,
+				mongoId: null,
+				libsqlId: null,
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "backup-orphan",
+				type: "backup",
+			});
+			expect(target).toEqual({ kind: "none" });
+		});
+	});
+
+	describe("volumeBackup", () => {
+		it("resolves through applicationId, composeId and the six database id columns", async () => {
+			const cases = [
+				["applicationId", "app-4"],
+				["composeId", "compose-6"],
+				["postgresId", "pg-2"],
+				["mysqlId", "my-2"],
+				["mariadbId", "maria-2"],
+				["mongoId", "mongo-2"],
+				["redisId", "redis-1"],
+				["libsqlId", "libsql-2"],
+			] as const;
+			for (const [column, id] of cases) {
+				mocks.findVolumeBackupById.mockResolvedValueOnce({
+					applicationId: null,
+					composeId: null,
+					postgresId: null,
+					mysqlId: null,
+					mariadbId: null,
+					mongoId: null,
+					redisId: null,
+					libsqlId: null,
+					[column]: id,
+				});
+				const target = await resolveDeploymentAllByTypeAuthTarget({
+					id: "volumeBackup-x",
+					type: "volumeBackup",
+				});
+				expect(target).toEqual({ kind: "service", serviceId: id });
+			}
+		});
+
+		it("returns 'none' when a volume backup has no attached service", async () => {
+			mocks.findVolumeBackupById.mockResolvedValue({
+				applicationId: null,
+				composeId: null,
+				postgresId: null,
+				mysqlId: null,
+				mariadbId: null,
+				mongoId: null,
+				redisId: null,
+				libsqlId: null,
+			});
+			const target = await resolveDeploymentAllByTypeAuthTarget({
+				id: "volumeBackup-orphan",
+				type: "volumeBackup",
+			});
+			expect(target).toEqual({ kind: "none" });
+		});
+	});
+});

--- a/apps/dokploy/server/api/routers/deployment.ts
+++ b/apps/dokploy/server/api/routers/deployment.ts
@@ -6,7 +6,6 @@ import {
 	findAllDeploymentsByServerId,
 	findAllDeploymentsCentralized,
 	findDeploymentById,
-	findScheduleById,
 	IS_CLOUD,
 	removeDeployment,
 	resolveServicePath,
@@ -14,6 +13,7 @@ import {
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
 import {
+	checkPermission,
 	checkServicePermissionAndAccess,
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
@@ -32,6 +32,7 @@ import {
 } from "@/server/db/schema";
 import { myQueue } from "@/server/queues/queueSetup";
 import { fetchDeployApiJobs, type QueueJobRow } from "@/server/utils/deploy";
+import { resolveDeploymentAllByTypeAuthTarget } from "@/server/utils/deployment-all-by-type-target";
 import { createTRPCRouter, protectedProcedure, withPermission } from "../trpc";
 
 export const deploymentRouter = createTRPCRouter({
@@ -127,27 +128,42 @@ export const deploymentRouter = createTRPCRouter({
 	allByType: protectedProcedure
 		.input(apiFindAllByType)
 		.query(async ({ input, ctx }) => {
-			if (input.type === "schedule") {
-				const schedule = await findScheduleById(input.id);
-				const serviceId = schedule.applicationId || schedule.composeId;
-				if (serviceId) {
-					await checkServicePermissionAndAccess(ctx, serviceId, {
-						deployment: ["read"],
+			const target = await resolveDeploymentAllByTypeAuthTarget(input);
+			if (target.kind === "service") {
+				await checkServicePermissionAndAccess(ctx, target.serviceId, {
+					deployment: ["read"],
+				});
+			} else if (target.kind === "server") {
+				await checkPermission(ctx, { deployment: ["read"] });
+				const targetServer = await findServerById(target.serverId);
+				if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message:
+							"You are not authorized to access this resource or it does not exist",
 					});
-				} else if (schedule.serverId) {
-					const targetServer = await findServerById(schedule.serverId);
-					if (
-						targetServer.organizationId !== ctx.session.activeOrganizationId
-					) {
-						throw new TRPCError({
-							code: "UNAUTHORIZED",
-							message: "You don't have access to this schedule.",
-						});
-					}
+				}
+			} else if (target.kind === "organization") {
+				await checkPermission(ctx, { deployment: ["read"] });
+				const member = await findMemberByUserId(
+					ctx.user.id,
+					ctx.session.activeOrganizationId,
+				);
+				if (
+					(member.role !== "owner" && member.role !== "admin") ||
+					target.organizationId !== ctx.session.activeOrganizationId
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message:
+							"You are not authorized to access this resource or it does not exist",
+					});
 				}
 			} else {
-				await checkServicePermissionAndAccess(ctx, input.id, {
-					deployment: ["read"],
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message:
+						"You are not authorized to access this resource or it does not exist",
 				});
 			}
 			const deploymentsList = await db.query.deployments.findMany({

--- a/apps/dokploy/server/utils/deployment-all-by-type-target.ts
+++ b/apps/dokploy/server/utils/deployment-all-by-type-target.ts
@@ -1,0 +1,83 @@
+import {
+	findBackupById,
+	findPreviewDeploymentById,
+	findScheduleById,
+	findVolumeBackupById,
+} from "@dokploy/server";
+import type { apiFindAllByType } from "@dokploy/server/db/schema";
+import type { z } from "zod";
+
+/**
+ * `deployment.allByType` accepts several `type`s whose `id` isn't itself a
+ * service id: `previewDeployment`, `backup`, `volumeBackup`, `schedule` and
+ * `server` are ids of things attached to a service (or a server). Passing them
+ * straight to `checkServicePermissionAndAccess` fails closed with a 401,
+ * because the service-existence lookup only unions the service tables. Resolve
+ * each type to the target the auth check has to run against before calling it.
+ *
+ * A `dokploy-server` schedule is the one case with neither: it runs on the
+ * Dokploy host itself, so it has no service and no server, and the only thing
+ * left to authorize against is its `organizationId`.
+ */
+export type DeploymentAllByTypeAuthTarget =
+	| { kind: "service"; serviceId: string }
+	| { kind: "server"; serverId: string }
+	| { kind: "organization"; organizationId: string | null }
+	| { kind: "none" };
+
+export const resolveDeploymentAllByTypeAuthTarget = async (
+	input: z.infer<typeof apiFindAllByType>,
+): Promise<DeploymentAllByTypeAuthTarget> => {
+	switch (input.type) {
+		case "application":
+		case "compose":
+			return { kind: "service", serviceId: input.id };
+		case "server":
+			return { kind: "server", serverId: input.id };
+		case "schedule": {
+			const schedule = await findScheduleById(input.id);
+			const serviceId = schedule.applicationId || schedule.composeId;
+			if (serviceId) return { kind: "service", serviceId };
+			if (schedule.serverId)
+				return { kind: "server", serverId: schedule.serverId };
+			if (schedule.scheduleType === "dokploy-server")
+				return {
+					kind: "organization",
+					organizationId: schedule.organizationId,
+				};
+			return { kind: "none" };
+		}
+		case "previewDeployment": {
+			const preview = await findPreviewDeploymentById(input.id);
+			const serviceId = preview.applicationId || preview.composeId;
+			if (serviceId) return { kind: "service", serviceId };
+			return { kind: "none" };
+		}
+		case "backup": {
+			const backup = await findBackupById(input.id);
+			const serviceId =
+				backup.composeId ||
+				backup.postgresId ||
+				backup.mysqlId ||
+				backup.mariadbId ||
+				backup.mongoId ||
+				backup.libsqlId;
+			if (serviceId) return { kind: "service", serviceId };
+			return { kind: "none" };
+		}
+		case "volumeBackup": {
+			const volumeBackup = await findVolumeBackupById(input.id);
+			const serviceId =
+				volumeBackup.applicationId ||
+				volumeBackup.composeId ||
+				volumeBackup.postgresId ||
+				volumeBackup.mysqlId ||
+				volumeBackup.mariadbId ||
+				volumeBackup.mongoId ||
+				volumeBackup.redisId ||
+				volumeBackup.libsqlId;
+			if (serviceId) return { kind: "service", serviceId };
+			return { kind: "none" };
+		}
+	}
+};


### PR DESCRIPTION
## Description

Regression from the org-scoping guard shipped in `v0.30.3-community.1` (hardening waves 3–4). `deployment.allByType` assumes `input.id` is a service id when `input.type` isn't `schedule`:

```ts
} else {
    await checkServicePermissionAndAccess(ctx, input.id, {
        deployment: ["read"],
    });
}
```

That holds for `application` and `compose`, but the input schema also allows `previewDeployment`, `backup`, `volumeBackup` and `server`. Their ids are attached to a service (or a server); they aren't service ids themselves. `checkServicePermissionAndAccess` calls `findServiceOrganizationId`, which resolves the id via a UNION over the service tables (`application`, `compose`, `postgres`, `mysql`, `mariadb`, `mongo`, `redis`, `libsql`) with no clause for `previewDeployment` / `backup` / `volumeBackup`. The lookup returns null, `assertServiceInOrganization` throws `UNAUTHORIZED`, and every request of these types 401s.

## Reproduction

Any application/compose with at least one preview deployment on `v0.30.3-community.1` or `.2`:

1. Go to the service page → *Preview Deployments* tab
2. Click **View Deployments** on a preview
3. The modal fires `GET /api/trpc/deployment.allByType?input={"0":{"json":{"id":"<previewDeploymentId>","type":"previewDeployment"}}}` and returns `401 UNAUTHORIZED` — the modal renders empty.

Same shape breaks the "deployments for this backup / volume backup / server" modals.

## Fix

Resolve `input.id` to the underlying service (or server) up front, then run the same auth check as before:

- `application` / `compose` — id is already a service id, unchanged
- `server` — id is a server id, check permission + org scope on that server
- `schedule` — `applicationId` / `composeId`, else `serverId` (unchanged), else see below
- `previewDeployment` — look up the preview and use its `applicationId` / `composeId`
- `backup` — look up the backup and use whichever of `composeId` / `postgresId` / `mysqlId` / `mariadbId` / `mongoId` / `libsqlId` is set
- `volumeBackup` — same over its eight service-id columns

### `dokploy-server` schedules

Worth calling out, because it's the same bug in the other direction. A schedule with `scheduleType: "dokploy-server"` runs on the Dokploy host itself, so `applicationId`, `composeId` **and** `serverId` are all null — only `organizationId` is set. Today `allByType` runs no check at all for it and returns the rows; a naive "resolve to a service or reject" rewrite would 401 the deployment history on `/dashboard/schedules`.

So that case resolves to its organization and is authorized the way `schedule.list` already gates the same `scheduleType`: `deployment: ["read"]`, plus owner/admin, plus an org match. Strictly tighter than the current no-check, and consistent with the neighbouring procedure.

Anything that still resolves to nothing (a preview / backup / volumeBackup row with no attached service, a service-typed schedule with no service) now fails closed with the same "not authorized to access this resource or it does not exist" message rather than reaching the SQL fetch.

## Scope

Fixes the modal for previews, backups and volume backups on every service. `application` / `compose` paths are unchanged. Service- and server-typed schedules keep their existing behaviour; `dokploy-server` schedules keep working, but now behind the same gate as `schedule.list`.

The resolution lives in `server/utils/deployment-all-by-type-target.ts` rather than inline in the procedure, so it can be unit tested without standing up a tRPC context. The router keeps the authorization itself.

## Test plan

`apps/dokploy/__test__/deploy/deployment-all-by-type-target.test.ts` — 16 tests over the full type matrix, finders mocked:

- `application` / `compose` → the id is returned verbatim as the service id
- `server` → resolves to a server target
- `schedule` → `applicationId`, then `composeId`, then `serverId`, then the `dokploy-server` organization fallback (incl. a null `organizationId` so the router fails closed), then fail-closed
- `previewDeployment` → `applicationId` / `composeId` (the 401 in the report), then fail-closed
- `backup` → each of the six service-id columns, then fail-closed
- `volumeBackup` → each of the eight service-id columns, then fail-closed

```
✓ __test__/deploy/deployment-all-by-type-target.test.ts (16 tests) 11ms
```

Also exercised against a live install running `v0.30.3-community.2` and reproducing the 401, rebuilt from this branch:

- the preview **View Deployments** modal returns its deployments instead of 401ing — the reported bug
- `/dashboard/schedules` (host-level `dokploy-server` schedules) still returns its deployment history, i.e. the new organization branch does its job

🤖 Generated with [Claude Code](https://claude.com/claude-code)
