### PR TITLE
fix(security): redact URL-embedded credentials in logged commands

### DIFF
--- a/apps/dokploy/__test__/process/redact-secrets.test.ts
+++ b/apps/dokploy/__test__/process/redact-secrets.test.ts
@@ -128,4 +128,65 @@ describe("redactSecrets", () => {
 		expect(redacted).toContain('--s3-region="us-east-1"');
 		expect(redacted).toContain("pg_dump -U dokploy mydb");
 	});
+
+	// Token values below are synthetic and only shaped like the real prefixes.
+	it("redacts the token in a git clone URL userinfo (GitHub App, GitLab)", () => {
+		const token = "ghs_FAKEFAKEFAKEFAKEFAKEFAKEFAKE";
+		const redacted = redactSecrets(
+			`git clone --branch main --depth 1 https://oauth2:${token}@github.com/org/repo.git /code --progress`,
+		);
+		expect(redacted).not.toContain(token);
+		expect(redacted).toContain(
+			"https://oauth2:[REDACTED]@github.com/org/repo.git /code --progress",
+		);
+
+		const gitlab = redactSecrets(
+			"https://oauth2:glFAKEaccessToken@gitlab.example.com/group/repo.git",
+		);
+		expect(gitlab).not.toContain("glFAKEaccessToken");
+		expect(gitlab).toContain("https://oauth2:[REDACTED]@gitlab.example.com/");
+	});
+
+	it("redacts URL credentials in the shell-escaped form the clone command uses", () => {
+		const token = "ghs_FAKEFAKEFAKEFAKEFAKEFAKEFAKE";
+		const redacted = redactSecrets(
+			`git clone --branch main --depth 1 https\\://oauth2\\:${token}\\@github.com/org/repo.git /code`,
+		);
+		expect(redacted).not.toContain(token);
+		expect(redacted).toContain(
+			"https\\://oauth2\\:[REDACTED]\\@github.com/org/repo.git /code",
+		);
+	});
+
+	it("redacts basic-auth passwords in any URL but keeps user and host", () => {
+		const redacted = redactSecrets(
+			"docker login https://user:appPassFAKE@registry.example.com:5000/v2/",
+		);
+		expect(redacted).not.toContain("appPassFAKE");
+		expect(redacted).toContain(
+			"https://user:[REDACTED]@registry.example.com:5000/v2/",
+		);
+	});
+
+	it("leaves credential-free URLs and scp-style remotes untouched", () => {
+		for (const command of [
+			"git clone --branch main https://github.com/org/repo.git /code",
+			"git clone git@github.com:org/repo.git /code",
+			"curl https://s3.example.com:9000/bucket/key",
+		]) {
+			expect(redactSecrets(command)).toBe(command);
+		}
+	});
+
+	it("redacts well-known token prefixes outside a URL", () => {
+		const redacted = redactSecrets(
+			"git remote set-url origin ghp_FAKEFAKEFAKEFAKEFAKE github_pat_FAKEFAKEFAKE_x glpat-FAKEFAKEFAKE",
+		);
+		expect(redacted).not.toContain("ghp_FAKE");
+		expect(redacted).not.toContain("github_pat_FAKE");
+		expect(redacted).not.toContain("glpat-FAKE");
+		expect(redacted).toContain(
+			"remote set-url origin [REDACTED] [REDACTED] [REDACTED]",
+		);
+	});
 });

--- a/packages/server/src/utils/process/redactSecrets.ts
+++ b/packages/server/src/utils/process/redactSecrets.ts
@@ -75,13 +75,40 @@ const redactAssignments = (value: string): string =>
 const redactAuthHeaders = (value: string): string =>
 	value.replace(/(Authorization:\s*)([^"'\r\n]+)/gi, "$1[REDACTED]");
 
+// Credentials embedded in a URL userinfo: `https://oauth2:<token>@github.com/…`
+// (GitHub App installation tokens, GitLab/Gitea OAuth tokens, Bitbucket app
+// passwords, registry basic-auth). Git clone commands are shell-escaped before
+// they run, so the `:` / `@` separators may appear as `\:` / `\@` — both forms
+// are matched. The scheme, user and host stay so the failure is still legible.
+const URL_USERINFO_PASSWORD =
+	/(\b[a-z][a-z0-9+.-]*\\?:\/\/[^\s/:@\\"']+\\?:)([^\s@"']+?)(\\?@)/gi;
+
+const redactUrlCredentials = (value: string): string =>
+	value.replace(URL_USERINFO_PASSWORD, "$1[REDACTED]$3");
+
+// Well-known token prefixes that identify a live credential on their own,
+// wherever they appear (GitHub ghp_/gho_/ghu_/ghs_/ghr_ + fine-grained PATs,
+// GitLab personal/project/runner tokens).
+const KNOWN_TOKEN =
+	/\b(?:gh[pousr]_[A-Za-z0-9]{8,}|github_pat_[A-Za-z0-9_]{8,}|glpat-[A-Za-z0-9_-]{8,}|glrt-[A-Za-z0-9_-]{8,})/g;
+
+const redactKnownTokens = (value: string): string =>
+	value.replace(KNOWN_TOKEN, "[REDACTED]");
+
 export const redactSecrets = (value: string): string =>
-	redactAuthHeaders(
-		redactAssignments(
-			redactFlags(
-				value
-					.replace(PRIVATE_KEY_BLOCK, "[REDACTED PRIVATE KEY]")
-					.replace(BASE64_DECODE_PIPE, 'echo "[REDACTED]" | base64 -d'),
+	redactKnownTokens(
+		redactUrlCredentials(
+			redactAuthHeaders(
+				redactAssignments(
+					redactFlags(
+						value
+							.replace(PRIVATE_KEY_BLOCK, "[REDACTED PRIVATE KEY]")
+							.replace(
+								BASE64_DECODE_PIPE,
+								'echo "[REDACTED]" | base64 -d',
+							),
+					),
+				),
 			),
 		),
 	);


### PR DESCRIPTION
## Problem

A failed `git clone` on a production host was logged with the GitHub App installation token in clear text. Node repeats the whole failed command in the child-process error, `ExecError` forwards it to the service logs, and `apps/dokploy/server/sentry.ts` runs the same redactor before sending events, so this material could reach both the logs and Sentry.

The clone URL Dokploy builds for GitHub, GitLab and Gitea carries the token in the URL userinfo (`https://oauth2:<token>@host/...`), and the command is shell-escaped before it runs, so the logged form is `https\://oauth2\:ghs_...\@github.com/...`. `redactSecrets` had rules for env assignments, rclone flags, Authorization headers, PEM blocks and base64 pipes, but nothing for URL-embedded credentials.

(The leaked tokens were one-hour installation tokens, already expired; no clone-failure event reached Sentry in the last 7 days.)

## Fix

`packages/server/src/utils/process/redactSecrets.ts`

- `redactUrlCredentials`: redacts the password part of any `scheme://user:password@host` userinfo, in plain and shell-escaped (`\:` / `\@`) forms. Scheme, user and host are kept so the failure stays diagnosable. Covers GitHub App / GitLab / Gitea clone URLs, Bitbucket app passwords, and registry basic-auth URLs.
- `redactKnownTokens`: redacts well-known credential prefixes wherever they appear (GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, `github_pat_`, GitLab `glpat-`/`glrt-`).

Both run last in the pipeline; every existing rule is unchanged.

## Tests

`apps/dokploy/__test__/process/redact-secrets.test.ts` gains five cases: GitHub App + GitLab clone URLs, the shell-escaped clone form, registry basic-auth, bare token prefixes, and a negative control that credential-free `https://` URLs, `git@host:` remotes and `host:port` paths are untouched. Existing cases still pass.
